### PR TITLE
feat(directive): Implement include directive

### DIFF
--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -18,11 +18,12 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/corazawaf/coraza/v2/types"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/corazawaf/coraza/v2/types"
 
 	"github.com/corazawaf/coraza/v2"
 	"go.uber.org/zap"
@@ -118,8 +119,12 @@ func (p *Parser) evaluate(data string) error {
 	if len(opts) >= 3 && opts[0] == '"' && opts[len(opts)-1] == '"' {
 		opts = strings.Trim(opts, `"`)
 	}
-
-	d, ok := directivesMap[strings.ToLower(directive)]
+	directive = strings.ToLower(directive)
+	if directive == "include" {
+		// this is a special hardcoded case
+		return p.FromFile(opts)
+	}
+	d, ok := directivesMap[directive]
 	if !ok || d == nil {
 		return p.log("Unsupported directive " + directive)
 	}

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -127,14 +127,12 @@ func (p *Parser) evaluate(data string) error {
 	if directive == "include" {
 		// this is a special hardcoded case
 		// we cannot add it as a directive type because there are recursion issues
-		if p.currentFile == opts {
-			return fmt.Errorf("include directive cannot include itself")
-		}
 		// note a user might still include another file that includes the original file
 		// generating a DDOS attack
 		if p.includeCount >= maxIncludeRecursion {
 			return fmt.Errorf("cannot include more than %d files", maxIncludeRecursion)
 		}
+		p.includeCount++
 		return p.FromFile(opts)
 	}
 	d, ok := directivesMap[directive]

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -15,6 +15,9 @@
 package seclang
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/corazawaf/coraza/v2"
@@ -62,6 +65,51 @@ func TestHardcodedIncludeDirective(t *testing.T) {
 	}
 	if err := p.FromString("Include unknown"); err == nil {
 		t.Error("Include directive should fail")
+	}
+}
+
+func TestHardcodedIncludeDirectiveDDOS(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	tmpFile, err := os.CreateTemp(os.TempDir(), "rand*.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := fmt.Sprintf("Include %s\n", tmpFile.Name())
+	// write data to tmpFile
+	w := bufio.NewWriter(tmpFile)
+	if _, err := w.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush()
+	tmpFile.Close()
+	if err := p.FromFile(tmpFile.Name()); err == nil {
+		t.Error("Include directive should fail in case of recursion")
+	}
+}
+
+func TestHardcodedIncludeDirectiveDDOS2(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	tmpFile, err := os.CreateTemp(os.TempDir(), "rand*.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile2, err := os.CreateTemp(os.TempDir(), "rand*.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := bufio.NewWriter(tmpFile)
+	for i := 0; i < maxIncludeRecursion+1; i++ {
+		data := fmt.Sprintf("Include %s\n", tmpFile2.Name())
+		if _, err := w.WriteString(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w.Flush()
+	tmpFile.Close()
+	if err := p.FromFile(tmpFile.Name()); err == nil {
+		t.Error("Include directive should fail in case of a lot of recursion")
 	}
 }
 

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -91,14 +91,15 @@ func TestHardcodedIncludeDirectiveDDOS(t *testing.T) {
 func TestHardcodedIncludeDirectiveDDOS2(t *testing.T) {
 	waf := coraza.NewWaf()
 	p, _ := NewParser(waf)
-	tmpFile, err := os.CreateTemp(os.TempDir(), "rand*.conf")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "rand1*.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpFile2, err := os.CreateTemp(os.TempDir(), "rand*.conf")
+	tmpFile2, err := os.CreateTemp(os.TempDir(), "rand2*.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	w := bufio.NewWriter(tmpFile)
 	for i := 0; i < maxIncludeRecursion+1; i++ {
 		data := fmt.Sprintf("Include %s\n", tmpFile2.Name())

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -17,6 +17,7 @@ package seclang
 import (
 	"testing"
 
+	"github.com/corazawaf/coraza/v2"
 	engine "github.com/corazawaf/coraza/v2"
 )
 
@@ -47,6 +48,20 @@ func TestDefaultConfigurationFile(t *testing.T) {
 	err := p.FromFile("../coraza.conf-recommended")
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestHardcodedIncludeDirective(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	if err := p.FromString("Include ../coraza.conf-recommended"); err != nil {
+		t.Error(err)
+	}
+	if waf.Rules.Count() == 0 {
+		t.Error("No rules loaded using include directive")
+	}
+	if err := p.FromString("Include unknown"); err == nil {
+		t.Error("Include directive should fail")
 	}
 }
 


### PR DESCRIPTION
The newly implemented Include directive simulates Apache Include. A Coraza user may use it to include files or file patterns from directives, for example.

If you include 1.conf you will get a log message from rules 1, 2, 3, and 4.

```
# 1.conf
SecAction "id:1,pass,log"
Include 2.conf
```

```
# 2.conf
SecAction "id:2,pass,log"
Include others/*.conf
```

```
# others/3.conf
SecAction "id:3,pass,log"
```

```
# others/4.conf
SecAction "id:4,pass,log"
```

Btw, the directive was hardcoded and not created using the plugin interface because of a recursion error:
```
func (*Parser).FromFile(profilePath string) error
FromFile imports directives from a file It will return error if any directive fails to parse or the file does not exist. If the path contains a *, it will be expanded to all files in the directory matching the pattern

(seclang.Parser).FromFile on pkg.go.dev

initialization cycle for directivesMap (see details)compilerInvalidInitCycle
directives.go(548, 5): initialization cycle for directivesMap
directives.go(548, 5): directivesMap refers to
directives.go(492, 6): directiveInclude refers to
parser.go(44, 18): FromFile refers to (this error)
parser.go(80, 18): FromString refers to
```

CC @airween 