### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @corazawaf/core-developers


### PR DESCRIPTION
This makes sure the Reviewers section on PRs is populated. While I think we generally watch the repos, it's good to populate that especially for other contributors