### PR TITLE
Don't copy to bytes when validating byte range

### DIFF
--- a/operators/validate_byte_range.go
+++ b/operators/validate_byte_range.go
@@ -77,11 +77,11 @@ func (o *validateByteRange) Evaluate(tx *coraza.Transaction, data string) bool {
 	if data == "" && lenData > 0 {
 		return false
 	}
-	input := []byte(data)
 	// we must iterate each byte from input and check if it is in the range
 	// if every byte is within the range we return false
 	matched := 0
-	for _, c := range input {
+	for i := 0; i < len(data); i++ {
+		c := data[i]
 		for _, r := range o.data {
 			if c >= r.start && c <= r.end {
 				matched++
@@ -89,7 +89,7 @@ func (o *validateByteRange) Evaluate(tx *coraza.Transaction, data string) bool {
 			}
 		}
 	}
-	return len(input) != matched
+	return len(data) != matched
 }
 
 func (o *validateByteRange) addRange(start uint64, end uint64) error {


### PR DESCRIPTION
`len` and numeric indexing of a string work on bytes so no need to convert

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [X] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: