### PR TITLE
Move resetCaptures defer out of loop

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -221,6 +221,7 @@ func (r *Rule) Evaluate(tx *Transaction) []types.MatchData {
 		r.matchVariable(tx, md)
 	} else {
 		ecol := tx.ruleRemoveTargetByID[r.ID]
+		captured := false
 		for _, v := range r.variables {
 			var values []types.MatchData
 			for _, c := range ecol {
@@ -269,12 +270,16 @@ func (r *Rule) Evaluate(tx *Transaction) []types.MatchData {
 
 						// we only capture when it matches
 						if r.Capture {
-							defer tx.resetCaptures()
+							captured = true
 						}
 					}
 					tx.Waf.Logger.Debug("[%s] [%d] Evaluating operator \"@%s %s\" for rule %d", tx.ID, rid, r.operator.Function, "", r.ID)
 				}
 			}
+		}
+
+		if captured {
+			defer tx.resetCaptures()
 		}
 	}
 


### PR DESCRIPTION
Defer in a loop causes the defer to be setup for each iteration in the loop that can cause issues. I noticed it specifically because while Go could still run fine with it, TinyGo crashed because of it.

Now, we record whether we should defer within the loop, and actually defer out of it.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: