### PR TITLE
fix MATCHED VARS issues

### DIFF
--- a/bodyprocessors/multipart.go
+++ b/bodyprocessors/multipart.go
@@ -88,6 +88,10 @@ func (mbp *multipartBodyProcessor) Read(reader io.Reader, options Options) error
 
 		}
 	}
+	pn := map[string][]string{}
+	for _, value := range postNames {
+		pn[value] = []string{value}
+	}
 	mbp.collections = &CollectionsMap{
 		variables.FilesNames: map[string][]string{
 			"": filesArgNames,
@@ -101,11 +105,9 @@ func (mbp *multipartBodyProcessor) Read(reader io.Reader, options Options) error
 		variables.FilesSizes: map[string][]string{
 			"": fileSizes,
 		},
-		variables.ArgsPostNames: map[string][]string{
-			"": postNames,
-		},
-		variables.ArgsPost: postFields,
-		variables.Args:     postFields,
+		variables.ArgsPostNames: pn,
+		variables.ArgsPost:      postFields,
+		variables.Args:          postFields,
 		variables.FilesCombinedSize: map[string][]string{
 			"": {fmt.Sprintf("%d", totalSize)},
 		},

--- a/bodyprocessors/urlencoded.go
+++ b/bodyprocessors/urlencoded.go
@@ -51,12 +51,14 @@ func (ubp *urlencodedBodyProcessor) Read(reader io.Reader, _ Options) error {
 		m[k] = vs
 		keys = append(keys, k)
 	}
+	pn := map[string][]string{}
+	for _, value := range keys {
+		pn[value] = []string{value}
+	}
 	ubp.collections = &CollectionsMap{
-		variables.ArgsPost: m,
-		variables.ArgsPostNames: map[string][]string{
-			"": keys,
-		},
-		variables.Args: m,
+		variables.ArgsPost:      m,
+		variables.ArgsPostNames: pn,
+		variables.Args:          m,
 		variables.RequestBody: map[string][]string{
 			"": {b},
 		},

--- a/transaction.go
+++ b/transaction.go
@@ -250,7 +250,6 @@ func (tx *Transaction) ParseRequestReader(data io.Reader) (*types.Interruption, 
 // MATCHED_VARS, MATCHED_VAR, MATCHED_VAR_NAME, MATCHED_VARS_NAMES
 func (tx *Transaction) matchVariable(match MatchData) {
 	varName := strings.Builder{}
-	//varName.Grow(len(match.VariableName) * 2)
 	varName.WriteString(match.VariableName)
 	if match.Key != "" {
 		varName.WriteByte(':')
@@ -267,7 +266,7 @@ func (tx *Transaction) matchVariable(match MatchData) {
 	// Array of keys
 	matchedVarsNames := tx.GetCollection(variables.MatchedVarsNames)
 
-	matchedVars.Add("", match.Value)
+	matchedVars.Add(match.Key, match.Value)
 	matchedVar.SetIndex("", 0, match.Value)
 	// fmt.Printf("%s: %s\n", match.VariableName, match.Value)
 

--- a/transaction.go
+++ b/transaction.go
@@ -266,11 +266,11 @@ func (tx *Transaction) matchVariable(match MatchData) {
 	// Array of keys
 	matchedVarsNames := tx.GetCollection(variables.MatchedVarsNames)
 
-	matchedVars.Add(match.Key, match.Value)
+	matchedVars.Add(varName.String(), match.Value)
 	matchedVar.SetIndex("", 0, match.Value)
 	// fmt.Printf("%s: %s\n", match.VariableName, match.Value)
 
-	matchedVarsNames.Add("", varName.String())
+	matchedVarsNames.Add(varName.String(), varName.String())
 	matchedVarName.SetIndex("", 0, varName.String())
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -488,7 +488,7 @@ func TestVariablesMatch(t *testing.T) {
 		}
 	}
 
-	if v := tx.GetCollection(variables.MatchedVars).GetFirstString("sample"); v != "samplevalue" {
+	if v := tx.GetCollection(variables.MatchedVars).GetFirstString("ARGS_NAMES:sample"); v != "samplevalue" {
 		t.Errorf("failed to match variable %s, got %s", variables.MatchedVars.Name(), v)
 	}
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -468,6 +468,29 @@ func TestTxPhase4Magic(t *testing.T) {
 	}
 }
 
+func TestVariablesMatch(t *testing.T) {
+	waf := NewWaf()
+	tx := waf.NewTransaction()
+	tx.matchVariable(MatchData{
+		VariableName: "ARGS_NAMES",
+		Variable:     variables.ArgsNames,
+		Key:          "sample",
+		Value:        "samplevalue",
+	})
+	expect := map[variables.RuleVariable]string{
+		variables.MatchedVar:       "samplevalue",
+		variables.MatchedVarName:   "ARGS_NAMES:sample",
+		variables.MatchedVars:      "samplevalue",
+		variables.MatchedVarsNames: "ARGS_NAMES:sample",
+	}
+
+	for k, v := range expect {
+		if m := tx.GetCollection(k).GetFirstString(""); m != v {
+			t.Errorf("failed to match variable %s, got %s", k.Name(), m)
+		}
+	}
+}
+
 func multipartRequest(req *http.Request) error {
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -478,16 +478,18 @@ func TestVariablesMatch(t *testing.T) {
 		Value:        "samplevalue",
 	})
 	expect := map[variables.RuleVariable]string{
-		variables.MatchedVar:       "samplevalue",
-		variables.MatchedVarName:   "ARGS_NAMES:sample",
-		variables.MatchedVars:      "samplevalue",
-		variables.MatchedVarsNames: "ARGS_NAMES:sample",
+		variables.MatchedVar:     "samplevalue",
+		variables.MatchedVarName: "ARGS_NAMES:sample",
 	}
 
 	for k, v := range expect {
 		if m := tx.GetCollection(k).GetFirstString(""); m != v {
 			t.Errorf("failed to match variable %s, got %s", k.Name(), m)
 		}
+	}
+
+	if v := tx.GetCollection(variables.MatchedVars).GetFirstString("sample"); v != "samplevalue" {
+		t.Errorf("failed to match variable %s, got %s", variables.MatchedVars.Name(), v)
 	}
 }
 


### PR DESCRIPTION
#174:
The data structure for ARGS_NAMES and ARGS_GET_NAMES used to be:
```json
{
    "": ["name 1", "name 2", "name 3"]
}
```
Now it has become:
```json
{
  "name 1": "name 1",
  "name 2": "name 2",
  "name 3": "name 3",
}
```

There is some redundancy but with the current design it solves the problem for CRS rule 920271 that expects the key name from ARGS_NAMES using MATCHED_VAR_NAME. In the old design MATCHED_VAR_NAME would return just ARGS_NAMES because the arg name was a value, not a key. In coraza v3 there should be a new design for this.

#173:

I've just added the key to MATCHED_VARS:
```go
matchedVars.Add(variableName.String(), match.Value)
```

Tests were added for both cases.