### PR TITLE
add waf.NewTransactionWithID

### DIFF
--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -142,8 +142,17 @@ type WAF struct {
 
 // NewTransaction Creates a new initialized transaction for this WAF instance
 func (w *WAF) NewTransaction(ctx context.Context) *Transaction {
+	return w.NewTransactionWithID(ctx, utils.RandomString(19))
+}
+
+// NewTransactionWithID Creates a new initialized transaction for this WAF instance
+// Using the specified ID
+func (w *WAF) NewTransactionWithID(ctx context.Context, id string) *Transaction {
+	if len(id) == 0 {
+		id = utils.RandomString(19)
+	}
 	tx := transactionPool.Get().(*Transaction)
-	tx.ID = utils.RandomString(19)
+	tx.ID = id
 	tx.MatchedRules = []types.MatchedRule{}
 	tx.Interruption = nil
 	tx.Collections = [types.VariablesCount]collection.Collection{}

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -15,7 +15,7 @@ func TestNewTransaction(t *testing.T) {
 	waf.RequestBodyAccess = true
 	waf.ResponseBodyAccess = true
 	waf.RequestBodyLimit = 1044
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransactionWithID(context.Background(), "test")
 	if !tx.RequestBodyAccess {
 		t.Error("Request body access not enabled")
 	}
@@ -24,6 +24,17 @@ func TestNewTransaction(t *testing.T) {
 	}
 	if tx.RequestBodyLimit != 1044 {
 		t.Error("Request body limit not set")
+	}
+	if tx.ID != "test" {
+		t.Error("ID not set")
+	}
+	tx = waf.NewTransactionWithID(context.Background(), "")
+	if tx.ID == "" {
+		t.Error("ID not set")
+	}
+	tx = waf.NewTransaction(context.Background())
+	if tx.ID == "" {
+		t.Error("ID not set")
 	}
 }
 

--- a/waf.go
+++ b/waf.go
@@ -22,6 +22,7 @@ import (
 type WAF interface {
 	// NewTransaction Creates a new initialized transaction for this WAF instance
 	NewTransaction(ctx context.Context) types.Transaction
+	NewTransactionWithID(ctx context.Context, id string) types.Transaction
 }
 
 // NewWAF creates a new WAF instance with the provided configuration.
@@ -101,4 +102,9 @@ type wafWrapper struct {
 // NewTransaction implements the same method on WAF.
 func (w wafWrapper) NewTransaction(ctx context.Context) types.Transaction {
 	return w.waf.NewTransaction(ctx)
+}
+
+// NewTransactionWithID implements the same method on WAF.
+func (w wafWrapper) NewTransactionWithID(ctx context.Context, id string) types.Transaction {
+	return w.waf.NewTransactionWithID(ctx, id)
 }


### PR DESCRIPTION
`waf.NewTransactionWithID(ctx, id)` can be used by connectors to use the web server ID instead of coraza generated IDs. Useful for logging.