### PR TITLE
fix: default actions for phase 2 are now hardcoded #191

### DIFF
--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -337,8 +337,8 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 	}
 
 	defaultActions := options.Config.Get("rule_default_actions", []string{
-    defaultActionsPhase2,
-  }).([]string)
+		defaultActionsPhase2,
+	}).([]string)
 	disabledRuleOperators := options.Config.Get("disabled_rule_operators", []string{}).([]string)
 
 	for _, da := range defaultActions {

--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -330,7 +330,9 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 		defaultActions: map[types.RulePhase][]ruleAction{},
 	}
 
-	defaultActions := options.Waf.Config.Get("rule_default_actions", []string{}).([]string)
+	defaultActions := options.Waf.Config.Get("rule_default_actions", []string{
+		"phase:2,log,auditlog,pass",
+	}).([]string)
 	disabledRuleOperators := options.Waf.Config.Get("disabled_rule_operators", []string{}).([]string)
 
 	for _, da := range defaultActions {

--- a/seclang/rule_parser_test.go
+++ b/seclang/rule_parser_test.go
@@ -77,3 +77,24 @@ func TestErrorLine(t *testing.T) {
 		t.Error("failed to find error line, got " + err.Error())
 	}
 }
+
+func TestDefaultActionsForPhase2(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	err := p.FromString(`
+	SecAction "id:1,phase:2"
+	SecAction "id:2,phase:1"`)
+	if err != nil {
+		t.Error("that shouldn't happen", err)
+	}
+	if waf.Rules.GetRules()[0].Log != true {
+		t.Error("failed to set log to true because of default actions")
+	}
+	if waf.Rules.GetRules()[0].Audit != true {
+		t.Error("failed to set audit to true because of default actions")
+	}
+
+	if waf.Rules.GetRules()[1].Log || waf.Rules.GetRules()[1].Audit {
+		t.Error("phase 1 rules shouldn't have log set by default actions")
+	}
+}


### PR DESCRIPTION
According to #191 report, the secdefault actions for phase 2 are `phase:2,log,auditlog,pass` by default. This PR includes a mechanism to hardcode default actions.

TODO: We must add some logic to avoid repeated default actions, for example, if you use some default actions multiple time you would just concatenate actions:

```
SecDefaultActions "phase:2,log,auditlog,pass"
SecDefaultActions "phase:2,nolog,noauditlog,deny"
```
The previous statement would create the following rule:
```
SecAction "id:1,phase:2"
# compiles into: SecAction "id:1,phase:2,log,auditlog,pass,nolog,noauditlog,deny"
```

Should we fix that behavior in this PR ?

We should update ```ParseDefaultActions``` and set the following rules:
```
Replacements, action X replaces > action Y:
nolog > log
log > nolog
auditlog > noauditlog
noauditlog > auditlog

A disruptive action replaces all previous disruptive actions

no actions should repeat, except:
setvar
ctl
t
```