### PR TITLE
Enhance github actions for sonarcloud and regression

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "CodeQL 2"
 on:
   push:
   pull_request:
@@ -33,7 +33,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
     - run: |
@@ -41,4 +41,4 @@ jobs:
        go mod vendor
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Tests and coverage
       run: go test -v -coverpkg=./... -coverprofile=coverage-waf.out ./...
     - name: SonarCloud Scan
-      if: ${{ matrix.go-version == '1.18.x' && github.repository_owner == 'corazawaf' }}
+      if: ${{ matrix.go-version == '1.17.x' && github.repository_owner == 'corazawaf' }}
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -1,4 +1,4 @@
-name: Regression Tests
+name: Tinygo tests
 
 on:
   push:
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,10 +23,4 @@ jobs:
     - name: Download vendored dependencies
       run: go mod vendor
     - name: Tests and coverage
-      run: go test -v -coverpkg=./... -coverprofile=coverage-waf.out ./...
-    - name: SonarCloud Scan
-      if: ${{ matrix.go-version == '1.18.x' && github.repository_owner == 'corazawaf' }}
-      uses: sonarsource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: go test -v --tags=tinygo ./...

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Regression Tests](https://github.com/corazawaf/coraza/actions/workflows/regression.yml/badge.svg)](https://github.com/corazawaf/coraza/actions/workflows/regression.yml)
 [![Coreruleset Compatibility](https://github.com/corazawaf/coraza/actions/workflows/go-ftw.yml/badge.svg)](https://github.com/corazawaf/coraza/actions/workflows/go-ftw.yml)
 [![CodeQL](https://github.com/corazawaf/coraza/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/corazawaf/coraza/actions/workflows/codeql-analysis.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jptosso_coraza-waf&metric=coverage)](https://sonarcloud.io/dashboard?id=jptosso_coraza-waf)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=coraza&metric=coverage)](https://sonarcloud.io/dashboard?id=jptosso_coraza-waf)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![OWASP Lab Project](https://img.shields.io/badge/owasp-lab%20project-brightgreen)](https://owasp.org/www-project-coraza-web-application-firewall)
 [![GoDoc](https://godoc.org/github.com/corazawaf/coraza?status.svg)](https://godoc.org/github.com/corazawaf/coraza/v2)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,9 @@
-sonar.projectKey=jptosso_coraza-waf
+sonar.projectKey=coraza
 sonar.organization=jptosso
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=coraza-waf
-sonar.projectVersion=v2.0.0-beta.4
+sonar.projectVersion=v2.0.0-dev
  
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 #sonar.sources=.


### PR DESCRIPTION
This PR fixes errors for remote forks, CI will ignore sonarcloud. It also adds the base for the tinygo tests.

- Add support for golang 1.18.x tests
- Add tinygo tag tests
- Fix sonarcloud for remote forks
- Upgrade CodeQL to v2