### PR TITLE
Reduce some data copies in modsecurity bridge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza/v3
 go 1.18
 
 require (
-	github.com/anuraaga/go-modsecurity v0.0.0-20220816070944-f36055ce7d5d
+	github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df
 	github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5
 	github.com/foxcpp/go-mockdns v1.0.0
 	github.com/magefile/mage v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/anuraaga/go-modsecurity v0.0.0-20220816070944-f36055ce7d5d h1:6MEruON1LI/62GV5Z6bh6eN1j7nN6np8dEoci7eMHwA=
-github.com/anuraaga/go-modsecurity v0.0.0-20220816070944-f36055ce7d5d/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=
 github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df h1:YWiVl53v0R8Knj/k+4slO0SXPL67Y4dXWiOIWNzrkew=
 github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=
 github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5 h1:SukhxLQRRBM3nJFEUF+ePG7l0JTWAvaxaG/o6X/FQVY=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/anuraaga/go-modsecurity v0.0.0-20220816070944-f36055ce7d5d h1:6MEruON1LI/62GV5Z6bh6eN1j7nN6np8dEoci7eMHwA=
 github.com/anuraaga/go-modsecurity v0.0.0-20220816070944-f36055ce7d5d/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=
+github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df h1:YWiVl53v0R8Knj/k+4slO0SXPL67Y4dXWiOIWNzrkew=
+github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=
 github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5 h1:SukhxLQRRBM3nJFEUF+ePG7l0JTWAvaxaG/o6X/FQVY=
 github.com/corazawaf/libinjection-go v0.0.0-20220207031228-44e9c4250eb5/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=

--- a/testing/modsecurity_test.go
+++ b/testing/modsecurity_test.go
@@ -61,20 +61,20 @@ func BenchmarkModSecurityCRSSimpleGET(b *testing.B) {
 		b.Error(err)
 	}
 	for i := 0; i < b.N; i++ {
-		tx, err := rs.NewTransaction("127.0.0.1:8080", "127.0.0.1:8080")
+		tx, err := rs.NewTransaction("127.0.0.1", 8080, "127.0.0.1", 8080)
 		if err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessUri("/some_path/with?parameters=and&other=Stuff", "GET", "1.1"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("Host"), []byte("localhost")); err != nil {
+		if err := tx.AddRequestHeader("Host", "localhost"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("User-Agent"), []byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")); err != nil {
+		if err := tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("Accept"), []byte("application/json")); err != nil {
+		if err := tx.AddRequestHeader("Accept", "application/json"); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessRequestHeaders(); err != nil {
@@ -83,7 +83,7 @@ func BenchmarkModSecurityCRSSimpleGET(b *testing.B) {
 		if err := tx.ProcessRequestBody(); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddResponseHeader([]byte("Content-Type"), []byte("application/json")); err != nil {
+		if err := tx.AddResponseHeader("Content-Type", "application/json"); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessResponseHeaders(200, "1.1"); err != nil {
@@ -106,28 +106,28 @@ func BenchmarkModSecurityCRSSimplePOST(b *testing.B) {
 		b.Error(err)
 	}
 	for i := 0; i < b.N; i++ {
-		tx, err := rs.NewTransaction("127.0.0.1:8080", "127.0.0.1:8080")
+		tx, err := rs.NewTransaction("127.0.0.1", 8080, "127.0.0.1", 8080)
 		if err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessUri("/some_path/with?parameters=and&other=Stuff", "POST", "1.1"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("Host"), []byte("localhost")); err != nil {
+		if err := tx.AddRequestHeader("Host", "localhost"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("User-Agent"), []byte("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")); err != nil {
+		if err := tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("Accept"), []byte("application/json")); err != nil {
+		if err := tx.AddRequestHeader("Accept", "application/json"); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddRequestHeader([]byte("Content-Type"), []byte("application/x-www-form-urlencoded")); err != nil {
+		if err := tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded"); err != nil {
 			b.Error(err)
 		}
 		body := []byte("parameters2=and&other2=Stuff")
 
-		if err := tx.AddRequestHeader([]byte("Content-Length"), []byte(strconv.Itoa(len(body)))); err != nil {
+		if err := tx.AddRequestHeader("Content-Length", strconv.Itoa(len(body))); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessRequestHeaders(); err != nil {
@@ -139,7 +139,7 @@ func BenchmarkModSecurityCRSSimplePOST(b *testing.B) {
 		if err := tx.ProcessRequestBody(); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AddResponseHeader([]byte("Content-Type"), []byte("application/json")); err != nil {
+		if err := tx.AddResponseHeader("Content-Type", "application/json"); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessResponseHeaders(200, "1.1"); err != nil {


### PR DESCRIPTION
I don't think there's much more to try to reduce overhead other than reducing overhead when reading log statements that aren't actually outputed for the current log level (some string conversions in the cgo bridge, for a string that's eventually dropped). But I think if we have similar performance to this, then we're in a good place

https://github.com/anuraaga/go-modsecurity/commit/b9a4099778df0cbf27d2a690a09240fe8f4f2593

The effect will be biggest with large bodies, previously there was this buffer copy

https://github.com/anuraaga/go-modsecurity/commit/b9a4099778df0cbf27d2a690a09240fe8f4f2593#diff-63ab601287b8b9c040760fe0bdd288f55b73f37cd7e4f1e519bea2bd43a18bbaL246

I'm a bit scared to make the change since not sure why anyone would append newline if not required, but I can't think of the reason. The current test cases pass without it so hoping it's OK.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: