### PR TITLE
feat: flattened json audit format

### DIFF
--- a/loggers/formats_test.go
+++ b/loggers/formats_test.go
@@ -17,6 +17,8 @@ package loggers
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/corazawaf/coraza/v2/types"
 )
 
 /*
@@ -76,8 +78,38 @@ func TestLegacyFormatter(t *testing.T) {
 	}
 }
 
+func TestFlattenFormatter(t *testing.T) {
+	al := createAuditLog()
+	bts, err := flattenFormatter(al)
+	if err != nil {
+		t.Error(err)
+	}
+	data := map[string]interface{}{}
+	if err := json.Unmarshal(bts, &data); err != nil {
+		t.Error(err)
+	}
+
+	expected := map[string]interface{}{
+		"timestamp":                        float64(0),
+		"transaction.id":                   "123",
+		"transaction.request.uri":          "/test.php",
+		"transaction.request.method":       "GET",
+		"transaction.request.headers.some": "somedata",
+		"transaction.response.status":      float64(200),
+	}
+	for k, v := range expected {
+		if data[k] != v {
+			t.Errorf("failed to match flatten formatter, \ngot: %s\nexpected: %s", data[k], v)
+			if testing.Verbose() {
+				t.Logf("%#v", data)
+			}
+		}
+	}
+}
+
 func createAuditLog() *AuditLog {
 	return &AuditLog{
+		Parts: types.AuditLogParts([]types.AuditLogPart("ABCDEFGHIJKZ")),
 		Transaction: AuditTransaction{
 			Timestamp:     "02/Jan/2006:15:04:20 -0700",
 			UnixTimestamp: 0,

--- a/loggers/logger.go
+++ b/loggers/logger.go
@@ -84,8 +84,4 @@ func init() {
 	RegisterLogWriter("serial", func() LogWriter {
 		return &serialWriter{}
 	})
-
-	RegisterLogFormatter("json", jsonFormatter)
-	RegisterLogFormatter("jsonlegacy", legacyJSONFormatter)
-	RegisterLogFormatter("native", nativeFormatter)
 }

--- a/types/waf.go
+++ b/types/waf.go
@@ -133,7 +133,7 @@ func ParseRequestBodyLimitAction(rbla string) (RequestBodyLimitAction, error) {
 	return -1, fmt.Errorf("invalid request body limit action: %s", rbla)
 }
 
-type auditLogPart byte
+type AuditLogPart byte
 
 // AuditLogParts represents the parts of the audit log
 // A: Audit log header (mandatory).
@@ -148,33 +148,72 @@ type auditLogPart byte
 // J: This part contains information about the files uploaded using multipart/form-data encoding.
 // K: This part contains a full list of every rule that matched (one per line)
 // Z: Final boundary, signifies the end of the entry (mandatory).
-type AuditLogParts []auditLogPart
+type AuditLogParts []AuditLogPart
+
+func (alp AuditLogParts) has(r rune) bool {
+	for _, p := range alp {
+		if p == AuditLogPart(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasRequestHeaders returns true if the audit log contains the request headers
+func (alp AuditLogParts) HasRequestHeaders() bool {
+	return alp.has('B')
+}
+
+// HasRequestBody returns true if the audit log contains the request body
+func (alp AuditLogParts) HasRequestBody() bool {
+	return alp.has('C')
+}
+
+// HasFinalResponseHeaders returns true if the audit log contains the final response headers
+func (alp AuditLogParts) HasFinalResponseHeaders() bool {
+	return alp.has('F')
+}
+
+// HasAuditLogTrailer returns true if the audit log contains the audit log trailer
+func (alp AuditLogParts) HasAuditLogTrailer() bool {
+	return alp.has('H')
+}
+
+// HasFilesInfo returns true if the audit log contains the files info
+func (alp AuditLogParts) HasFilesInfo() bool {
+	return alp.has('J')
+}
+
+// HasRuleMatches returns true if the audit log contains the rule matches
+func (alp AuditLogParts) HasRuleMatches() bool {
+	return alp.has('K')
+}
 
 const (
 	// AuditLogPartAuditLogHeader is the mandatory header part
-	AuditLogPartAuditLogHeader auditLogPart = 'A'
+	AuditLogPartAuditLogHeader AuditLogPart = 'A'
 	// AuditLogPartRequestHeaders is the request headers part
-	AuditLogPartRequestHeaders auditLogPart = 'B'
+	AuditLogPartRequestHeaders AuditLogPart = 'B'
 	// AuditLogPartRequestBody is the request body part
-	AuditLogPartRequestBody auditLogPart = 'C'
+	AuditLogPartRequestBody AuditLogPart = 'C'
 	// AuditLogPartIntermediaryResponseHeaders is the intermediary response headers part
-	AuditLogPartIntermediaryResponseHeaders auditLogPart = 'D'
+	AuditLogPartIntermediaryResponseHeaders AuditLogPart = 'D'
 	// AuditLogPartIntermediaryResponseBody is the intermediary response body part
-	AuditLogPartIntermediaryResponseBody auditLogPart = 'E'
+	AuditLogPartIntermediaryResponseBody AuditLogPart = 'E'
 	// AuditLogPartResponseHeaders is the final response headers part
-	AuditLogPartResponseHeaders auditLogPart = 'F'
+	AuditLogPartResponseHeaders AuditLogPart = 'F'
 	// AuditLogPartResponseBody is the final response body part
-	AuditLogPartResponseBody auditLogPart = 'G'
+	AuditLogPartResponseBody AuditLogPart = 'G'
 	// AuditLogPartAuditLogTrailer is the audit log trailer part
-	AuditLogPartAuditLogTrailer auditLogPart = 'H'
+	AuditLogPartAuditLogTrailer AuditLogPart = 'H'
 	// AuditLogPartRequestBodyAlternative is the request body replaced part
-	AuditLogPartRequestBodyAlternative auditLogPart = 'I'
+	AuditLogPartRequestBodyAlternative AuditLogPart = 'I'
 	// AuditLogPartUploadedFiles is the uploaded files part
-	AuditLogPartUploadedFiles auditLogPart = 'J'
+	AuditLogPartUploadedFiles AuditLogPart = 'J'
 	// AuditLogPartRulesMatched is the matched rules part
-	AuditLogPartRulesMatched auditLogPart = 'K'
+	AuditLogPartRulesMatched AuditLogPart = 'K'
 	// AuditLogPartFinalBoundary is the mandatory final boundary part
-	AuditLogPartFinalBoundary auditLogPart = 'Z'
+	AuditLogPartFinalBoundary AuditLogPart = 'Z'
 )
 
 // Interruption is used to notify the Coraza implementation


### PR DESCRIPTION
Following #266, new flattened JSON format.

Friendly with SIEMs, and easy to process, the new struct is:

You can use it like:
```
SecAuditLogFormat flatten
```

```json
{
  "messages.0.actionset": "",
  "messages.0.data.accuracy": 0,
  "messages.0.data.data": "",
  "messages.0.data.file": "",
  "messages.0.data.id": 0,
  "messages.0.data.line": 0,
  "messages.0.data.maturity": 0,
  "messages.0.data.msg": "some message",
  "messages.0.data.rev": "",
  "messages.0.data.severity": 0,
  "messages.0.data.tags": "",
  "messages.0.data.ver": "",
  "messages.0.message": "some message",
  "timestamp": 0,
  "transaction.client_ip": "",
  "transaction.client_port": 0,
  "transaction.host_ip": "",
  "transaction.host_port": 0,
  "transaction.id": "123",
  "transaction.producer.connector": "",
  "transaction.producer.rule_engine": "",
  "transaction.producer.server": "",
  "transaction.producer.stopwatch": "",
  "transaction.producer.version": "",
  "transaction.request.body": "",
  "transaction.request.headers.some": "somedata",
  "transaction.request.http_version": "",
  "transaction.request.method": "GET",
  "transaction.request.uri": "/test.php",
  "transaction.response.headers.some": "somedata",
  "transaction.response.status": 200,
  "transaction.server_id": ""
}
```