### PR TITLE
Implements ipMatchFromDataset, parsing for ipMatchFromFile

### DIFF
--- a/operators/ip_match_from_dataset.go
+++ b/operators/ip_match_from_dataset.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package operators
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/corazawaf/coraza/v3"
+	engine "github.com/corazawaf/coraza/v3"
+)
+
+type ipMatchFromDataset struct {
+	ip *ipMatch
+}
+
+func (o *ipMatchFromDataset) Init(options coraza.RuleOperatorOptions) error {
+	data := options.Arguments
+	dataset, ok := options.Datasets[data]
+	if !ok || len(dataset) == 0 {
+		return fmt.Errorf("Dataset %q not found", data)
+	}
+
+	datasetParsed := strings.Join(dataset, ",")
+
+	o.ip = &ipMatch{}
+	opts := coraza.RuleOperatorOptions{
+		Arguments: datasetParsed,
+	}
+	return o.ip.Init(opts)
+}
+
+func (o *ipMatchFromDataset) Evaluate(tx *engine.Transaction, value string) bool {
+	return o.ip.Evaluate(tx, value)
+}

--- a/operators/ip_match_from_dataset.go
+++ b/operators/ip_match_from_dataset.go
@@ -34,3 +34,5 @@ func (o *ipMatchFromDataset) Init(options coraza.RuleOperatorOptions) error {
 func (o *ipMatchFromDataset) Evaluate(tx *engine.Transaction, value string) bool {
 	return o.ip.Evaluate(tx, value)
 }
+
+var _ coraza.RuleOperator = (*ipMatchFromDataset)(nil)

--- a/operators/ip_match_from_dataset_test.go
+++ b/operators/ip_match_from_dataset_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package operators
+
+import (
+	_ "fmt"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+)
+
+func TestIpMatchFromDataset(t *testing.T) {
+	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
+	addrfail := []string{"127.0.0.2", "192.168.1.1"}
+
+	ipm := &ipMatchFromDataset{}
+	opts := coraza.RuleOperatorOptions{
+		Arguments: "test_1",
+		Datasets: map[string][]string{
+			"test_1": {"127.0.0.1", "192.168.0.0/24"},
+		},
+	}
+
+	if err := ipm.Init(opts); err != nil {
+		t.Error("Cannot init ipmatchfromfile operator")
+	}
+	for _, ok := range addrok {
+		if !ipm.Evaluate(nil, ok) {
+			t.Errorf("Invalid result for single CIDR IpMatchFromDataset " + ok)
+		}
+	}
+
+	for _, fail := range addrfail {
+		if ipm.Evaluate(nil, fail) {
+			t.Errorf("Invalid result for single CIDR IpMatchFromDataset" + fail)
+		}
+	}
+}

--- a/operators/ip_match_from_dataset_test.go
+++ b/operators/ip_match_from_dataset_test.go
@@ -37,3 +37,16 @@ func TestIpMatchFromDataset(t *testing.T) {
 		}
 	}
 }
+
+func TestIpMatchFromEmptyDataset(t *testing.T) {
+	ipm := &ipMatchFromDataset{}
+	opts := coraza.RuleOperatorOptions{
+		Arguments: "test_1",
+		Datasets: map[string][]string{
+			"test_1": {},
+		},
+	}
+	if err := ipm.Init(opts); err == nil {
+		t.Error("Empty dataset not checked")
+	}
+}

--- a/operators/ip_match_from_file.go
+++ b/operators/ip_match_from_file.go
@@ -43,3 +43,5 @@ func (o *ipMatchFromFile) Init(options coraza.RuleOperatorOptions) error {
 func (o *ipMatchFromFile) Evaluate(tx *engine.Transaction, value string) bool {
 	return o.ip.Evaluate(tx, value)
 }
+
+var _ coraza.RuleOperator = (*ipMatchFromFile)(nil)

--- a/operators/ip_match_from_file.go
+++ b/operators/ip_match_from_file.go
@@ -4,6 +4,7 @@
 package operators
 
 import (
+	"bufio"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3"
@@ -17,10 +18,24 @@ type ipMatchFromFile struct {
 func (o *ipMatchFromFile) Init(options coraza.RuleOperatorOptions) error {
 	data := options.Arguments
 
+	dataParsed := ""
+	sc := bufio.NewScanner(strings.NewReader(data))
+	for sc.Scan() {
+		l := sc.Text()
+		l = strings.TrimSpace(l)
+		if len(l) == 0 {
+			continue
+		}
+		if l[0] == '#' {
+			continue
+		}
+		dataParsed += ","
+		dataParsed += l
+	}
+
 	o.ip = &ipMatch{}
-	subnets := strings.ReplaceAll(data, "\n", ",")
 	opts := coraza.RuleOperatorOptions{
-		Arguments: subnets,
+		Arguments: dataParsed,
 	}
 	return o.ip.Init(opts)
 }

--- a/operators/operators.go
+++ b/operators/operators.go
@@ -33,6 +33,7 @@ func init() {
 	Register("streq", func() coraza.RuleOperator { return &streq{} })
 	Register("ipMatch", func() coraza.RuleOperator { return &ipMatch{} })
 	Register("ipMatchFromFile", func() coraza.RuleOperator { return &ipMatchFromFile{} })
+	Register("ipMatchFromDataset", func() coraza.RuleOperator { return &ipMatchFromDataset{} })
 	Register("rbl", func() coraza.RuleOperator { return &rbl{} })
 	Register("validateUtf8Encoding", func() coraza.RuleOperator { return &validateUtf8Encoding{} })
 	Register("noMatch", func() coraza.RuleOperator { return &noMatch{} })

--- a/operators/pm_from_dataset.go
+++ b/operators/pm_from_dataset.go
@@ -30,7 +30,6 @@ func (o *pmFromDataset) Init(options coraza.RuleOperatorOptions) error {
 		DFA:                  true,
 	})
 
-	// TODO this operator is supposed to support snort data syntax: "@pmFromDataset A|42|C|44|F"
 	o.matcher = builder.Build(dataset)
 	return nil
 }

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -39,7 +39,6 @@ func (o *pmFromFile) Init(options coraza.RuleOperatorOptions) error {
 		DFA:                  false,
 	})
 
-	// TODO this operator is supposed to support snort data syntax: "@pm A|42|C|44|F"
 	o.matcher = builder.Build(lines)
 	return nil
 }


### PR DESCRIPTION

Follows https://github.com/corazawaf/coraza/pull/361 (Thank you so much @jptosso!).
- Parses the input file in `ipMatchFromFile`
Based on the `pmFromFile` implementation, the PR proposes to also ignore empty and comment lines (#...) in the `ipMatchFromFile` operator.

- Implements the `ipMatchFromDataset` operator. 
`ipMatchFromDataset` is the second operator that can benefit from the introduction of `SecDataset`. This PR proposes an implementation of it.

- chore: removes misleading comments about snort syntax in `pmFromDataset` and `pmFromDataset`. See [comment](https://github.com/corazawaf/coraza/pull/361#discussion_r956138113).

**Question**: Do I have to register the new operator? I'm aware of a list of operators inside [operators.go](https://github.com/corazawaf/coraza/blob/v3/dev/operators/operators.go#L16-L43), but I can not also find the recent `pmFromDataset`. Thanks for your guidance!

### ipMatchFromDataset
**Description**: Performs a fast ipv4 or ipv6 match of REMOTE_ADDR variable, loading data from a `SecDataset`. 
**Sample**:
```
SecRule REMOTE_ADDR "@ipMatchFromDataset sample_dataset" "..."
```


> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: