### PR TITLE
gh action - license check

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,6 +18,9 @@ jobs:
       run: |
         go install github.com/google/go-licenses@latest
     - uses: actions/checkout@v2
+    - name: Go mod vendor
+      run: |
+        go mod vendor
     - name: Run go-licenses
       run: |
         go-licenses csv github.com/corazawaf/coraza/v2

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -7,7 +7,7 @@ on:
     branches: [v2/*]
 
 jobs:
-  pre-commit:
+  license-check:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,24 @@
+name: license-check
+
+on:
+  pull_request:
+    branches: [v2/*]
+  push:
+    branches: [v2/*]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: v1.17.x
+    - name: Install go-licenses
+      run: |
+        go install github.com/google/go-licenses@latest
+    - uses: actions/checkout@v2
+    - name: Run go-licenses
+      run: |
+        go-licenses csv github.com/corazawaf/coraza/v2
+        go-licenses check github.com/corazawaf/coraza/v2

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -473,12 +473,18 @@ func directiveSecRuleUpdateTargetByID(w *coraza.Waf, opts string) error {
 		return err
 	}
 	rule := w.Rules.FindByID(id)
+	if rule == nil {
+		return fmt.Errorf("rule %d not found ", id)
+	}
 	rp := &RuleParser{
 		rule:           rule,
 		options:        RuleOptions{},
 		defaultActions: map[types.RulePhase][]ruleAction{},
 	}
-	return rp.ParseVariables(strings.Trim(spl[1], "\""))
+	if err := rp.ParseVariables(strings.Trim(spl[1], "\"")); err != nil {
+		return fmt.Errorf("SecRuleUpdateTargetById error %q: %s", opts, err)
+	}
+	return nil
 }
 
 func directiveSecIgnoreRuleCompilationErrors(w *coraza.Waf, opts string) error {

--- a/seclang/rule_parser_test.go
+++ b/seclang/rule_parser_test.go
@@ -77,3 +77,14 @@ func TestErrorLine(t *testing.T) {
 		t.Error("failed to find error line, got " + err.Error())
 	}
 }
+
+func TestVariableParsing2(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	if err := p.FromString(`
+	SecRule ARGS|REQUEST_COOKIES|REQUEST_HEADERS "" "id:930120"
+	SecRuleUpdateTargetById 930120 "!ARGS:/(?i:csrf)/|!ARGS:/(?i:xsrf)/|!REQUEST_COOKIES:/(?i:csrf)/|!REQUEST_COOKIES:/(?i:xsrf)/|!REQUEST_HEADERS:/(?i:csrf)/|!REQUEST_HEADERS:/(?i:xsrf)/"
+	`); err != nil {
+		t.Error(err)
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -147,6 +147,7 @@ func (tx *Transaction) AddRequestHeader(key string, value string) {
 			return
 		}
 		for k, vr := range values {
+			k = strings.ToLower(k)
 			tx.GetCollection(variables.RequestCookiesNames).AddUnique("", k)
 			for _, v := range vr {
 				tx.GetCollection(variables.RequestCookies).Add(k, v)


### PR DESCRIPTION
This PR contains the new github action to use https://github.com/google/go-licenses

It will fail if any of this licenses is used within recursive dependencies:
- AGPL10
- AGPL30
- CCBYNC10
- CCBYNC20
- CCBYNC25
- CCBYNC30
- CCBYNC40
- CCBYNCND10
- CCBYNCND20
- CCBYNCND25
- CCBYNCND30
- CCBYNCND40
- CCBYNCSA10
- CCBYNCSA20
- CCBYNCSA25
- CCBYNCSA30
- CCBYNCSA40
- CommonsClause
- Facebook2Clause
- Facebook3Clause
- FacebookExamples
- WTFPL

**TODO:** We must find a way to add the restrictive licenses:  BCL, CCBYND10, CCBYND20, CCBYND25, CCBYND30, CCBYND40, CCBYSA10, CCBYSA20, CCBYSA25, CCBYSA30, CCBYSA40, GPL10, GPL20, GPL20withautoconfexception, GPL20withbisonexception, GPL20withclasspathexception, GPL20withfontexception, GPL20withGCCexception, GPL30, GPL30withautoconfexception, GPL30withGCCexception, LGPL20, LGPL21, LGPL30, NPL10, NPL11, OSL10, OSL11, OSL20, OSL21, OSL30, QPL10, Sleepycat,