### PR TITLE
chore: loads file inside operator when using FromFile.

### DIFF
--- a/operators/from_file.go
+++ b/operators/from_file.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package operators
+
+import (
+	"os"
+	"path"
+)
+
+func loadFromFile(filepath string, paths []string) ([]byte, error) {
+	if path.IsAbs(filepath) {
+		return os.ReadFile(filepath)
+	}
+
+	// handling files by operators is hard because we must know the paths where we can
+	// search, for example, the policy path or the binary path...
+	// CRS stores the .data files in the same directory as the directives
+	var (
+		content []byte
+		err     error
+	)
+
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+
+		absFilepath := path.Join(p, filepath)
+		content, err = os.ReadFile(absFilepath)
+		if err != nil {
+			if err == os.ErrNotExist {
+				continue
+			} else {
+				return nil, err
+			}
+		}
+
+		return content, nil
+	}
+
+	return nil, err
+}

--- a/operators/from_file_test.go
+++ b/operators/from_file_test.go
@@ -18,7 +18,10 @@ func getTestFile(t *testing.T) (string, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpFile.WriteString(fileContent)
+	_, err = tmpFile.WriteString(fileContent)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return tmpDir, tmpFile.Name()
 }
 

--- a/operators/from_file_test.go
+++ b/operators/from_file_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package operators
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const fileContent = "abc123"
+
+func getTestFile(t *testing.T) (string, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	tmpFile, err := os.Create(filepath.Join(tmpDir, "tmpfile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.WriteString(fileContent)
+	return tmpDir, tmpFile.Name()
+}
+
+func TestLoadFromFileNoExist(t *testing.T) {
+	content, err := loadFromFile("non-existing-file", []string{t.TempDir()})
+	if err == nil {
+		t.Errorf("expected error: %s", os.ErrNotExist.Error())
+	}
+
+	if len(content) != 0 {
+		t.Errorf("expected empty content, got %q", content)
+	}
+}
+
+func TestLoadFromFileAbsolutePath(t *testing.T) {
+	_, testFile := getTestFile(t)
+	absFilepath, err := filepath.Abs(testFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := loadFromFile(absFilepath, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, have := fileContent, string(content); want != have {
+		t.Errorf("unexpected content, want %q, have %q", want, have)
+	}
+}
+
+func TestLoadFromFileRelativePath(t *testing.T) {
+	testDir, testFile := getTestFile(t)
+
+	content, err := loadFromFile(testFile, []string{"/does-not-exist", testDir})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if want, have := fileContent, string(content); want != have {
+		t.Errorf("unexpected content, want %q, have %q", want, have)
+	}
+}

--- a/operators/ip_match_from_file_test.go
+++ b/operators/ip_match_from_file_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package operators
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+)
+
+func TestFromFile(t *testing.T) {
+	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
+	addrfail := []string{"127.0.0.2", "192.168.1.1"}
+
+	ipm := &ipMatchFromFile{}
+	opts := coraza.RuleOperatorOptions{
+		Arguments: string("./testdata/op/netranges.dat"),
+		Path:      []string{"."},
+	}
+	if err := ipm.Init(opts); err != nil {
+		t.Error("Cannot init ipmatchfromfile operator")
+	}
+	for _, ok := range addrok {
+		t.Run(ok, func(t *testing.T) {
+			if !ipm.Evaluate(nil, ok) {
+				t.Errorf("Invalid result for single CIDR IpMatchFromFile")
+			}
+		})
+	}
+
+	for _, fail := range addrfail {
+		t.Run(fail, func(t *testing.T) {
+			if ipm.Evaluate(nil, fail) {
+				t.Errorf("Invalid result for single CIDR IpMatchFromFile")
+			}
+		})
+	}
+}

--- a/operators/ip_match_test.go
+++ b/operators/ip_match_test.go
@@ -5,7 +5,6 @@ package operators
 
 import (
 	_ "fmt"
-	"os"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
@@ -43,41 +42,13 @@ func TestMultipleAddress(t *testing.T) {
 	}
 	for _, ok := range addrok {
 		if !ipm.Evaluate(nil, ok) {
-			t.Errorf("Invalid result for single CIDR IpMatch " + ok)
+			t.Errorf("Invalid result for single CIDR IpMatch: %s", ok)
 		}
 	}
 
 	for _, fail := range addrfail {
 		if ipm.Evaluate(nil, fail) {
-			t.Errorf("Invalid result for single CIDR IpMatch" + fail)
-		}
-	}
-}
-
-func TestFromFile(t *testing.T) {
-	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
-	addrfail := []string{"127.0.0.2", "192.168.1.1"}
-
-	ipm := &ipMatchFromFile{}
-	data, err := os.ReadFile("./testdata/op/netranges.dat")
-	if err != nil {
-		t.Error("Cannot read test data", err)
-	}
-	opts := coraza.RuleOperatorOptions{
-		Arguments: string(data),
-	}
-	if err := ipm.Init(opts); err != nil {
-		t.Error("Cannot init ipmatchfromfile operator")
-	}
-	for _, ok := range addrok {
-		if !ipm.Evaluate(nil, ok) {
-			t.Errorf("Invalid result for single CIDR IpMatchFromFile " + ok)
-		}
-	}
-
-	for _, fail := range addrfail {
-		if ipm.Evaluate(nil, fail) {
-			t.Errorf("Invalid result for single CIDR IpMatchFromFile" + fail)
+			t.Errorf("Invalid result for single CIDR IpMatch: %s", fail)
 		}
 	}
 }

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -6,7 +6,6 @@ package operators
 import (
 	"context"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -42,7 +41,7 @@ func TestOperators(t *testing.T) {
 	}
 	waf := coraza.NewWaf()
 	for _, f := range files {
-		cases := unmarshalTests(f)
+		cases := unmarshalTests(t, f)
 		for _, data := range cases {
 			t.Run(data.Name, func(t *testing.T) {
 				// UNMARSHALL does not transform \u0000 to binary
@@ -69,17 +68,10 @@ func TestOperators(t *testing.T) {
 					t.Logf("skipped error: %v", err)
 					return
 				}
-				if data.Name == "pmFromFile" || data.Name == "ipMatchFromFile" {
-					// read file
-					fname := path.Join(root, "op", data.Param)
-					d, err := os.ReadFile(fname)
-					if err != nil {
-						t.Errorf("Cannot open file %q", data.Param)
-					}
-					data.Param = string(d)
-				}
+
 				opts := coraza.RuleOperatorOptions{
 					Arguments: data.Param,
+					Path:      []string{"./testdata/op"},
 				}
 				if err := op.Init(opts); err != nil {
 					t.Error(err)
@@ -99,7 +91,8 @@ func TestOperators(t *testing.T) {
 	}
 }
 
-func unmarshalTests(json []byte) []Test {
+func unmarshalTests(t *testing.T, json []byte) []Test {
+	t.Helper()
 	var tests []Test
 	v := gjson.ParseBytes(json).Value()
 	for _, in := range v.([]interface{}) {

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -5,6 +5,7 @@ package operators
 
 import (
 	"bufio"
+	"bytes"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3"
@@ -16,10 +17,15 @@ type pmFromFile struct {
 }
 
 func (o *pmFromFile) Init(options coraza.RuleOperatorOptions) error {
-	data := options.Arguments
+	path := options.Arguments
+
+	data, err := loadFromFile(path, options.Path)
+	if err != nil {
+		return err
+	}
 
 	lines := []string{}
-	sc := bufio.NewScanner(strings.NewReader(data))
+	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
 		l := sc.Text()
 		l = strings.TrimSpace(l)

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -142,6 +142,12 @@ func (p *Parser) evaluate(data string) error {
 	p.options.Config.Set("last_profile_line", p.currentLine)
 	p.options.Config.Set("parser_config_file", p.currentFile)
 	p.options.Config.Set("parser_config_dir", p.currentDir)
+	wd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	p.options.Config.Set("working_dir", wd)
+
 	return d(p.options)
 }
 

--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -6,8 +6,6 @@ package seclang
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path"
 	"regexp"
 	"strings"
 
@@ -194,22 +192,13 @@ func (p *RuleParser) ParseOperator(operator string) error {
 		return err
 	}
 	data := []byte(opdata)
-	// handling files by operators is hard because we must know the paths where we can
-	// search, for example, the policy path or the binary path...
-	// CRS stores the .data files in the same directory as the directives
-	if strings.HasSuffix(op, "FromFile") {
-		// TODO make enhancements here
-		tpath := path.Join(p.options.Config.Get("parser_config_dir", "").(string), opdata)
-		var err error
-		content, err := os.ReadFile(tpath)
-		if err != nil {
-			return err
-		}
-		opdata = tpath
-		data = content
-	}
+
 	opts := coraza.RuleOperatorOptions{
 		Arguments: string(data),
+		Path: []string{
+			p.options.Config.Get("parser_config_dir", "").(string),
+			p.options.Config.Get("working_dir", "").(string),
+		},
 	}
 	err = opfn.Init(opts)
 	if err != nil {


### PR DESCRIPTION
Currently files are loaded on parsing and passed down to operators (e.g. pmFromFile) inside the options, this is inconvenient because we have custom logic for them (making useless the interface) but also making it hard to implement things like lazy load of the data.

Ping @anuraaga 

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: