### PR TITLE
fix: improves mage lint user experience.

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -52,6 +52,9 @@ func Lint() error {
 		return err
 	}
 
+	sh.Run("git", "stash", "-k", "-u") // stash unstagged changes so they don't interfere with git diff below
+	defer sh.Run("git", "stash", "pop")
+
 	mg.SerialDeps(Format)
 
 	if sh.Run("git", "diff", "--exit-code") != nil {


### PR DESCRIPTION
Currently, lint was running golang-ci lint a then running the format command to later inspect the diff. If a user had unstagged files, lint would fail anyways because git diff would list those unstaged files which is akward because the diff was already there and wasn't originated by the format command instead. In this change we stash unstagged changes, run diff and then unstash them.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: