### PR TITLE
chore: organize imports in 3 blocks: stdlib, 3rd party, coraza

### DIFF
--- a/actions/append.go
+++ b/actions/append.go
@@ -15,9 +15,10 @@
 package actions
 
 import (
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
-	"go.uber.org/zap"
 )
 
 type appendFn struct {

--- a/actions/ctl.go
+++ b/actions/ctl.go
@@ -20,11 +20,12 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
 	utils "github.com/corazawaf/coraza/v2/utils/strings"
-	"go.uber.org/zap"
 )
 
 type ctlFunctionType int

--- a/actions/setenv.go
+++ b/actions/setenv.go
@@ -19,10 +19,11 @@ import (
 	"os"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
-	"go.uber.org/zap"
 )
 
 type setenvFn struct {

--- a/actions/setvar.go
+++ b/actions/setvar.go
@@ -19,10 +19,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
-	"go.uber.org/zap"
 )
 
 type setvarFn struct {

--- a/actions/skipafter.go
+++ b/actions/skipafter.go
@@ -17,9 +17,10 @@ package actions
 import (
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
-	"go.uber.org/zap"
 )
 
 type skipafterFn struct {

--- a/magefile.go
+++ b/magefile.go
@@ -49,7 +49,11 @@ func Format() error {
 		"-ignore", "examples/**", "."); err != nil {
 		return err
 	}
-	return sh.RunV("go", "run", fmt.Sprintf("github.com/rinchsan/gosimports/cmd/gosimports@%s", gosImportsVer), "-w", ".")
+	return sh.RunV("go", "run", fmt.Sprintf("github.com/rinchsan/gosimports/cmd/gosimports@%s", gosImportsVer),
+		"-w",
+		"-local",
+		"github.com/corazawaf/coraza",
+		".")
 }
 
 // Lint verifies code quality.

--- a/operators/detect_sqli.go
+++ b/operators/detect_sqli.go
@@ -15,8 +15,9 @@
 package operators
 
 import (
-	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/libinjection-go"
+
+	"github.com/corazawaf/coraza/v2"
 )
 
 type detectSQLi struct {

--- a/operators/detect_xss.go
+++ b/operators/detect_xss.go
@@ -15,8 +15,9 @@
 package operators
 
 import (
-	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/libinjection-go"
+
+	"github.com/corazawaf/coraza/v2"
 )
 
 type detectXSS struct {

--- a/operators/pm.go
+++ b/operators/pm.go
@@ -17,8 +17,9 @@ package operators
 import (
 	"strings"
 
-	"github.com/corazawaf/coraza/v2"
 	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+
+	"github.com/corazawaf/coraza/v2"
 )
 
 // TODO according to coraza researchs, re2 matching is faster than ahocorasick

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -18,8 +18,9 @@ import (
 	"bufio"
 	"strings"
 
-	"github.com/corazawaf/coraza/v2"
 	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+
+	"github.com/corazawaf/coraza/v2"
 )
 
 type pmFromFile struct {

--- a/operators/rbl_test.go
+++ b/operators/rbl_test.go
@@ -17,9 +17,10 @@ package operators
 import (
 	"testing"
 
+	"github.com/foxcpp/go-mockdns"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types/variables"
-	"github.com/foxcpp/go-mockdns"
 )
 
 type testLogger struct{ t *testing.T }

--- a/rule.go
+++ b/rule.go
@@ -20,9 +20,10 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
-	"go.uber.org/zap"
 )
 
 // RuleTransformation is used to create transformation plugins

--- a/rulegroup.go
+++ b/rulegroup.go
@@ -19,10 +19,11 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
 	"github.com/corazawaf/coraza/v2/utils/strings"
-	"go.uber.org/zap"
 )
 
 // RuleGroup is a collection of rules

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -22,10 +22,11 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/loggers"
 	"github.com/corazawaf/coraza/v2/types"
-	"go.uber.org/zap"
 )
 
 // DirectiveOptions contains the parsed options for a directive

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -23,9 +23,10 @@ import (
 	"regexp"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/types"
-	"go.uber.org/zap"
 )
 
 // maxIncludeRecursion is used to avoid DDOS by including files that include

--- a/testing/profile.go
+++ b/testing/profile.go
@@ -17,9 +17,10 @@ package testing
 import (
 	"os"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/corazawaf/coraza/v2"
 	"github.com/corazawaf/coraza/v2/seclang"
-	"gopkg.in/yaml.v2"
 )
 
 // Profile represents a test profile

--- a/transaction.go
+++ b/transaction.go
@@ -26,13 +26,14 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/corazawaf/coraza/v2/bodyprocessors"
 	"github.com/corazawaf/coraza/v2/loggers"
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
 	utils "github.com/corazawaf/coraza/v2/utils/strings"
 	url2 "github.com/corazawaf/coraza/v2/utils/url"
-	"go.uber.org/zap"
 )
 
 // Transaction is created from a WAF instance to handle web requests and responses,

--- a/transformations/base64decode_test.go
+++ b/transformations/base64decode_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Juan Pablo Tosso
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package transformations
 
 import "testing"

--- a/transformations/url_encode_test.go
+++ b/transformations/url_encode_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Juan Pablo Tosso
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package transformations
 
 import "testing"

--- a/waf.go
+++ b/waf.go
@@ -24,12 +24,13 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/corazawaf/coraza/v2/loggers"
 	"github.com/corazawaf/coraza/v2/types"
 	"github.com/corazawaf/coraza/v2/types/variables"
 	utils "github.com/corazawaf/coraza/v2/utils/strings"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // Initializing pool for transactions


### PR DESCRIPTION
Update the `format` build target to organize imports in 3 blocks: stdlib, 3rd party dependencies, and current project dependencies. This is a common practice and makes it easier to see, for any given file, what external dependencies are being used there.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Note**: _that go.mod and go.sum can only be modified for tested dependency updates or justified new features._

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v2sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).

Thanks for your PR :heart: