### PR TITLE
Add fast path for macro with single token

### DIFF
--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -699,3 +699,27 @@ func TestMacro(t *testing.T) {
 	//   t.Errorf("failed to parse replacements %v", macro.tokens)
 	// }
 }
+
+func BenchmarkMacro(b *testing.B) {
+	tests := []string{
+		"%{tx.a}",
+		"%{tx.a} %{tx.b}",
+		"goodbye world",
+	}
+
+	tx := makeTransaction(b)
+	tx.Variables.TX.Set("a", []string{"hello"})
+	tx.Variables.TX.Set("b", []string{"world"})
+
+	for _, tc := range tests {
+		m, err := macro.NewMacro(tc)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(tc, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				m.Expand(tx)
+			}
+		})
+	}
+}


### PR DESCRIPTION
No need to do any allocation for a single token macro

After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/corazawaf
BenchmarkMacro
BenchmarkMacro/%{tx.a}
BenchmarkMacro/%{tx.a}-10         	32559846	        37.08 ns/op
BenchmarkMacro/%{tx.a}_%{tx.b}
BenchmarkMacro/%{tx.a}_%{tx.b}-10 	 9336523	       128.8 ns/op
BenchmarkMacro/goodbye_world
BenchmarkMacro/goodbye_world-10   	292027911	         4.070 ns/op
PASS
```

Before
```
BenchmarkMacro
BenchmarkMacro/%{tx.a}
BenchmarkMacro/%{tx.a}-10         	19797242	        55.83 ns/op
BenchmarkMacro/%{tx.a}_%{tx.b}
BenchmarkMacro/%{tx.a}_%{tx.b}-10 	 9750448	       120.0 ns/op
BenchmarkMacro/goodbye_world
BenchmarkMacro/goodbye_world-10   	55078822	        21.45 ns/op
PASS
```