### PR TITLE
Optimize random string generation

### DIFF
--- a/loggers/formats.go
+++ b/loggers/formats.go
@@ -92,7 +92,7 @@ func legacyJSONFormatter(al *AuditLog) ([]byte, error) {
 }
 
 func nativeFormatter(al *AuditLog) ([]byte, error) {
-	boundary := utils.SafeRandom(10)
+	boundary := utils.RandomString(10)
 	parts := map[byte]string{}
 	// [27/Jul/2016:05:46:16 +0200] V5guiH8AAQEAADTeJ2wAAAAK 192.168.3.1 50084 192.168.3.111 80
 	parts['A'] = fmt.Sprintf("[%s] %s %s %d %s %d", al.Transaction.Timestamp, al.Transaction.ID,

--- a/seclang/directives_log_test.go
+++ b/seclang/directives_log_test.go
@@ -36,7 +36,7 @@ func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 	`, filepath.Join(auditpath, "audit.log"), auditpath)); err != nil {
 		t.Error(err)
 	}
-	id := utils.SafeRandom(10)
+	id := utils.RandomString(10)
 	if waf.AuditLogWriter == nil {
 		t.Error("Invalid audit logger (nil)")
 		return

--- a/testing/coreruleset_test.go
+++ b/testing/coreruleset_test.go
@@ -95,6 +95,7 @@ func BenchmarkCRSSimplePOST(b *testing.B) {
 	if err != nil {
 		b.Error(err)
 	}
+	b.ResetTimer() // only benchmark execution, not compilation
 	for i := 0; i < b.N; i++ {
 		tx := waf.NewTransaction(context.Background())
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)

--- a/waf.go
+++ b/waf.go
@@ -143,7 +143,7 @@ type WAF struct {
 // NewTransaction Creates a new initialized transaction for this WAF instance
 func (w *WAF) NewTransaction(ctx context.Context) *Transaction {
 	tx := transactionPool.Get().(*Transaction)
-	tx.ID = utils.SafeRandom(19)
+	tx.ID = utils.RandomString(19)
 	tx.MatchedRules = []types.MatchedRule{}
 	tx.Interruption = nil
 	tx.Collections = [types.VariablesCount]collection.Collection{}


### PR DESCRIPTION
Currently, random string generation uses cryptographic random which is very slow. Random strings are used for identifiers and don't seem to have any cryptographic significance (please confirm!) so this removes that, and also applies some smaller optimizations.

It stood out in profiles within non-alloc, unfortunately the numbers are still quite dominated by allocator / GC so reducing garbage will be an ongoing effort.

After
```
Preparing CRS...
CRS PATH: /var/folders/vx/38td0k79201f9zn_myzbqx_40000gn/T/crs1403234494
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/testing
BenchmarkCRSSimplePOST
BenchmarkCRSSimplePOST-10    	     541	   2162702 ns/op
PASS
```

Before
```
Preparing CRS...
CRS PATH: /var/folders/vx/38td0k79201f9zn_myzbqx_40000gn/T/crs2813219423
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/testing
BenchmarkCRSSimplePOST
BenchmarkCRSSimplePOST-10    	     548	   2295711 ns/op
PASS
```