### PR TITLE
Test engine for interruptions, test disruptive actions

### DIFF
--- a/testdata/engine/disruptive_actions.yaml
+++ b/testdata/engine/disruptive_actions.yaml
@@ -1,0 +1,164 @@
+---
+  meta:
+    author: sts
+    description: Test if disruptive actions trigger an interruption
+    enabled: true
+    name: disruptive_actions.yaml
+  tests:
+  -
+    test_title: disruptive_actions
+    stages:
+    -
+      # Phase 1
+      stage:
+        input:
+            uri: /deny1
+        output:
+          triggered_rules:
+            - 2
+          interruption:
+            status: 500
+            data: ""
+            rule_id: 2
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop1
+        output:
+          triggered_rules:
+            - 3
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 3
+            action: drop
+    -
+      # Phase 2
+      stage:
+        input:
+            uri: /deny2
+        output:
+          triggered_rules:
+            - 22
+          interruption:
+            status: 500
+            data:
+            rule_id: 22
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop2
+        output:
+          triggered_rules:
+            - 23
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 23
+            action: drop
+      # Phase 3
+    -
+      stage:
+        input:
+            uri: /deny3
+        output:
+          triggered_rules:
+            - 32
+          interruption:
+            status: 500
+            data:
+            rule_id: 32
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop3
+        output:
+          triggered_rules:
+            - 33
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 33
+            action: drop
+    -
+      stage:
+        input:
+            uri: /deny4
+        output:
+          triggered_rules:
+            - 42
+          interruption:
+            status: 500
+            data:
+            rule_id: 42
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop4
+        output:
+          triggered_rules:
+            - 43
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 43
+            action: drop
+    -
+      stage:
+        input:
+            uri: /deny5
+        output:
+          triggered_rules:
+            - 52
+          interruption:
+            status: 500
+            data:
+            rule_id: 52
+            action: deny
+    -
+      stage:
+        input:
+            uri: /drop5
+        output:
+          triggered_rules:
+            - 53
+          interruption:
+            status: 0
+            data: ""
+            rule_id: 53
+            action: drop
+    -
+      stage:
+        input:
+            uri: /default/block
+        output:
+          triggered_rules:
+            - 103
+          log_contains: "WOOOP_BLOCKED_BY_CORAZA_TEST"
+          interruption:
+            status: 501
+            data: ""
+            rule_id: 103
+            action: deny
+  rules: |
+    SecRule REQUEST_URI "/deny1$" "phase:1,id:2,log,status:500,deny"
+    SecRule REQUEST_URI "/drop1$" "phase:1,id:3,log,drop"
+
+    SecRule REQUEST_URI "/deny2$" "phase:2,id:22,log,status:500,deny"
+    SecRule REQUEST_URI "/drop2$" "phase:2,id:23,log,drop"
+
+    SecRule REQUEST_URI "/deny3$" "phase:3,id:32,log,status:500,deny"
+    SecRule REQUEST_URI "/drop3$" "phase:3,id:33,log,drop"
+
+    SecRule REQUEST_URI "/deny4$" "phase:4,id:42,log,status:500,deny"
+    SecRule REQUEST_URI "/drop4$" "phase:4,id:43,log,drop"
+
+    SecRule REQUEST_URI "/deny5$" "phase:5,id:52,log,status:500,deny"
+    SecRule REQUEST_URI "/drop5$" "phase:5,id:53,log,drop"
+
+    SecDefaultAction phase:2,deny,status:501,log,logdata:'WOOOP_BLOCKED_BY_CORAZA_TEST'
+    SecRule REQUEST_URI "/default/block" "id:103,block"

--- a/testing/coraza_test.go
+++ b/testing/coraza_test.go
@@ -14,7 +14,12 @@
 
 package testing
 
-/*
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
 func TestEngine(t *testing.T) {
 	files, err := filepath.Glob("../testdata/engine/*.yaml")
 	if err != nil {
@@ -33,17 +38,33 @@ func TestEngine(t *testing.T) {
 			t.Error(err)
 		}
 		for _, test := range tt {
-			if err := test.RunPhases(); err != nil {
-				t.Error(err)
-			}
-			for _, e := range test.OutputErrors() {
-				debug := ""
-				for _, mr := range test.transaction.MatchedRules {
-					debug += fmt.Sprintf(" %d", mr.Rule.ID)
+			testname := profile.Tests[0].Title
+
+			t.Run(testname, func(t *testing.T) {
+				if err := test.RunPhases(); err != nil {
+					t.Errorf("%s, ERROR: %s", test.Name, err)
 				}
-				t.Errorf("%s - %s: %s\nGot: %s\n%s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, debug, test.String(), test.Request())
-			}
+
+				for _, e := range test.OutputErrors() {
+					debug := ""
+					for _, mr := range test.transaction.MatchedRules {
+						debug += fmt.Sprintf(" %d", mr.Rule.ID)
+					}
+					if testing.Verbose() {
+						t.Errorf("\x1b[41m ERROR \x1b[0m: %s:%s: %s, got:%s\n%s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, debug, test.String(), test.Request())
+					} else {
+						t.Errorf("%s: ERROR: %s", test.Name, e)
+					}
+				}
+
+				for _, e := range test.OutputInterruptionErrors() {
+					if testing.Verbose() {
+						t.Errorf("\x1b[41m ERROR \x1b[0m: %s:%s: %s\n %s\nREQUEST:\n%s", profile.Meta.Name, test.Name, e, test.String(), test.Request())
+					} else {
+						t.Errorf("%s: ERROR: %s", test.Name, e)
+					}
+				}
+			})
 		}
 	}
 }
-*/

--- a/testing/engine_test.go
+++ b/testing/engine_test.go
@@ -46,8 +46,8 @@ func TestDebug(t *testing.T) {
 	}
 	debug := test.String()
 	expected := []string{
-		"REQUEST_URI:\n-->/test",
-		"REQUEST_METHOD:\n-->OPTIONS",
+		"REQUEST_URI: /test",
+		"REQUEST_METHOD: OPTIONS",
 	}
 	for _, e := range expected {
 		if !strings.Contains(debug, e) {

--- a/testing/profile.go
+++ b/testing/profile.go
@@ -58,14 +58,22 @@ type Profile struct {
 }
 
 type expectedOutput struct {
-	Headers           map[string]string `yaml:"headers,omitempty"`
-	Data              interface{}       `yaml:"data,omitempty"` // Accepts array or string
-	LogContains       string            `yaml:"log_contains,omitempty"`
-	NoLogContains     string            `yaml:"no_log_contains,omitempty"`
-	ExpectError       bool              `yaml:"expect_error,omitempty"`
-	TriggeredRules    []int             `yaml:"triggered_rules,omitempty"`
-	NonTriggeredRules []int             `yaml:"non_triggered_rules,omitempty"`
-	Status            interface{}       `yaml:"status,omitempty"`
+	Headers           map[string]string     `yaml:"headers,omitempty"`
+	Data              interface{}           `yaml:"data,omitempty"` // Accepts array or string
+	LogContains       string                `yaml:"log_contains,omitempty"`
+	NoLogContains     string                `yaml:"no_log_contains,omitempty"`
+	ExpectError       bool                  `yaml:"expect_error,omitempty"`
+	TriggeredRules    []int                 `yaml:"triggered_rules,omitempty"`
+	NonTriggeredRules []int                 `yaml:"non_triggered_rules,omitempty"`
+	Status            interface{}           `yaml:"status,omitempty"`
+	Interruption      *expectedInterruption `yaml:"interruption,omitempty"`
+}
+
+type expectedInterruption struct {
+	RuleID int    `yaml:"rule_id,omitempty"`
+	Action string `yaml:"action,omitempty"`
+	Status int    `yaml:"status,omitempty"`
+	Data   string `yaml:"data,omitempty"`
 }
 
 // TestList returns a list of tests created for a profile


### PR DESCRIPTION
- Enhance the test engine to perform tests of returned interruptions (output.interruption)
- Add testing for disruptive actions
- Enhance test output (verbose vs non-verbose, add colors, use less space for verbose output

-------------------------------
- [X] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).