### PR TITLE
Fix the problem that the debug log directory does not exist abnormally

### DIFF
--- a/waf.go
+++ b/waf.go
@@ -265,7 +265,7 @@ func (w *Waf) SetDebugLogPath(path string) error {
 	cfg := zap.NewProductionConfig()
 	if path != "" {
 		dir := filepath.Dir(path)
-		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			return err
 		}
 		cfg.OutputPaths = []string{path}

--- a/waf.go
+++ b/waf.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -262,13 +263,16 @@ func (w *Waf) NewTransaction() *Transaction {
 // note: this is not thread safe
 func (w *Waf) SetDebugLogPath(path string) error {
 	cfg := zap.NewProductionConfig()
-	// sampling would make us loose some debug logs
-	cfg.Sampling = nil
-	if path == "" {
-		cfg.OutputPaths = []string{}
-	} else {
+	if path != "" {
+		dir := filepath.Dir(path)
+		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
+			return err
+		}
 		cfg.OutputPaths = []string{path}
 	}
+
+	// sampling would make us loose some debug logs
+	cfg.Sampling = nil
 	cfg.Level = *w.loggerAtomicLevel
 	logger, err := cfg.Build()
 	if err != nil {


### PR DESCRIPTION
Fix the problem that the debug log path is set, and the directory does not exist that causes an exception.

`cfg.openSinks()` will fail because the file Mu does not exist, when run `cfg.Build()`.
ref: https://github.com/uber-go/zap/blob/v1.21.0/config.go#L179

zap's `newFileSink` method only creates files, not directories automatically.
ref: https://github.com/uber-go/zap/blob/v1.21.0/sink.go#L139