### PR TITLE
Document that RandomString is pseudorandom

### DIFF
--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -18,8 +18,8 @@ const (
 
 var src = rand.NewSource(time.Now().UnixNano())
 
-// RandomString returns a random string of length n
-// It is safe to use this function in concurrent environments
+// RandomString returns a pseudorandom string of length n.
+// It is safe to use this function in concurrent environments.
 // Implementation from https://stackoverflow.com/a/31832326
 func RandomString(n int) string {
 	sb := strings.Builder{}


### PR DESCRIPTION
I went with adding a doc instead of renaming but if others feel strongly could rename. In my experience, which may include too old languages ;), pseudorandom tends to be the default, so e.g. the standard library provides a random and a secure random or crypto random - so I've never assumed the word random to assume cryptographically secure, and have had the opposite reaction of often finding it to be using cryptographically secure when just called random. This may just be me though :) But especially for an internal function, the shorter name is another pro I guess.