### PR TITLE
add rule and waf clone

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -458,6 +458,17 @@ func (r *Rule) executeTransformations(value string) (string, []error) {
 	return value, errs
 }
 
+func (r *Rule) Clone() *Rule {
+	clone := &Rule{
+		RuleMetadata:    r.RuleMetadata,
+		ParentID:        r.ParentID,
+		Chain:           r.Chain,
+		Msg:             r.Msg,
+		transformations: r.transformations,
+	}
+	return clone
+}
+
 // NewRule returns a new initialized rule
 func NewRule() *Rule {
 	return &Rule{

--- a/waf.go
+++ b/waf.go
@@ -428,6 +428,32 @@ func (w *WAF) SetDebugLogPath(path string) error {
 	return nil
 }
 
+// Clone creates a deepy copy of the WAF
+// It include deep copies of all rules and settings
+func (w *WAF) Clone() *WAF {
+	waf := &WAF{
+		ArgumentSeparator:        w.ArgumentSeparator,
+		AuditLogWriter:           w.AuditLogWriter,
+		AuditEngine:              w.AuditEngine,
+		AuditLogParts:            types.AuditLogParts(w.AuditLogParts),
+		RequestBodyInMemoryLimit: w.RequestBodyInMemoryLimit,
+		RequestBodyLimit:         w.RequestBodyLimit,
+		ResponseBodyMimeTypes:    append([]string{}, w.ResponseBodyMimeTypes...),
+		ResponseBodyLimit:        w.ResponseBodyLimit,
+		ResponseBodyAccess:       w.ResponseBodyAccess,
+		RuleEngine:               w.RuleEngine,
+		Rules:                    NewRuleGroup(),
+		TmpDir:                   w.TmpDir,
+		AuditLogRelevantStatus:   regexp.MustCompile(w.AuditLogRelevantStatus.String()),
+		RequestBodyAccess:        w.RequestBodyAccess,
+		Logger:                   w.Logger,
+	}
+	for _, rule := range w.Rules.rules {
+		waf.Rules.Add(rule.Clone())
+	}
+	return waf
+}
+
 // NewWAF creates a new WAF instance with default variables
 func NewWAF() *WAF {
 	logger := &stdDebugLogger{


### PR DESCRIPTION
Web servers like Apache and NGINX merges contexts to handle cases like `Server` -> `Location`

For example:
```nginx
    server {
        listen       8000;
        coraza on;
        coraza_rules '
        SecRuleEngine On
        ';
        location / {
            root   html;
            index  index.html index.htm;
        }
    }
```

The previous NGINX configuration will create a new `*WAF` for server and another `*WAF` for location.

To make it work we must "merge" the context by cloning the server WAF and adding the location directives.

It should look something like this:

```go
func NewWafFromMerge(orig *WAF, directives string)  (*WAF, error) {
  waf := orig.Clone()
  parser := seclang.NewParser(waf)
  return  parser.FromString(directives)
}
```

New directives should apply for the original WAF

### A cloned WAF must only contain new pointers, nothing pointing to the old WAF. (UNLESS DATA IS IMMUTABLE)