### PR TITLE
Don't explicitly initialize empty slices

### DIFF
--- a/collection/collection_map.go
+++ b/collection/collection_map.go
@@ -22,7 +22,7 @@ type Map struct {
 
 // Get returns a slice of strings for a key
 func (c *Map) Get(key string) []string {
-	values := []string{}
+	var values []string
 	for _, a := range c.data[key] {
 		values = append(values, a.Value)
 	}
@@ -31,7 +31,7 @@ func (c *Map) Get(key string) []string {
 
 // FindRegex returns a slice of MatchData for the regex
 func (c *Map) FindRegex(key *regexp.Regexp) []types.MatchData {
-	result := []types.MatchData{}
+	var result []types.MatchData
 	for k, data := range c.data {
 		if key.MatchString(k) {
 			for _, d := range data {
@@ -49,7 +49,7 @@ func (c *Map) FindRegex(key *regexp.Regexp) []types.MatchData {
 
 // FindString returns a slice of MatchData for the string
 func (c *Map) FindString(key string) []types.MatchData {
-	result := []types.MatchData{}
+	var result []types.MatchData
 	if key == "" {
 		for _, data := range c.data {
 			for _, d := range data {
@@ -79,7 +79,7 @@ func (c *Map) FindString(key string) []types.MatchData {
 
 // FindAll returns all the contained elements
 func (c *Map) FindAll() []types.MatchData {
-	result := []types.MatchData{}
+	var result []types.MatchData
 	for _, data := range c.data {
 		for _, d := range data {
 			result = append(result, types.MatchData{
@@ -94,7 +94,7 @@ func (c *Map) FindAll() []types.MatchData {
 }
 
 func (c *Map) keysRx(rx *regexp.Regexp) []string {
-	keys := []string{}
+	var keys []string
 	for k := range c.data {
 		if rx.MatchString(k) {
 			keys = append(keys, k)
@@ -104,7 +104,7 @@ func (c *Map) keysRx(rx *regexp.Regexp) []string {
 }
 
 func (c *Map) keys() []string {
-	keys := []string{}
+	var keys []string
 	for k := range c.data {
 		keys = append(keys, k)
 	}

--- a/collection/collection_proxy.go
+++ b/collection/collection_proxy.go
@@ -22,7 +22,7 @@ type Proxy struct {
 
 // FindRegex returns a slice of MatchData for the regex
 func (c *Proxy) FindRegex(key *regexp.Regexp) []types.MatchData {
-	res := []types.MatchData{}
+	var res []types.MatchData
 	for _, c := range c.data {
 		res = append(res, c.FindRegex(key)...)
 	}
@@ -31,7 +31,7 @@ func (c *Proxy) FindRegex(key *regexp.Regexp) []types.MatchData {
 
 // FindString returns a slice of MatchData for the string
 func (c *Proxy) FindString(key string) []types.MatchData {
-	res := []types.MatchData{}
+	var res []types.MatchData
 	for _, c := range c.data {
 		res = append(res, c.FindString(key)...)
 	}
@@ -40,7 +40,7 @@ func (c *Proxy) FindString(key string) []types.MatchData {
 
 // FindAll returns all matches for all collections
 func (c *Proxy) FindAll() []types.MatchData {
-	res := []types.MatchData{}
+	var res []types.MatchData
 	for _, c := range c.data {
 		res = append(res, c.FindAll()...)
 	}
@@ -54,7 +54,7 @@ func (c *Proxy) Name() string {
 
 // Get returns the data for the key
 func (c *Proxy) Get(key string) []string {
-	res := []string{}
+	var res []string
 	for _, c := range c.data {
 		res = append(res, c.Get(key)...)
 	}

--- a/collection/collection_translation_proxy.go
+++ b/collection/collection_translation_proxy.go
@@ -22,8 +22,8 @@ type TranslationProxy struct {
 
 // FindRegex returns a slice of MatchData for the regex
 func (c *TranslationProxy) FindRegex(key *regexp.Regexp) []types.MatchData {
-	res := []types.MatchData{}
-	keys := []string{}
+	var res []types.MatchData
+	var keys []string
 	for _, c := range c.data {
 		keys = append(keys, c.keysRx(key)...)
 	}
@@ -55,11 +55,11 @@ func (c *TranslationProxy) FindString(key string) []types.MatchData {
 
 // FindAll returns all keys from Proxy Collections
 func (c *TranslationProxy) FindAll() []types.MatchData {
-	keys := []string{}
+	var keys []string
 	for _, c := range c.data {
 		keys = append(keys, c.keys()...)
 	}
-	res := []types.MatchData{}
+	var res []types.MatchData
 	for _, k := range keys {
 		res = append(res, types.MatchData{
 			VariableName: c.name,
@@ -72,7 +72,7 @@ func (c *TranslationProxy) FindAll() []types.MatchData {
 
 // Data returns the keys of all Proxy collections
 func (c *TranslationProxy) Data() []string {
-	res := []string{}
+	var res []string
 	for _, c := range c.data {
 		res = append(res, c.keys()...)
 	}

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -171,7 +171,7 @@ func (r *Rule) doEvaluate(tx *Transaction) []types.MatchData {
 		rid = r.ParentID
 	}
 
-	matchedValues := []types.MatchData{}
+	var matchedValues []types.MatchData
 	// we log if we are the parent rule
 	tx.WAF.Logger.Debug("[%s] [%d] Evaluating rule %d", tx.ID, rid, r.ID)
 	defer tx.WAF.Logger.Debug("[%s] [%d] Finish evaluating rule %d", tx.ID, rid, r.ID)
@@ -416,7 +416,7 @@ func (r *Rule) executeOperator(data string, tx *Transaction) (result bool) {
 
 func (r *Rule) executeTransformationsMultimatch(value string) ([]string, []error) {
 	res := []string{value}
-	errs := []error{}
+	var errs []error
 	var err error
 	for _, t := range r.transformations {
 		value, err = t.Function(value)
@@ -430,7 +430,7 @@ func (r *Rule) executeTransformationsMultimatch(value string) ([]string, []error
 }
 
 func (r *Rule) executeTransformations(value string) (string, []error) {
-	errs := []error{}
+	var errs []error
 	for _, t := range r.transformations {
 		v, err := t.Function(value)
 		if err != nil {

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -62,7 +62,7 @@ func (rg *RuleGroup) DeleteByID(id int) {
 
 // FindByMsg returns a slice of rules that matches the msg
 func (rg *RuleGroup) FindByMsg(msg string) []*Rule {
-	rules := []*Rule{}
+	var rules []*Rule
 	for _, r := range rg.rules {
 		if r.Msg.String() == msg {
 			rules = append(rules, r)
@@ -73,7 +73,7 @@ func (rg *RuleGroup) FindByMsg(msg string) []*Rule {
 
 // FindByTag returns a slice of rules that matches the tag
 func (rg *RuleGroup) FindByTag(tag string) []*Rule {
-	rules := []*Rule{}
+	var rules []*Rule
 	for _, r := range rg.rules {
 		if strings.InSlice(tag, r.Tags) {
 			rules = append(rules, r)

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -379,7 +379,7 @@ func (tx *Transaction) GetField(rv ruleVariableParams) []types.MatchData {
 		matches = col.FindRegex(rv.KeyRx)
 	}
 
-	rmi := []int{}
+	var rmi []int
 	for i, c := range matches {
 		for _, ex := range rv.Exceptions {
 			lkey := strings.ToLower(c.Key)
@@ -820,7 +820,7 @@ func (tx *Transaction) AuditLog() *loggers.AuditLog {
 	* if you don’t want to have (often large) files stored in your audit logs.
 	 */
 	// upload data
-	files := []loggers.AuditTransactionRequestFiles{}
+	var files []loggers.AuditTransactionRequestFiles
 	al.Transaction.Request.Files = []loggers.AuditTransactionRequestFiles{}
 	for _, file := range tx.Variables.Files.Get("") {
 		var size int64
@@ -837,7 +837,7 @@ func (tx *Transaction) AuditLog() *loggers.AuditLog {
 		files = append(files, at)
 	}
 	al.Transaction.Request.Files = files
-	mrs := []loggers.AuditMessage{}
+	var mrs []loggers.AuditMessage
 	for _, mr := range tx.MatchedRules {
 		r := mr.Rule
 		for _, matchData := range mr.MatchedDatas {
@@ -873,7 +873,7 @@ func (tx *Transaction) Clean() error {
 	for k := range tx.Collections {
 		tx.Collections[k] = nil
 	}
-	errs := []error{}
+	var errs []error
 	if err := tx.RequestBodyBuffer.Close(); err != nil {
 		errs = append(errs, err)
 	}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -480,7 +480,7 @@ func directiveSecDataset(options *DirectiveOptions) error {
 	if _, ok := options.Datasets[name]; ok {
 		options.WAF.Logger.Warn("Dataset %s already exists, overwriting", name)
 	}
-	arr := []string{}
+	var arr []string
 	data := strings.Trim(spl[1], "`")
 	for _, s := range strings.Split(data, "\n") {
 		s = strings.TrimSpace(s)

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -50,8 +50,8 @@ func (p *RuleParser) ParseVariables(vars string) error {
 	curr := 0
 	isnegation := false
 	iscount := false
-	curvar := []byte{}
-	curkey := []byte{}
+	var curvar []byte
+	var curkey []byte
 	isescaped := false
 	isquoted := false
 	for i := 0; i < len(vars); i++ {
@@ -418,7 +418,7 @@ func parseActions(actions string) ([]ruleAction, error) {
 	ckey := ""
 	cval := ""
 	quoted := false
-	res := []ruleAction{}
+	var res []ruleAction
 actionLoop:
 	for i, c := range actions {
 		switch {
@@ -488,7 +488,7 @@ SecAction "id:1, phase:2, status:403, log, nolog, deny"
 In the future I shall optimize that redundant log and nolog, it won't actually change anything but would look cooler
 */
 func mergeActions(origin []ruleAction, defaults []ruleAction) []ruleAction {
-	res := []ruleAction{}
+	var res []ruleAction
 	var da ruleAction // Disruptive action
 	for _, action := range defaults {
 		if action.Atype == rules.ActionTypeDisruptive {

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -131,7 +131,7 @@ func TestSecAuditLogs(t *testing.T) {
 
 func TestRuleLogging(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	logs := []string{}
+	var logs []string
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
@@ -192,7 +192,7 @@ func TestRuleChains(t *testing.T) {
 
 func TestTagsAreNotPrintedTwice(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	logs := []string{}
+	var logs []string
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
@@ -224,7 +224,7 @@ func TestTagsAreNotPrintedTwice(t *testing.T) {
 
 func TestStatusFromInterruptions(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	logs := []string{}
+	var logs []string
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})
@@ -262,7 +262,7 @@ func TestChainWithUnconditionalMatch(t *testing.T) {
 
 func TestLogsAreNotPrintedManyTimes(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	logs := []string{}
+	var logs []string
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		logs = append(logs, mr.ErrorLog(403))
 	})

--- a/loggers/formats_json.go
+++ b/loggers/formats_json.go
@@ -32,11 +32,11 @@ func legacyJSONFormatter(al *AuditLog) ([]byte, error) {
 	for k, v := range al.Transaction.Response.Headers {
 		resHeaders[k] = strings.Join(v, ", ")
 	}
-	messages := []string{}
+	var messages []string
 	for _, m := range al.Messages {
 		messages = append(messages, m.Message)
 	}
-	producers := []string{}
+	var producers []string
 	if conn := al.Transaction.Producer.Connector; conn != "" {
 		producers = append(producers, conn)
 	}

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -28,7 +28,7 @@ type Test struct {
 // https://github.com/SpiderLabs/secrules-language-tests/
 func TestOperators(t *testing.T) {
 	root := "./testdata"
-	files := [][]byte{}
+	var files [][]byte
 	if _, err := os.Stat(root); os.IsNotExist(err) {
 		t.Fatal("failed to find operator test files")
 	}

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -27,7 +27,7 @@ func (o *pmFromFile) Init(options rules.OperatorOptions) error {
 		return err
 	}
 
-	lines := []string{}
+	var lines []string
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
 		l := sc.Text()

--- a/operators/rbl.go
+++ b/operators/rbl.go
@@ -45,7 +45,7 @@ func (o *rbl) Evaluate(tx rules.TransactionState, ipAddr string) bool {
 	}()
 
 	addr := fmt.Sprintf("%s.%s", ipAddr, o.service)
-	captures := []string{}
+	var captures []string
 	go func(ctx context.Context) {
 		defer func() {
 			close(resC)

--- a/transformations/cmd_line.go
+++ b/transformations/cmd_line.go
@@ -22,7 +22,7 @@ transform all characters to lowercase
 */
 func cmdLine(data string) (string, error) {
 	space := false
-	ret := []byte{}
+	var ret []byte
 	for _, a := range data {
 		switch {
 		case a == '"' || a == '\'' || a == '\\' || a == '^':

--- a/transformations/compress_whitespace.go
+++ b/transformations/compress_whitespace.go
@@ -8,7 +8,7 @@ import (
 )
 
 func compressWhitespace(value string) (string, error) {
-	a := []byte{}
+	var a []byte
 	i := 0
 	inWhiteSpace := false
 	length := len(value)

--- a/transformations/remove_comments_char.go
+++ b/transformations/remove_comments_char.go
@@ -36,7 +36,7 @@ func removeCommentsChar(data string) (string, error) {
 
 func erase(str []byte, i int, count int) []byte {
 	// TODO There are better algorithms to do this but not today
-	res := []byte{}
+	var res []byte
 	res = append(res, str[0:i]...)
 	res = append(res, str[i+count:]...)
 	return res

--- a/transformations/transformations_test.go
+++ b/transformations/transformations_test.go
@@ -24,7 +24,7 @@ type Test struct {
 // https://github.com/SpiderLabs/secrules-language-tests/
 func TestTransformations(t *testing.T) {
 	root := "./testdata"
-	files := [][]byte{}
+	var files [][]byte
 	if _, err := os.Stat(root); os.IsNotExist(err) {
 		t.Error("failed to find transformation test files")
 	}


### PR DESCRIPTION
It's conventional to use `nil` for empty slice and maybe a tiny bit faster.

Applied this automatically with GoLand