### PR TITLE
Add command for installing precommit hook

### DIFF
--- a/.pre-commit.hook
+++ b/.pre-commit.hook
@@ -1,0 +1,2 @@
+echo "Executing precommit checks"
+go run mage.go check


### PR DESCRIPTION
This adds a command for installing a precommit hook. The current precommit infrastructure has a couple of issues

- Requires installing external tool, `precommit` (and python if not installed yet)
- Requires installing the actual linting tools as [here](https://github.com/corazawaf/coraza/blob/v2/master/.github/workflows/lint.yml#L16). More problematically, requires reinstalling if updated.

These aren't the end of the world, but we can continue to support all our tooling while only requiring Go. This adds the command `go run mage.go precommit` which copies a pre-commit hook to `.git` which simply runs `go run mage.go check`. `go run mage.go check` will run the same across CI, dev machines, etc even if we update tool versions, no version maintenance required by users.

If this is accepted, then next I will copy the magefile.go to v2 branch and then update CI to use `go run mage.go check` instead of the current pre-commit action and update the README to remove mention of it.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: