### PR TITLE
chore: improves errors on tinygo.

### DIFF
--- a/actions/append.go
+++ b/actions/append.go
@@ -28,7 +28,7 @@ func (a *appendFn) Evaluate(r *coraza.Rule, tx *coraza.Transaction) {
 	}
 	data := a.data.Expand(tx)
 	if _, err := tx.ResponseBodyBuffer.Write([]byte(data)); err != nil {
-		tx.Waf.Logger.Error("append failed to write to response buffer %v", err)
+		tx.Waf.Logger.Error("append failed to write to response buffer: %s", err.Error())
 	}
 }
 

--- a/actions/ctl.go
+++ b/actions/ctl.go
@@ -63,7 +63,7 @@ func (a *ctlFn) Evaluate(r *coraza.Rule, tx *coraza.Transaction) {
 	case ctlRemoveTargetByID:
 		ran, err := a.rangeToInts(tx.Waf.Rules.GetRules(), a.value)
 		if err != nil {
-			tx.Waf.Logger.Error("[ctl REMOVE_TARGET_BY_ID] invalid range: %v", err)
+			tx.Waf.Logger.Error("[ctl REMOVE_TARGET_BY_ID] invalid range: %s", err.Error())
 			return
 		}
 		for _, id := range ran {

--- a/actions/setenv.go
+++ b/actions/setenv.go
@@ -35,7 +35,7 @@ func (a *setenvFn) Evaluate(r *coraza.Rule, tx *coraza.Transaction) {
 	v := a.value.Expand(tx)
 	// set env variable
 	if err := os.Setenv(a.key, v); err != nil {
-		tx.Waf.Logger.Error("[%s] Error setting env variable for rule %d: %v", tx.ID, r.ID, err)
+		tx.Waf.Logger.Error("[%s] Error setting env variable for rule %d: %s", tx.ID, r.ID, err.Error())
 	}
 	// TODO is this ok?
 	tx.Variables.Env.Set(a.key, []string{v})

--- a/actions/severity_test.go
+++ b/actions/severity_test.go
@@ -42,7 +42,7 @@ func TestSeverity(t *testing.T) {
 				t.Error(err)
 			}
 			if got := rule.Severity; got != tt.want {
-				t.Errorf("Severity = %v, want %v", got, tt.want)
+				t.Errorf("Severity = %s, want %s", got.String(), tt.want.String())
 			}
 		})
 	}

--- a/bodyprocessors/xml_test.go
+++ b/bodyprocessors/xml_test.go
@@ -8,7 +8,6 @@ package bodyprocessors
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/strings"
@@ -37,7 +36,6 @@ func TestXMLAttribures(t *testing.T) {
 	}
 	if len(contents) != 4 {
 		t.Errorf("Expected 4 contents, got %d", len(contents))
-		fmt.Println(contents)
 	}
 	eattrs := []string{"en", "value"}
 	econtent := []string{"Harry Potter", "29.99", "Learning XML", "39.95"}

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -37,7 +37,7 @@ func TestOperators(t *testing.T) {
 		}
 		return nil
 	}); err != nil {
-		t.Error("failed to walk test files")
+		t.Errorf("failed to walk test files: %s", err.Error())
 	}
 	waf := coraza.NewWaf()
 	for _, f := range files {
@@ -51,7 +51,7 @@ func TestOperators(t *testing.T) {
 				if strings.Contains(data.Input, `\x`) {
 					in, err := strconv.Unquote(`"` + data.Input + `"`)
 					if err != nil {
-						t.Error("Cannot parse test case", err)
+						t.Errorf("Cannot parse test case: %s", err.Error())
 					} else {
 						data.Input = in
 					}
@@ -59,13 +59,13 @@ func TestOperators(t *testing.T) {
 				if strings.Contains(data.Param, `\x`) {
 					p, err := strconv.Unquote(`"` + data.Param + `"`)
 					if err != nil {
-						t.Error("Cannot parse test case", err)
+						t.Errorf("Cannot parse test case: %s", err.Error())
 					}
 					data.Param = p
 				}
 				op, err := Get(data.Name)
 				if err != nil {
-					t.Logf("skipped error: %v", err)
+					t.Logf("skipped error: %s", err.Error())
 					return
 				}
 

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -77,14 +77,14 @@ func directiveSecRule(options *DirectiveOptions) error {
 	if err != nil && !ignoreErrors {
 		return newCompileRuleError(err, options.Opts)
 	} else if err != nil && ignoreErrors {
-		options.Waf.Logger.Debug("Ignoring rule compilation error for rule %s: %v", options.Opts, err)
+		options.Waf.Logger.Debug("Ignoring rule compilation error for rule %s: %s", options.Opts, err.Error())
 		return nil
 	}
 	err = options.Waf.Rules.Add(rule)
 	if err != nil && !ignoreErrors {
 		return err
 	} else if err != nil && ignoreErrors {
-		options.Waf.Logger.Debug("Ignoring rule compilation error for rule %s: %v", options.Opts, err)
+		options.Waf.Logger.Debug("Ignoring rule compilation error for rule %s: %s", options.Opts, err.Error())
 		return nil
 	}
 	return nil

--- a/seclang/rule_parser_test.go
+++ b/seclang/rule_parser_test.go
@@ -16,7 +16,7 @@ func TestInvalidRule(t *testing.T) {
 
 	err := p.FromString("")
 	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Errorf("unexpected error: %s", err.Error())
 	}
 
 	err = p.FromString("SecRule ")
@@ -88,7 +88,7 @@ func TestSecRuleInlineVariableNegation(t *testing.T) {
 		SecRule REQUEST_URI|!REQUEST_COOKIES: "abc" "id:9,phase:2"
 	`)
 	if !strings.Contains(err.Error(), "failed to compile rule") {
-		t.Error("Error should be failed to compile rule, got ", err)
+		t.Errorf("Error should be failed to compile rule, got %s", err)
 	}
 }
 
@@ -109,7 +109,7 @@ func TestSecRuleUpdateTargetVariableNegation(t *testing.T) {
 		SecRuleUpdateTargetById 8 "!REQUEST_HEADERS:"
 	`)
 	if err.Error() != "unknown variable" {
-		t.Error("Error should be unknown variable, got ", err)
+		t.Errorf("Error should be unknown variable, got %s", err.Error())
 	}
 
 	// Try to update undefined rule
@@ -128,10 +128,10 @@ func TestErrorLine(t *testing.T) {
 	p, _ := NewParser(waf)
 	err := p.FromString("SecAction \"id:1\"\n#test\nSomefaulty")
 	if err == nil {
-		t.Error("that shouldn't happen o.o")
+		t.Error("expected error")
 	}
 	if !strings.Contains(err.Error(), "Line 3") {
-		t.Error("failed to find error line, got " + err.Error())
+		t.Errorf("failed to find error line, got %s", err.Error())
 	}
 }
 
@@ -142,7 +142,7 @@ func TestDefaultActionsForPhase2(t *testing.T) {
 	SecAction "id:1,phase:2"
 	SecAction "id:2,phase:1"`)
 	if err != nil {
-		t.Error("that shouldn't happen", err)
+		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if waf.Rules.GetRules()[0].Log != true {
 		t.Error("failed to set log to true because of default actions")

--- a/waf.go
+++ b/waf.go
@@ -420,7 +420,7 @@ func (w *Waf) SetDebugLogPath(path string) error {
 	}
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		w.Logger.Error("error opening file: %v", err)
+		w.Logger.Error("error opening file: %s", err.Error())
 	}
 	w.Logger.SetOutput(f)
 	return nil
@@ -434,7 +434,7 @@ func NewWaf() *Waf {
 	}
 	logWriter, err := loggers.GetLogWriter("serial")
 	if err != nil {
-		logger.Error("error creating serial log writer: %v", err)
+		logger.Error("error creating serial log writer: %s", err.Error())
 	}
 	waf := &Waf{
 		ArgumentSeparator:        "&",


### PR DESCRIPTION
As reflection (using %v interpolator) isn't fully supported, hence we stick to string (%s) when possible.

**Note:** not every usage of `%v` has been replaced as some require other treatment to become string (e.g. `[]error` or `[]string`)

Ping @anuraaga 

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: