### PR TITLE
replace aho corasick 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/corazawaf/coraza/v2
 go 1.16
 
 require (
-	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
 	github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5
 	github.com/foxcpp/go-mockdns v1.0.0
+	github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 h1:8yL+85JpbwrIc6m+7N1iYrjn/22z68jwrTIBOJHNe4k=
-github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5 h1:SukhxLQRRBM3nJFEUF+ePG7l0JTWAvaxaG/o6X/FQVY=
 github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +14,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/miekg/dns v1.1.25 h1:dFwPR6SfLtrSwgDcIq2bcU/gVutB4sNApq2HBdqcakg=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
+github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9 h1:lL+y4Xv20pVlCGyLzNHRC0I0rIHhIL1lTvHizoS/dU8=
+github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/operators/pm.go
+++ b/operators/pm.go
@@ -17,38 +17,47 @@ package operators
 import (
 	"strings"
 
-	"github.com/cloudflare/ahocorasick"
 	"github.com/corazawaf/coraza/v2"
+	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
 )
 
 // TODO according to coraza researchs, re2 matching is faster than ahocorasick
 // maybe we should switch in the future
 // pm is always lowercase
 type pm struct {
-	matcher *ahocorasick.Matcher
-	// dict is used for capturing
-	dict []string
+	matcher ahocorasick.AhoCorasick
 }
 
 func (o *pm) Init(data string) error {
 	data = strings.ToLower(data)
-	o.dict = strings.Split(data, " ")
-	o.matcher = ahocorasick.NewStringMatcher(o.dict)
+	dict := strings.Split(data, " ")
+	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
+		AsciiCaseInsensitive: true,
+		MatchOnlyWholeWords:  false,
+		MatchKind:            ahocorasick.LeftMostLongestMatch,
+		DFA:                  true,
+	})
+
 	// TODO this operator is supposed to support snort data syntax: "@pm A|42|C|44|F"
-	// TODO modsecurity uses mutex to queue ahocorasick, maybe its for a reason...
+	o.matcher = builder.Build(dict)
 	return nil
 }
 
 func (o *pm) Evaluate(tx *coraza.Transaction, value string) bool {
-	value = strings.ToLower(value)
-	matches := o.matcher.MatchThreadSafe([]byte(value))
-	for i := 0; i < len(matches); i++ {
-		if i == 10 {
-			return true
+	if tx.Capture {
+		matches := o.matcher.FindAll(value)
+		for i, match := range matches {
+			if i == 10 {
+				return true
+			}
+			tx.CaptureField(i, value[match.Start():match.End()])
 		}
-		tx.CaptureField(i, o.dict[matches[i]])
+		return len(matches) > 0
+	} else {
+		iter := o.matcher.Iter(value)
+		next := iter.Next()
+		return next != nil
 	}
-	return len(matches) > 0
 }
 
 var _ coraza.RuleOperator = (*pm)(nil)

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -18,12 +18,12 @@ import (
 	"bufio"
 	"strings"
 
-	"github.com/cloudflare/ahocorasick"
 	"github.com/corazawaf/coraza/v2"
+	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
 )
 
 type pmFromFile struct {
-	pm *pm
+	matcher ahocorasick.AhoCorasick
 }
 
 func (o *pmFromFile) Init(data string) error {
@@ -40,13 +40,34 @@ func (o *pmFromFile) Init(data string) error {
 		}
 		lines = append(lines, strings.ToLower(l))
 	}
-	o.pm = &pm{
-		dict:    lines,
-		matcher: ahocorasick.NewStringMatcher(lines),
-	}
+
+	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
+		AsciiCaseInsensitive: true,
+		MatchOnlyWholeWords:  false,
+		MatchKind:            ahocorasick.LeftMostLongestMatch,
+		DFA:                  false,
+	})
+
+	// TODO this operator is supposed to support snort data syntax: "@pm A|42|C|44|F"
+	o.matcher = builder.Build(lines)
 	return nil
 }
 
 func (o *pmFromFile) Evaluate(tx *coraza.Transaction, value string) bool {
-	return o.pm.Evaluate(tx, value)
+	if tx.Capture {
+		matches := o.matcher.FindAll(value)
+		for i, match := range matches {
+			if i == 10 {
+				return true
+			}
+			tx.CaptureField(i, value[match.Start():match.End()])
+		}
+		return len(matches) > 0
+	} else {
+		iter := o.matcher.Iter(value)
+		next := iter.Next()
+		return next != nil
+	}
 }
+
+var _ coraza.RuleOperator = (*pmFromFile)(nil)

--- a/operators/pm_from_file_test.go
+++ b/operators/pm_from_file_test.go
@@ -31,7 +31,4 @@ func TestPmfm(t *testing.T) {
 	if !p.Evaluate(tx, "def") {
 		t.Error("failed to match pmFromFile")
 	}
-	if len(p.pm.dict) != 4 {
-		t.Error("failed to load pmFromFile")
-	}
 }


### PR DESCRIPTION
This is a huge improvement, memory consumption is 60% less, and execution time was 233% faster

## Benchmark results using CRS:

**Old results:**
```
Preparing CRS...
CRS PATH: /var/folders/tf/23czq0cd4wd5v54zcvctvtzw0000gn/T/crs1564927737
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/testing
BenchmarkCRSCompilation-10             3         378610667 ns/op
BenchmarkCRSSimpleGET-10             613           1791376 ns/op
BenchmarkCRSSimplePOST-10            308           3499975 ns/op
PASS
ok      github.com/corazawaf/coraza/v3/testing  13.985s
```

**New results:**
```
Preparing CRS...
CRS PATH: /var/folders/tf/23czq0cd4wd5v54zcvctvtzw0000gn/T/crs1721984072
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/testing
BenchmarkCRSCompilation-10            21          48269002 ns/op
BenchmarkCRSSimpleGET-10             777           1396721 ns/op
BenchmarkCRSSimplePOST-10            489           2396956 ns/op
PASS
ok      github.com/corazawaf/coraza/v3/testing  5.969s
```