### PR TITLE
feat: adds support for stdout.

### DIFF
--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -24,15 +24,18 @@ func main() {
 }
 
 func createWAF() coraza.WAF {
-	waf, err := coraza.NewWAF(coraza.NewWAFConfig().
-		WithDirectives(`
-		# This is a comment
-		SecDebugLogLevel 9
-		SecRequestBodyAccess On
-		SecRule ARGS:id "@eq 0" "id:1, phase:1,deny, status:403,msg:'Invalid id',log,auditlog"
-		SecRule REQUEST_BODY "somecontent" "id:100, phase:2,deny, status:403,msg:'Invalid request body',log,auditlog"
-		SecRule RESPONSE_BODY "somecontent" "id:200, phase:4,deny, status:403,msg:'Invalid response body',log,auditlog"
-	`))
+	waf, err := coraza.NewWAF(
+		coraza.NewWAFConfig().
+			WithDirectives(`
+				# This is a comment
+				SecDebugLogLevel 5
+				SecRequestBodyAccess On
+				SecDebugLog /dev/stdout
+				SecRule ARGS:id "@eq 0" "id:1, phase:1,deny, status:403,msg:'Invalid id',log,auditlog"
+				SecRule REQUEST_BODY "somecontent" "id:100, phase:2,deny, status:403,msg:'Invalid request body',log,auditlog"
+				SecRule RESPONSE_BODY "somecontent" "id:200, phase:4,deny, status:403,msg:'Invalid response body',log,auditlog"
+			`),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/corazawaf/logger.go
+++ b/internal/corazawaf/logger.go
@@ -17,6 +17,8 @@ type stdDebugLogger struct {
 	Level  loggers.LogLevel
 }
 
+var _ loggers.DebugLogger = (*stdDebugLogger)(nil)
+
 func (l *stdDebugLogger) formatLog(level loggers.LogLevel, message string, args ...interface{}) {
 	if l.Level >= level {
 		l.logger.Printf("[%s] %s", level.String(), fmt.Sprintf(message, args...))

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -409,7 +409,7 @@ func (w *WAF) NewTransaction(ctx context.Context) *Transaction {
 	tx.Variables.HighestSeverity.Set("0")
 	tx.Variables.UniqueID.Set(tx.ID)
 
-	w.Logger.Debug("new transaction created with id %q", tx.ID)
+	w.Logger.Debug("New transaction created with id %q", tx.ID)
 
 	return tx
 }
@@ -422,9 +422,15 @@ func (w *WAF) SetDebugLogPath(path string) error {
 		w.Logger.SetOutput(io.Discard)
 		return nil
 	}
+
+	if path == "/dev/stdout" {
+		w.Logger.SetOutput(os.Stdout)
+		return nil
+	}
+
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		w.Logger.Error("error opening file: %s", err.Error())
+		w.Logger.Error("failed to open the file: %s", err.Error())
 	}
 	w.Logger.SetOutput(f)
 	return nil

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -428,6 +428,11 @@ func (w *WAF) SetDebugLogPath(path string) error {
 		return nil
 	}
 
+	if path == "/dev/stderr" {
+		w.Logger.SetOutput(os.Stderr)
+		return nil
+	}
+
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		w.Logger.Error("failed to open the file: %s", err.Error())


### PR DESCRIPTION
This PR adds support for stdout as output for debug log. Most of the references to stdout in modsec world points to `/dev/stdout` as the target although it isn't idiomatic to Windows.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: