### PR TITLE
Remove unescaping in string handling and use proper unicode regex syntax.

### DIFF
--- a/actions/msg.go
+++ b/actions/msg.go
@@ -13,7 +13,7 @@ type msgFn struct {
 }
 
 func (a *msgFn) Init(r *coraza.Rule, data string) error {
-	data = utils.MaybeUnquote(data)
+	data = utils.MaybeRemoveQuotes(data)
 	msg, err := coraza.NewMacro(data)
 	if err != nil {
 		return err

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -5,7 +5,6 @@ package strings
 
 import (
 	"math/rand"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -69,46 +68,25 @@ func X2c(what string) byte {
 	return digit
 }
 
-// MaybeUnquote unquotes a string if it is quoted, or returns it as-is if it isn't.
-func MaybeUnquote(s string) string {
+// MaybeRemoveQuotes removes the quotes from the string if it begins and ends with them.
+func MaybeRemoveQuotes(s string) string {
 	if len(s) < 2 {
 		return s
 	}
 
-	var quote byte
 	if s[0] == '"' {
 		if s[len(s)-1] != '"' {
 			return s
 		}
-		quote = '"'
 	} else if s[0] == '\'' {
 		if s[len(s)-1] != '\'' {
 			return s
 		}
-		quote = '\''
-	}
-
-	// Not a quoted string
-	if quote == 0 {
+	} else {
 		return s
 	}
 
-	// Unquote characters, passing through illegal escape sequences because seclang rules commonly use them to make
-	// regex more readable.
-	res := strings.Builder{}
-	tail := s[1 : len(s)-1]
-	for len(tail) > 0 {
-		c, _, t, err := strconv.UnquoteChar(tail, quote)
-		if err != nil {
-			res.WriteByte(tail[0])
-			tail = tail[1:]
-		} else {
-			res.WriteRune(c)
-			tail = t
-		}
-	}
-
-	return res.String()
+	return s[1 : len(s)-1]
 }
 
 // InSlice returns true if the string is in the slice

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -74,15 +74,16 @@ func MaybeRemoveQuotes(s string) string {
 		return s
 	}
 
-	if s[0] == '"' {
+	switch s[0] {
+	case '"':
 		if s[len(s)-1] != '"' {
 			return s
 		}
-	} else if s[0] == '\'' {
+	case '\'':
 		if s[len(s)-1] != '\'' {
 			return s
 		}
-	} else {
+	default:
 		return s
 	}
 

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -8,7 +8,7 @@ package strings
 
 import "testing"
 
-func TestMaybeUnquote(t *testing.T) {
+func TestMaybeRemoveQuotes(t *testing.T) {
 	tests := []struct {
 		input string
 		want  string
@@ -39,7 +39,7 @@ func TestMaybeUnquote(t *testing.T) {
 		},
 		{
 			input: `'hello \'world'`,
-			want:  `hello 'world`,
+			want:  `hello \'world`,
 		},
 		{
 			input: `"hello 'world"`,
@@ -47,7 +47,7 @@ func TestMaybeUnquote(t *testing.T) {
 		},
 		{
 			input: `"hello \"world"`,
-			want:  `hello "world`,
+			want:  `hello \"world`,
 		},
 		{
 			input: `"hello world'`,
@@ -66,18 +66,18 @@ func TestMaybeUnquote(t *testing.T) {
 			want:  `'hello world`,
 		},
 		{
-			input: `"\u30cf\u30ed\u30fc world"`,
-			want:  `ハロー world`,
+			input: `"\x{30cf}\x{30ed}\x{30fc} world"`,
+			want:  `\x{30cf}\x{30ed}\x{30fc} world`,
 		},
 		{
-			input: `"\s\x5c\x5c.*"`,
-			want:  `\s\\.*`,
+			input: `"\s\x5c.*"`,
+			want:  `\s\x5c.*`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			if got := MaybeUnquote(tt.input); got != tt.want {
-				t.Errorf("MaybeUnquote() = %s, want %s", got, tt.want)
+			if got := MaybeRemoveQuotes(tt.input); got != tt.want {
+				t.Errorf("MaybeRemoveQuotes() = %s, want %s", got, tt.want)
 			}
 		})
 	}

--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -345,7 +345,7 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 		if len(matches) == 0 {
 			return nil, fmt.Errorf("invalid rule with no transformation matches: %q", options.Data)
 		}
-		operator := utils.MaybeUnquote(matches[0])
+		operator := utils.MaybeRemoveQuotes(matches[0])
 		if utils.InSlice(operator, disabledRuleOperators) {
 			return nil, fmt.Errorf("%s rule operator is disabled", operator)
 		}
@@ -359,7 +359,7 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 			return nil, err
 		}
 		if len(matches) > 1 {
-			actions = utils.MaybeUnquote(matches[1])
+			actions = utils.MaybeRemoveQuotes(matches[1])
 			err = rp.ParseActions(actions)
 			if err != nil {
 				return nil, err
@@ -367,7 +367,7 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 		}
 	} else {
 		// quoted actions separated by comma (,)
-		actions = utils.MaybeUnquote(options.Data)
+		actions = utils.MaybeRemoveQuotes(options.Data)
 		err = rp.ParseActions(actions)
 		if err != nil {
 			return nil, err

--- a/seclang/rules_test.go
+++ b/seclang/rules_test.go
@@ -441,7 +441,7 @@ func TestRxCapture(t *testing.T) {
 
 func TestUnicode(t *testing.T) {
 	waf := coraza.NewWAF()
-	rules := `SecRule ARGS "@rx \u30cf\u30ed\u30fc" "id:101,phase:2,t:lowercase,deny"`
+	rules := `SecRule ARGS "@rx \x{30cf}\x{30ed}\x{30fc}" "id:101,phase:2,t:lowercase,deny"`
 	parser := NewParser(waf)
 
 	err := parser.FromString(rules)

--- a/testing/engine/variables.go
+++ b/testing/engine/variables.go
@@ -85,7 +85,7 @@ SecRule ARGS_GET_NAMES "t1" "id:400,log"
 
 SecRule ARGS_NAMES "jsessionid" "id: 500, log, phase:2"
 SecRule ARGS_NAMES "pineapple" "id: 600, log, phase:2"
-SecRule ARGS "(?:^|[^\x5c\x5c])\x5c\x5c[cdeghijklmpqwxyz123456789]" "id:700,log,phase:2"
+SecRule ARGS "(?:^|[^\x5c])\x5c[cdeghijklmpqwxyz123456789]" "id:700,log,phase:2"
 
 SecRule ARGS|!ARGS:t1 "aaa" "id:800,log,phase:1"
 


### PR DESCRIPTION
SecLang rules generally use expressions where it is expected that escape sequences are preserved in the regex itself. This doesn't work for unicode sequences though, so we unquote only unicode sequences.