### PR TITLE
Use iter for pm operator instead of always finding all when capturing

### DIFF
--- a/operators/pm_from_dataset.go
+++ b/operators/pm_from_dataset.go
@@ -36,18 +36,7 @@ func (o *pmFromDataset) Init(options coraza.RuleOperatorOptions) error {
 }
 
 func (o *pmFromDataset) Evaluate(tx *coraza.Transaction, value string) bool {
-	if tx.Capture {
-		matches := o.matcher.FindAll(value)
-		for i, match := range matches {
-			if i == 10 {
-				return true
-			}
-			tx.CaptureField(i, value[match.Start():match.End()])
-		}
-		return len(matches) > 0
-	}
-	iter := o.matcher.Iter(value)
-	return iter.Next() != nil
+	return pmEvaluate(o.matcher, tx, value)
 }
 
 var _ coraza.RuleOperator = (*pmFromDataset)(nil)

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -51,18 +51,7 @@ func (o *pmFromFile) Init(options coraza.RuleOperatorOptions) error {
 }
 
 func (o *pmFromFile) Evaluate(tx *coraza.Transaction, value string) bool {
-	if tx.Capture {
-		matches := o.matcher.FindAll(value)
-		for i, match := range matches {
-			if i == 10 {
-				return true
-			}
-			tx.CaptureField(i, value[match.Start():match.End()])
-		}
-		return len(matches) > 0
-	}
-	iter := o.matcher.Iter(value)
-	return iter.Next() != nil
+	return pmEvaluate(o.matcher, tx, value)
 }
 
 var _ coraza.RuleOperator = (*pmFromFile)(nil)


### PR DESCRIPTION
@jcchavezs Mostly to validate against https://github.com/petar-dambovaliev/aho-corasick/pull/9/files. Since this doesn't allocate the result array, I guess even if `FindN` was provided we would stick to this pattern. If `FindAllFunc` were added we would use it though