### PR TITLE
Reduce include recursion limit

### DIFF
--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -28,7 +28,7 @@ import (
 )
 
 // maxIncludeRecursion is used to avoid DDOS by including files that include
-const maxIncludeRecursion = 500
+const maxIncludeRecursion = 100
 
 // Parser provides functions to evaluate (compile) SecLang directives
 type Parser struct {


### PR DESCRIPTION
I found that the current recursion limit does not work with TinyGo, it probably has a smaller max stack size than Go. I could confirm that 200 is too high and 100 works, didn't check in the middle. 100 seems high enough (even just 1 maybe ?) so I changed the constant, an alternative would be to use build tags to set to 500 normally and 100 only on TinyGo.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [X] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: