### PR TITLE
Reads the request protocol instead of hacks

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -34,7 +34,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 	}
 
 	var in *types.Interruption
-	// There is no socket access in the request object so we don't know the server client or port
+	// There is no socket access in the request object, so we neither know the server client nor port.
 	tx.ProcessConnection(client, cport, "", 0)
 	tx.ProcessURI(req.URL.String(), req.Method, req.Proto)
 	for k, vr := range req.Header {

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -41,7 +41,7 @@ func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {
 		}
 
 		// We continue with the other middlewares by catching the response
-		h.ServeHTTP(wrap(w, tx), r)
+		h.ServeHTTP(wrap(w, r, tx), r)
 
 		if it, err := tx.ProcessResponseBody(); err != nil {
 			l("failed to process response body: %v", err)

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -78,34 +78,47 @@ func createWAF(t *testing.T) coraza.WAF {
 
 func TestHttpServer(t *testing.T) {
 	tests := map[string]struct {
+		http2            bool
 		reqURI           string
 		reqBody          string
 		respBody         string
+		expectedProto    string
 		expectedStatus   int
 		expectedRespBody string
 	}{
 		"no blocking": {
 			reqURI:         "/hello",
+			expectedProto:  "HTTP/1.1",
+			expectedStatus: 201,
+		},
+		"no blocking HTTP/2": {
+			http2:          true,
+			reqURI:         "/hello",
+			expectedProto:  "HTTP/2.0",
 			expectedStatus: 201,
 		},
 		"args blocking": {
 			reqURI:         "/hello?id=0",
+			expectedProto:  "HTTP/1.1",
 			expectedStatus: 403,
 		},
 		"request body blocking": {
 			reqURI:         "/hello",
 			reqBody:        "eval('cat /etc/passwd')",
+			expectedProto:  "HTTP/1.1",
 			expectedStatus: 403,
 		},
 		"response body not blocking": {
 			reqURI:           "/hello",
 			respBody:         "true negative response body",
+			expectedProto:    "HTTP/1.1",
 			expectedStatus:   201,
 			expectedRespBody: "true negative response body",
 		},
 		"response body blocking": {
 			reqURI:           "/hello",
 			respBody:         "password=xxxx",
+			expectedProto:    "HTTP/1.1",
 			expectedStatus:   201,
 			expectedRespBody: "", // blocking at response body phase means returning it empty
 		},
@@ -118,7 +131,11 @@ func TestHttpServer(t *testing.T) {
 			defer close(serverErrC)
 
 			// Spin up the test server
-			srv := httptest.NewServer(WrapHandler(createWAF(t), t.Logf, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ts := httptest.NewUnstartedServer(WrapHandler(createWAF(t), t.Logf, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if want, have := tCase.expectedProto, w.(ResponseWriter).Proto(); want != have {
+					t.Errorf("unexpected proto, want: %s, have: %s", want, have)
+				}
+
 				w.Header().Set("Content-Type", "text/plain")
 				_, err := w.Write([]byte(tCase.respBody))
 				if err != nil {
@@ -127,16 +144,22 @@ func TestHttpServer(t *testing.T) {
 				w.Header().Add("coraza-middleware", "true")
 				w.WriteHeader(201)
 			})))
-			defer srv.Close()
+			if tCase.http2 {
+				ts.EnableHTTP2 = true
+				ts.StartTLS()
+			} else {
+				ts.Start()
+			}
+			defer ts.Close()
 
 			var reqBody io.Reader
 			if tCase.reqBody != "" {
 				reqBody = strings.NewReader(tCase.reqBody)
 			}
-			req, _ := http.NewRequest("POST", srv.URL+tCase.reqURI, reqBody)
+			req, _ := http.NewRequest("POST", ts.URL+tCase.reqURI, reqBody)
 			// TODO(jcchavezs): Fix it once the discussion in https://github.com/corazawaf/coraza/issues/438 is settled
 			req.Header.Add("content-type", "application/x-www-form-urlencoded")
-			res, err := http.DefaultClient.Do(req)
+			res, err := ts.Client().Do(req)
 			if err != nil {
 				t.Fatalf("unexpected error when performing the request: %v", err)
 			}


### PR DESCRIPTION
Not sure when, but Go has the correct protocol version now. This removes the hack workaround and backfills tests

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: