### PR TITLE
Fix parser backticks 

### DIFF
--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -117,7 +117,7 @@ func (p *Parser) FromString(data string) error {
 			linebuffer.Reset()
 		}
 	}
-	if inBackticks == true {
+	if inBackticks {
 		return errors.New("backticks left open")
 	}
 	return nil

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -87,7 +87,7 @@ func (p *Parser) FromString(data string) error {
 		}
 
 		// Looks for a line like "SecDataset test `". The backtick starts an action list.
-		// A line starting with # is a comment, therefore must be able to start an action list.
+		// A line starting with # is a comment, therefore it must NOT be able to start an action list.
 		// The list will be closed only with a single "`" line.
 		if !inBackticks && line[0] != '#' && line[lineLen-1] == '`' {
 			inBackticks = true

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -85,11 +85,14 @@ func (p *Parser) FromString(data string) error {
 		if lineLen == 0 {
 			continue
 		}
+		// As a first step, the parser has to ignore all the comments (lines starting with "#") in any circumstances.
+		if line[0] == '#' {
+			continue
+		}
 
 		// Looks for a line like "SecDataset test `". The backtick starts an action list.
-		// A line starting with # is a comment, therefore it must NOT be able to start an action list.
 		// The list will be closed only with a single "`" line.
-		if !inBackticks && line[0] != '#' && line[lineLen-1] == '`' {
+		if !inBackticks && line[lineLen-1] == '`' {
 			inBackticks = true
 		} else if inBackticks && line[0] == '`' {
 			inBackticks = false
@@ -98,10 +101,6 @@ func (p *Parser) FromString(data string) error {
 		if inBackticks {
 			linebuffer.WriteString(line)
 			linebuffer.WriteString("\n")
-			continue
-		}
-
-		if line[0] == '#' {
 			continue
 		}
 

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -40,6 +40,19 @@ func TestDirectivesCaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestCommentsWithBackticks(t *testing.T) {
+	waf := coraza.NewWAF()
+	p := NewParser(waf)
+	err := p.FromString(
+		"# This comment has a trailing backtick:`" +
+			`
+		SecAction "id:1,deny,log,phase:1"
+		`)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestDefaultConfigurationFile(t *testing.T) {
 	waf := coraza.NewWAF()
 	p := NewParser(waf)

--- a/seclang/parser_test.go
+++ b/seclang/parser_test.go
@@ -44,11 +44,19 @@ func TestCommentsWithBackticks(t *testing.T) {
 	waf := coraza.NewWAF()
 	p := NewParser(waf)
 	err := p.FromString(
-		"# This comment has a trailing backtick:`" +
-			`
+		"# This comment has a trailing backtick `here`" + `
 		SecAction "id:1,deny,log,phase:1"
 		`)
 	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestErrorWithBackticks(t *testing.T) {
+	waf := coraza.NewWAF()
+	p := NewParser(waf)
+	err := p.FromString("SecDataset test `")
+	if err == nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/corazawaf/coraza/issues/432.
This PR basically evolves the conversation that we had here: https://github.com/corazawaf/coraza/pull/412#discussion_r966533852.
The `inQuotes` (now `inBackticks`) logic comes before considering lines that are comments. Therefore a trailing backtick in a comment is considered a valid backtick.
- One solution I see is the one implemented in the PR, explicitly ignoring a line that starts with `#` when looking for backticks. 
- An alternative to don't complicate an already quite tricky line would be just adding the logic that skips comment:
```
		if line[0] == '#' {
			continue
		}
		
		if !inBackticks && line[lineLen-1] == '`' {
			inBackticks = true
		...
```
before the backticks logic. This implies that all the lines starting with `#` will be ignored, reducing a bit the blackhole power of the backticks (Commented lines would now be skipped already from this point instead of inside the [directiveSecDataset](https://github.com/corazawaf/coraza/blob/c7ec8112b8a94860a27663d3a1908a4fdc1f8cb8/seclang/directives.go#L487)). Are there any real reason to do not evaluate the comments as soon as possible?
		

