### PR TITLE
chore: improves ResponseBodyMimeTypes storage.

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/corazawaf/coraza/v3/bodyprocessors"
 	"github.com/corazawaf/coraza/v3/collection"
-	stringsutil "github.com/corazawaf/coraza/v3/internal/strings"
 	urlutil "github.com/corazawaf/coraza/v3/internal/url"
 	"github.com/corazawaf/coraza/v3/loggers"
 	"github.com/corazawaf/coraza/v3/rules"
@@ -667,7 +666,8 @@ func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Int
 func (tx *Transaction) IsProcessableResponseBody() bool {
 	// TODO add more validations
 	ct := tx.Variables.ResponseContentType.String()
-	return stringsutil.InSlice(ct, tx.WAF.ResponseBodyMimeTypes)
+	_, ok := tx.WAF.ResponseBodyMimeTypes[ct]
+	return ok
 }
 
 func (tx *Transaction) ResponseBodyWriter() io.Writer {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -81,7 +81,7 @@ type WAF struct {
 	RejectOnRequestBodyLimit bool
 
 	// Responses will only be loaded if mime is listed here
-	ResponseBodyMimeTypes []string
+	ResponseBodyMimeTypes map[string]struct{}
 
 	// Web Application id, apps sharing the same id will share persistent collections
 	WebAppID string
@@ -467,7 +467,7 @@ func NewWAF() *WAF {
 		AuditLogParts:            types.AuditLogParts("ABCFHZ"),
 		RequestBodyInMemoryLimit: 131072,
 		RequestBodyLimit:         134217728, // 10mb
-		ResponseBodyMimeTypes:    []string{"text/html", "text/plain"},
+		ResponseBodyMimeTypes:    map[string]struct{}{"text/html": {}, "text/plain": {}},
 		ResponseBodyLimit:        524288,
 		ResponseBodyAccess:       false,
 		RuleEngine:               types.RuleEngineOn,

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -165,6 +165,10 @@ func directiveSecResponseBodyMimeTypesClear(options *DirectiveOptions) error {
 }
 
 func directiveSecResponseBodyMimeType(options *DirectiveOptions) error {
+	if options.WAF.ResponseBodyMimeTypes == nil {
+		options.WAF.ResponseBodyMimeTypes = map[string]struct{}{}
+	}
+
 	for _, mType := range strings.Split(options.Opts, " ") {
 		options.WAF.ResponseBodyMimeTypes[mType] = struct{}{}
 	}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -165,7 +165,9 @@ func directiveSecResponseBodyMimeTypesClear(options *DirectiveOptions) error {
 }
 
 func directiveSecResponseBodyMimeType(options *DirectiveOptions) error {
-	options.WAF.ResponseBodyMimeTypes = strings.Split(options.Opts, " ")
+	for _, mType := range strings.Split(options.Opts, " ") {
+		options.WAF.ResponseBodyMimeTypes[mType] = struct{}{}
+	}
 	return nil
 }
 

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -117,7 +117,7 @@ func Test_directive(t *testing.T) {
 	if err := p.FromString("SecResponseBodyMimeType text/html"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if p.options.WAF.ResponseBodyMimeTypes[0] != "text/html" {
+	if _, ok := p.options.WAF.ResponseBodyMimeTypes["text/html"]; !ok {
 		t.Error("failed to set SecResponseBodyMimeType")
 	}
 	if err := p.FromString(`SecServerSignature "Microsoft-IIS/6.0"`); err != nil {


### PR DESCRIPTION
This PR changes the way we store the mime types so `IsProcessableResponseBody` moves from `O(n)` to `O(1)`.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: