### PR TITLE
Remove err return from NewParser

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -30,7 +30,7 @@ func main() {
 
 func setupCoraza() error {
 	waf = coraza.NewWaf()
-	seclang, _ := seclang.NewParser(waf)
+	seclang := seclang.NewParser(waf)
 	if err := seclang.FromString(`
 		# This is a comment
 		SecRequestBodyAccess On

--- a/seclang/body_test.go
+++ b/seclang/body_test.go
@@ -32,7 +32,7 @@ func TestRequestBodyAccessOff(t *testing.T) {
 
 func TestRequestBodyAccessOn(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	if err := parser.FromString(`
 	SecRequestBodyAccess On
 	`); err != nil {

--- a/seclang/directives_log_test.go
+++ b/seclang/directives_log_test.go
@@ -25,7 +25,7 @@ import (
 func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 	waf := coraza.NewWaf()
 	auditpath := t.TempDir()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	if err := parser.FromString(fmt.Sprintf(`
 	SecAuditLog %s
 	SecAuditLogFormat json
@@ -70,7 +70,7 @@ func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 func TestDebugDirectives(t *testing.T) {
 	waf := coraza.NewWaf()
 	tmp := filepath.Join(t.TempDir(), "tmp.log")
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := directiveSecDebugLog(&DirectiveOptions{
 		Waf:  waf,
 		Opts: tmp,

--- a/seclang/directives_test.go
+++ b/seclang/directives_test.go
@@ -24,7 +24,7 @@ func Test_NonImplementedDirective(t *testing.T) {
 		`SecHashEngine On`,
 	}
 	w := coraza.NewWaf()
-	p, _ := NewParser(w)
+	p := NewParser(w)
 	for _, rule := range rules {
 		err := p.FromString(rule)
 		if err != nil {
@@ -35,7 +35,7 @@ func Test_NonImplementedDirective(t *testing.T) {
 
 func Test_directive(t *testing.T) {
 	w := coraza.NewWaf()
-	p, _ := NewParser(w)
+	p := NewParser(w)
 	if err := p.FromString("SecWebAppId test123"); err != nil {
 		t.Error("failed to set parser from string")
 	}
@@ -158,7 +158,7 @@ func TestSecRuleUpdateTargetBy(t *testing.T) {
 
 func TestInvalidBooleanForDirectives(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString("SecIgnoreRuleCompilationErrors sure"); err == nil {
 		t.Error("failed to error on invalid boolean")
 	}
@@ -171,12 +171,12 @@ func TestInvalidRulesWithIgnoredErrors(t *testing.T) {
 	SecRule REQUEST_URI "@rx ^/test" "id:181,tag:repeated-id"
 	`
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString("secignorerulecompilationerrors On\n" + directives); err != nil {
 		t.Error(err)
 	}
 	waf = coraza.NewWaf()
-	p, _ = NewParser(waf)
+	p = NewParser(waf)
 	if err := p.FromString(directives); err == nil {
 		t.Error("failed to error on invalid rule")
 	}
@@ -184,7 +184,7 @@ func TestInvalidRulesWithIgnoredErrors(t *testing.T) {
 
 func TestSecDataset(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString("" +
 		"SecDataset test `\n123\n456\n`\n"); err != nil {
 		t.Error(err)

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -168,10 +168,7 @@ func (p *Parser) SetCurrentDir(dir string) {
 // NewParser creates a new parser from a WAF instance
 // Rules and settings will be inserted into the WAF
 // rule container (RuleGroup).
-func NewParser(waf *coraza.Waf) (*Parser, error) {
-	if waf == nil {
-		return nil, errors.New("must use a valid waf instance")
-	}
+func NewParser(waf *coraza.Waf) *Parser {
 	p := &Parser{
 		options: &DirectiveOptions{
 			Waf:      waf,
@@ -179,5 +176,5 @@ func NewParser(waf *coraza.Waf) (*Parser, error) {
 			Datasets: make(map[string][]string),
 		},
 	}
-	return p, nil
+	return p
 }

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestInterruption(t *testing.T) {
 	waf := engine.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString(`SecAction "id:1,deny,log,phase:1"`); err != nil {
 		t.Error("Could not create from string")
 	}
@@ -29,7 +29,7 @@ func TestInterruption(t *testing.T) {
 
 func TestDirectivesCaseInsensitive(t *testing.T) {
 	waf := engine.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString("seCwEbAppid 15")
 	if err != nil {
 		t.Error(err)
@@ -38,7 +38,7 @@ func TestDirectivesCaseInsensitive(t *testing.T) {
 
 func TestDefaultConfigurationFile(t *testing.T) {
 	waf := engine.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromFile("../coraza.conf-recommended")
 	if err != nil {
 		t.Error(err)
@@ -47,7 +47,7 @@ func TestDefaultConfigurationFile(t *testing.T) {
 
 func TestHardcodedIncludeDirective(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString("Include ../coraza.conf-recommended"); err != nil {
 		t.Error(err)
 	}
@@ -61,7 +61,7 @@ func TestHardcodedIncludeDirective(t *testing.T) {
 
 func TestHardcodedSubIncludeDirective(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString("Include ./testdata/includes/parent.conf"); err != nil {
 		t.Error(err)
 	}
@@ -72,7 +72,7 @@ func TestHardcodedSubIncludeDirective(t *testing.T) {
 
 func TestHardcodedSubIncludeDirectiveAbsolutePath(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	currentDir, _ := filepath.Abs("./")
 	ruleFile := filepath.Join(currentDir, "./testdata/includes/parent.conf")
 	if err := p.FromString("Include " + ruleFile); err != nil {
@@ -85,7 +85,7 @@ func TestHardcodedSubIncludeDirectiveAbsolutePath(t *testing.T) {
 
 func TestHardcodedIncludeDirectiveDDOS(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	tmpFile, err := os.Create(filepath.Join(t.TempDir(), "rand.conf"))
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +105,7 @@ func TestHardcodedIncludeDirectiveDDOS(t *testing.T) {
 
 func TestHardcodedIncludeDirectiveDDOS2(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	tmpFile, err := os.Create(filepath.Join(t.TempDir(), "rand1.conf"))
 	if err != nil {
 		t.Fatal(err)

--- a/seclang/rule_parser_test.go
+++ b/seclang/rule_parser_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInvalidRule(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 
 	err := p.FromString("")
 	if err != nil {
@@ -27,7 +27,7 @@ func TestInvalidRule(t *testing.T) {
 
 func TestVariables(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 
 	// single variable with key
 	err := p.FromString(`SecRule REQUEST_HEADERS:test "" "id:1"`)
@@ -60,7 +60,7 @@ func TestVariables(t *testing.T) {
 
 func TestVariableCases(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString(`SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|!REQUEST_COOKIES:/_pk_ref/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* "" "id:7,pass"`)
 	if err != nil {
 		t.Error(err)
@@ -69,7 +69,7 @@ func TestVariableCases(t *testing.T) {
 
 func TestSecRuleInlineVariableNegation(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString(`
 		SecRule REQUEST_URI|!REQUEST_COOKIES "abc" "id:7,phase:2"
 	`)
@@ -94,7 +94,7 @@ func TestSecRuleInlineVariableNegation(t *testing.T) {
 
 func TestSecRuleUpdateTargetVariableNegation(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString(`
 		SecRule REQUEST_URI|REQUEST_COOKIES "abc" "id:7,phase:2"
 		SecRuleUpdateTargetById 7 "!REQUEST_HEADERS:/xyz/"
@@ -125,7 +125,7 @@ func TestSecRuleUpdateTargetVariableNegation(t *testing.T) {
 
 func TestErrorLine(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString("SecAction \"id:1\"\n#test\nSomefaulty")
 	if err == nil {
 		t.Error("expected error")
@@ -137,7 +137,7 @@ func TestErrorLine(t *testing.T) {
 
 func TestDefaultActionsForPhase2(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	err := p.FromString(`
 	SecAction "id:1,phase:2"
 	SecAction "id:2,phase:1"`)

--- a/seclang/rules_http_test.go
+++ b/seclang/rules_http_test.go
@@ -23,7 +23,7 @@ import (
 // from issue https://github.com/corazawaf/coraza/issues/159 @zpeasystart
 func TestDirectiveSecAuditLog(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString(`
 	SecRule REQUEST_FILENAME "@unconditionalMatch" "id:100, phase:2, t:none, log, setvar:'tx.count=+1',chain"
 	SecRule ARGS:username "@unconditionalMatch" "t:none, setvar:'tx.count=+2',chain"

--- a/seclang/rules_test.go
+++ b/seclang/rules_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRuleMatch(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRuleEngine On
 		SecDefaultAction "phase:1,deny,status:403,log"
@@ -43,7 +43,7 @@ func TestRuleMatch(t *testing.T) {
 
 func TestRuleMatchWithRegex(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRuleEngine On
 		SecDefaultAction "phase:1,deny,status:403,log"
@@ -67,7 +67,7 @@ func TestRuleMatchWithRegex(t *testing.T) {
 
 func TestSecMarkers(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRuleEngine On		
 		SecAction "phase:1, id:1,log,skipAfter:SoMe_TEST"
@@ -102,7 +102,7 @@ func TestSecMarkers(t *testing.T) {
 
 func TestSecAuditLogs(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecAuditEngine On
 		SecAction "id:4482,log,auditlog, msg:'test'"
@@ -135,7 +135,7 @@ func TestRuleLogging(t *testing.T) {
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRule ARGS ".*" "phase:1, id:1,capture,log,setvar:'tx.arg_%{tx.0}=%{tx.0}'"
 		SecAction "id:2,phase:1,log,setvar:'tx.test=ok'"
@@ -168,7 +168,7 @@ func TestRuleLogging(t *testing.T) {
 
 func TestRuleChains(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRule ARGS "123" "id:1,phase:1,log,chain"
 			SecRule &ARGS "@gt 0" "chain"
@@ -196,7 +196,7 @@ func TestTagsAreNotPrintedTwice(t *testing.T) {
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRule ARGS ".*" "phase:1, id:1,log,tag:'some1',tag:'some2'"
 	`)
@@ -228,7 +228,7 @@ func TestStatusFromInterruptions(t *testing.T) {
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRule ARGS "123" "phase:1, id:1,log,deny,status:500"
 	`)
@@ -248,7 +248,7 @@ func TestStatusFromInterruptions(t *testing.T) {
 
 func TestChainWithUnconditionalMatch(t *testing.T) {
 	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
+	p := NewParser(waf)
 	if err := p.FromString(`
 	SecAction "id:7, pass, phase:1, log, chain, skip:2"
     SecRule REMOTE_ADDR "@unconditionalMatch" ""
@@ -266,7 +266,7 @@ func TestLogsAreNotPrintedManyTimes(t *testing.T) {
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 		SecRule ARGS|REQUEST_HEADERS|!ARGS:test1 ".*" "phase:1, id:1,log,tag:'some1',tag:'some2'"
 	`)
@@ -290,7 +290,7 @@ func TestLogsAreNotPrintedManyTimes(t *testing.T) {
 
 func TestSampleRxRule(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`
 	SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" "phase:1,id:1,log,deny,status:403,chain"
 	SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$"`)
@@ -308,7 +308,7 @@ func TestSampleRxRule(t *testing.T) {
 func TestTXIssue147(t *testing.T) {
 	// https://github.com/corazawaf/coraza/issues/147
 	waf := coraza.NewWaf()
-	parser, _ := NewParser(waf)
+	parser := NewParser(waf)
 	err := parser.FromString(`SecRule RESPONSE_BODY "@rx ^#!\s?/" "id:950140,phase:4,log,deny,status:403"`)
 	if err != nil {
 		t.Error(err.Error())
@@ -347,13 +347,9 @@ func TestTXIssue147(t *testing.T) {
 func TestIssue176(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule REQUEST_COOKIES:sessionId "test" "id:1,phase:1,deny,log,msg:'test rule',logdata:'Matched %{MATCHED_VAR_NAME}'"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -427,13 +423,9 @@ func TestRxCapture(t *testing.T) {
             "t:lowercase,\
             ctl:forceRequestBodyVariable=On,\
             setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -472,13 +464,9 @@ func Test941310(t *testing.T) {
         ctl:auditLogParts=+E,\
         setvar:'tx.xss_score=+%{tx.critical_anomaly_score}',\
         setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -498,13 +486,9 @@ func Test941310(t *testing.T) {
 func TestArgumentNamesCaseSensitive(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule ARGS_NAMES "Test1" "id:3, phase:2, log, deny"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -545,13 +529,9 @@ func TestArgumentNamesCaseSensitive(t *testing.T) {
 func TestArgumentsCaseSensitive(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule ARGS:Test1 "Xyz" "id:3, phase:2, log, deny"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -611,13 +591,9 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 func TestCookiesCaseSensitive(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule REQUEST_COOKIES:Test1 "Xyz" "id:3, phase:2, log, deny"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -677,13 +653,9 @@ func TestCookiesCaseSensitive(t *testing.T) {
 func TestHeadersCaseSensitive(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule REQUEST_HEADERS:Test1 "Xyz" "id:3, phase:2, log, deny"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -743,13 +715,9 @@ func TestHeadersCaseSensitive(t *testing.T) {
 func TestParameterPollution(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule Args:TESt1 "Xyz" "id:3, phase:2, log, pass"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -798,13 +766,9 @@ func TestParameterPollution(t *testing.T) {
 func TestURIQueryParamCaseSensitive(t *testing.T) {
 	waf := coraza.NewWaf()
 	rules := `SecRule ARGS:Test1 "@contains SQLI" "id:3, phase:2, log, pass"`
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Error()
 		return
@@ -946,13 +910,9 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "
     setvar:'tx.lfi_score=+%{tx.critical_anomaly_score}'"
 `
 
-	parser, err := NewParser(waf)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	parser := NewParser(waf)
 
-	err = parser.FromString(rules)
+	err := parser.FromString(rules)
 	if err != nil {
 		t.Fatal(err)
 		return

--- a/testing/auditlog_test.go
+++ b/testing/auditlog_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAuditLogMessages(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := seclang.NewParser(waf)
+	parser := seclang.NewParser(waf)
 	// generate a random tmp file
 	file, err := os.Create(filepath.Join(t.TempDir(), "tmp.log"))
 	if err != nil {
@@ -71,7 +71,7 @@ func TestAuditLogMessages(t *testing.T) {
 
 func TestAuditLogRelevantOnly(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := seclang.NewParser(waf)
+	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
 		SecAuditEngine RelevantOnly
@@ -108,7 +108,7 @@ func TestAuditLogRelevantOnly(t *testing.T) {
 
 func TestAuditLogRelevantOnlyOk(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := seclang.NewParser(waf)
+	parser := seclang.NewParser(waf)
 	// generate a random tmp file
 	file, err := os.Create(filepath.Join(t.TempDir(), "tmp.log"))
 	if err != nil {
@@ -145,7 +145,7 @@ func TestAuditLogRelevantOnlyOk(t *testing.T) {
 
 func TestAuditLogRelevantOnlyNoAuditlog(t *testing.T) {
 	waf := coraza.NewWaf()
-	parser, _ := seclang.NewParser(waf)
+	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
 		SecAuditEngine RelevantOnly

--- a/testing/coraza_test.go
+++ b/testing/coraza_test.go
@@ -64,7 +64,7 @@ func testList(p *profile.Profile, waf *coraza.Waf) ([]*Test, error) {
 			w := waf
 			if w == nil || p.Rules != "" {
 				w = coraza.NewWaf()
-				parser, _ := seclang.NewParser(w)
+				parser := seclang.NewParser(w)
 				parser.SetCurrentDir("./testdata")
 				if err := parser.FromString(p.Rules); err != nil {
 					return nil, err

--- a/testing/coreruleset_test.go
+++ b/testing/coreruleset_test.go
@@ -50,7 +50,7 @@ func BenchmarkCRSCompilation(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		waf := coraza.NewWaf()
-		parser, _ := seclang.NewParser(waf)
+		parser := seclang.NewParser(waf)
 		for _, f := range files {
 			if err := parser.FromFile(f); err != nil {
 				b.Error(err)
@@ -129,7 +129,7 @@ func crsWAF() (*coraza.Waf, error) {
 		path.Join(crspath, "rules/", "*.conf"),
 	}
 	waf := coraza.NewWaf()
-	parser, _ := seclang.NewParser(waf)
+	parser := seclang.NewParser(waf)
 	for _, f := range files {
 		if err := parser.FromFile(f); err != nil {
 			return nil, err


### PR DESCRIPTION
I don't think it's common to have an err result just for a nil check, but it makes the `NewParser` method quite a bit harder to use. All the logic that can generate errors is in parsing methods, this just creates a default struct.

Note that if going with #371, this would be superceded as we would want to keep all configuration in the same place at the entrypoint to the library, and this type would probably go away.