### PR TITLE
Make RandomString concurrent-safe

### DIFF
--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -6,6 +6,7 @@ package strings
 import (
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -17,6 +18,7 @@ const (
 )
 
 var src = rand.NewSource(time.Now().UnixNano())
+var mu sync.Mutex
 
 // RandomString returns a pseudorandom string of length n.
 // It is safe to use this function in concurrent environments.
@@ -24,6 +26,8 @@ var src = rand.NewSource(time.Now().UnixNano())
 func RandomString(n int) string {
 	sb := strings.Builder{}
 	sb.Grow(n)
+
+	mu.Lock()
 	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
 	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
 		if remain == 0 {
@@ -36,6 +40,7 @@ func RandomString(n int) string {
 		cache >>= letterIdxBits
 		remain--
 	}
+	mu.Unlock()
 
 	return sb.String()
 }

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package strings
 
 import "testing"

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -7,7 +7,7 @@ import "testing"
 
 func TestRandomStringConcurrency(t *testing.T) {
 	// Make sure random strings don't crash under high concurrency.
-	for i := 0; i < 100000; i++ {
-		go RandomString(100)
+	for i := 0; i < 5000; i++ {
+		go RandomString(10000)
 	}
 }

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -1,0 +1,10 @@
+package strings
+
+import "testing"
+
+func TestRandomStringConcurrency(t *testing.T) {
+	// Make sure random strings don't crash under high concurrency.
+	for i := 0; i < 100000; i++ {
+		go RandomString(100)
+	}
+}

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -1,6 +1,9 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !tinygo
+// +build !tinygo
+
 package strings
 
 import "testing"


### PR DESCRIPTION
Always forget that rand objects aren't threadsafe

Fixes #429