### PR TITLE
fix(tx): Force Request Body now works

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -660,7 +660,7 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 
 	// Default variables.ReqbodyProcessor values
 	// XML and JSON must be forced with ctl:requestBodyProcessor=JSON
-	if rbp == "" && tx.ForceRequestBodyVariable {
+	if tx.ForceRequestBodyVariable {
 		// We force URLENCODED if mime is x-www... or we have an empty RBP and ForceRequestBodyVariable
 		rbp = "URLENCODED"
 		tx.GetCollection(variables.ReqbodyProcessor).Set("", []string{rbp})

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -493,6 +493,38 @@ func TestVariablesMatch(t *testing.T) {
 	}
 }
 
+func TestTxReqBodyForce(t *testing.T) {
+	waf := NewWaf()
+	tx := waf.NewTransaction()
+	tx.RequestBodyAccess = true
+	tx.ForceRequestBodyVariable = true
+	if _, err := tx.RequestBodyBuffer.Write([]byte("test")); err != nil {
+		t.Error(err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Error(err)
+	}
+	if tx.GetCollection(variables.RequestBody).GetFirstString("") != "test" {
+		t.Error("failed to set request body")
+	}
+}
+
+func TestTxReqBodyForceNegative(t *testing.T) {
+	waf := NewWaf()
+	tx := waf.NewTransaction()
+	tx.RequestBodyAccess = true
+	tx.ForceRequestBodyVariable = false
+	if _, err := tx.RequestBodyBuffer.Write([]byte("test")); err != nil {
+		t.Error(err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Error(err)
+	}
+	if tx.GetCollection(variables.RequestBody).GetFirstString("") == "test" {
+		t.Error("reqbody should not be there")
+	}
+}
+
 func multipartRequest(req *http.Request) error {
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)


### PR DESCRIPTION
ForceRequestBodyVariable was only forcing cases where the content type was empty. Now it will always force.