### PR TITLE
chore: avoids too many open files error when running CRS.

### DIFF
--- a/testing/coreruleset_test.go
+++ b/testing/coreruleset_test.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // These benchmarks don't currently compile with TinyGo
+//go:build !tinygo
+// +build !tinygo
 
 package testing
 


### PR DESCRIPTION
Mainly removed the usage of `defer` in a loop.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CaONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: