### PR TITLE
chore: drops context first param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Coraza can be used as a library for your Go program to implement a security midd
 package main
 
 import (
-	"context"
 	"fmt"
 	"github.com/corazawaf/coraza/v3"
 )
@@ -93,7 +92,7 @@ func main() {
 	}
 
 	// Then we create a transaction and assign some variables
-	tx := waf.NewTransaction(context.Background())
+    tx := waf.NewTransaction()
 	defer func() {
 		tx.ProcessLogging()
 		tx.Close()

--- a/actions/ctl_test.go
+++ b/actions/ctl_test.go
@@ -4,7 +4,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -13,7 +12,7 @@ import (
 
 func TestCtl(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	r := corazawaf.NewRule()
 	ctlf := ctl()
 

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -10,7 +10,6 @@ package http
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -28,7 +27,7 @@ import (
 func TestProcessRequest(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://www.coraza.io/test", strings.NewReader("test=456"))
 	waf := corazawaf.NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	if _, err := processRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +96,7 @@ func multipartRequest(t *testing.T, req *http.Request) error {
 
 func makeTransaction(t *testing.T) *corazawaf.Transaction {
 	t.Helper()
-	tx := corazawaf.NewWAF().NewTransaction(context.Background())
+	tx := corazawaf.NewWAF().NewTransaction()
 	tx.RequestBodyAccess = true
 	ht := []string{
 		"POST /testurl.php?id=123&b=456 HTTP/1.1",
@@ -125,7 +124,7 @@ func TestDirectiveSecAuditLog(t *testing.T) {
 		`); err != nil {
 		t.Error(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.RequestBodyAccess = true
 	tx.ForceRequestBodyVariable = true
 	// request

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -8,7 +8,6 @@
 package http
 
 import (
-	"context"
 	"io"
 	"net/http"
 
@@ -18,7 +17,7 @@ import (
 
 func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		tx := waf.NewTransaction(context.Background())
+		tx := waf.NewTransaction()
 		defer func() {
 			// We run phase 5 rules and create audit logs (if enabled)
 			tx.ProcessLogging()

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -4,7 +4,6 @@
 package corazawaf
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"runtime/debug"
@@ -64,7 +63,7 @@ func TestTxSetters(t *testing.T) {
 	validateMacroExpansion(exp, tx, t)
 }
 func TestTxMultipart(t *testing.T) {
-	tx := wafi.NewTransaction(context.Background())
+	tx := wafi.NewTransaction()
 	body := []string{
 		"-----------------------------9051914041544843365972754266",
 		"Content-Disposition: form-data; name=\"text\"",
@@ -167,7 +166,7 @@ func TestRequestBody(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			urlencoded := "some=result&second=data"
 			// xml := "<test><content>test</content></test>"
-			tx := wafi.NewTransaction(context.Background())
+			tx := wafi.NewTransaction()
 			tx.RequestBodyAccess = true
 			tx.RequestBodyLimit = testCase.requestBodyLimit
 			tx.WAF.RequestBodyLimitAction = testCase.requestBodyLimitAction
@@ -308,7 +307,7 @@ func TestLogCallback(t *testing.T) {
 	waf.SetErrorLogCb(func(mr types.MatchedRule) {
 		buffer = mr.ErrorLog(403)
 	})
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	rule := NewRule()
 	tx.MatchRule(rule, []types.MatchData{
 		{
@@ -326,7 +325,7 @@ func TestLogCallback(t *testing.T) {
 
 func TestHeaderSetters(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "abc=def;hij=klm")
 	tx.AddRequestHeader("test1", "test2")
 	c := tx.Variables.RequestCookies.Get("abc")[0]
@@ -349,7 +348,7 @@ func TestHeaderSetters(t *testing.T) {
 
 func TestRequestBodyProcessingAlgorithm(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.RuleEngine = types.RuleEngineOn
 	tx.RequestBodyAccess = true
 	tx.ForceRequestBodyVariable = true
@@ -446,7 +445,7 @@ func TestAuditLogMessages(t *testing.T) {
 
 func TestTransactionSyncPool(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.MatchedRules = append(tx.MatchedRules, types.MatchedRule{
 		Rule: types.RuleMetadata{
 			ID: 1234,
@@ -456,7 +455,7 @@ func TestTransactionSyncPool(t *testing.T) {
 		if err := tx.Close(); err != nil {
 			t.Error(err)
 		}
-		tx = waf.NewTransaction(context.Background())
+		tx = waf.NewTransaction()
 		if len(tx.MatchedRules) != 0 {
 			t.Errorf("failed to sync transaction pool, %d rules found after %d attempts", len(tx.MatchedRules), i+1)
 			return
@@ -466,7 +465,7 @@ func TestTransactionSyncPool(t *testing.T) {
 
 func TestTxPhase4Magic(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddResponseHeader("content-type", "text/html")
 	tx.ResponseBodyAccess = true
 	tx.WAF.ResponseBodyLimit = 3
@@ -486,7 +485,7 @@ func TestTxPhase4Magic(t *testing.T) {
 
 func TestVariablesMatch(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.matchVariable(types.MatchData{
 		VariableName: "ARGS_NAMES",
 		Variable:     variables.ArgsNames,
@@ -511,7 +510,7 @@ func TestVariablesMatch(t *testing.T) {
 
 func TestTxReqBodyForce(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.RequestBodyAccess = true
 	tx.ForceRequestBodyVariable = true
 	if _, err := tx.RequestBodyBuffer.Write([]byte("test")); err != nil {
@@ -527,7 +526,7 @@ func TestTxReqBodyForce(t *testing.T) {
 
 func TestTxReqBodyForceNegative(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.RequestBodyAccess = true
 	tx.ForceRequestBodyVariable = false
 	if _, err := tx.RequestBodyBuffer.Write([]byte("test")); err != nil {
@@ -543,7 +542,7 @@ func TestTxReqBodyForceNegative(t *testing.T) {
 
 func TestTxProcessConnection(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessConnection("127.0.0.1", 80, "127.0.0.2", 8080)
 	if tx.Variables.RemoteAddr.String() != "127.0.0.1" {
 		t.Error("failed to set client ip")
@@ -566,7 +565,7 @@ func TestTxGetField(t *testing.T) {
 
 func TestTxProcessURI(t *testing.T) {
 	waf := NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	uri := "http://example.com/path/to/file.html?query=string&other=value"
 	tx.ProcessURI(uri, "GET", "HTTP/1.1")
 	if s := tx.Variables.RequestURI.String(); s != uri {
@@ -594,7 +593,7 @@ func BenchmarkTransactionCreation(b *testing.B) {
 
 func makeTransaction(t testing.TB) *Transaction {
 	t.Helper()
-	tx := wafi.NewTransaction(context.Background())
+	tx := wafi.NewTransaction()
 	tx.RequestBodyAccess = true
 	ht := []string{
 		"POST /testurl.php?id=123&b=456 HTTP/1.1",
@@ -618,7 +617,7 @@ func makeTransactionMultipart(t *testing.T) *Transaction {
 	if t != nil {
 		t.Helper()
 	}
-	tx := wafi.NewTransaction(context.Background())
+	tx := wafi.NewTransaction()
 	tx.RequestBodyAccess = true
 	ht := []string{
 		"POST /testurl.php?id=123&b=456 HTTP/1.1",

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -4,7 +4,6 @@
 package corazawaf
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -12,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -141,16 +141,21 @@ type WAF struct {
 }
 
 // NewTransaction Creates a new initialized transaction for this WAF instance
-func (w *WAF) NewTransaction(ctx context.Context) *Transaction {
-	return w.NewTransactionWithID(ctx, utils.RandomString(19))
+func (w *WAF) NewTransaction() *Transaction {
+	return w.newTransactionWithID(utils.RandomString(19))
+}
+
+func (w *WAF) NewTransactionWithID(id string) *Transaction {
+	if len(strings.TrimSpace(id)) == 0 {
+		id = utils.RandomString(19)
+		w.Logger.Warn("Empty ID passed for new transaction")
+	}
+	return w.newTransactionWithID(id)
 }
 
 // NewTransactionWithID Creates a new initialized transaction for this WAF instance
 // Using the specified ID
-func (w *WAF) NewTransactionWithID(ctx context.Context, id string) *Transaction {
-	if len(id) == 0 {
-		id = utils.RandomString(19)
-	}
+func (w *WAF) newTransactionWithID(id string) *Transaction {
 	tx := transactionPool.Get().(*Transaction)
 	tx.ID = id
 	tx.MatchedRules = []types.MatchedRule{}

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -4,7 +4,6 @@
 package corazawaf
 
 import (
-	"context"
 	"io"
 	"os"
 	"testing"
@@ -15,7 +14,7 @@ func TestNewTransaction(t *testing.T) {
 	waf.RequestBodyAccess = true
 	waf.ResponseBodyAccess = true
 	waf.RequestBodyLimit = 1044
-	tx := waf.NewTransactionWithID(context.Background(), "test")
+	tx := waf.NewTransactionWithID("test")
 	if !tx.RequestBodyAccess {
 		t.Error("Request body access not enabled")
 	}
@@ -28,11 +27,11 @@ func TestNewTransaction(t *testing.T) {
 	if tx.ID != "test" {
 		t.Error("ID not set")
 	}
-	tx = waf.NewTransactionWithID(context.Background(), "")
+	tx = waf.NewTransactionWithID("")
 	if tx.ID == "" {
 		t.Error("ID not set")
 	}
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	if tx.ID == "" {
 		t.Error("ID not set")
 	}

--- a/internal/seclang/body_test.go
+++ b/internal/seclang/body_test.go
@@ -4,7 +4,6 @@
 package seclang
 
 import (
-	"context"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -19,7 +18,7 @@ func TestRequestBodyAccessOff(t *testing.T) {
 	`); err != nil {
 		t.Fatal(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/", "POST", "http/1.1")
 	tx.RequestBodyBuffer.Write([]byte("test=123"))
 	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
@@ -38,7 +37,7 @@ func TestRequestBodyAccessOn(t *testing.T) {
 	`); err != nil {
 		t.Fatal(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/", "POST", "http/1.1")
 	if _, err := tx.RequestBodyBuffer.Write([]byte("test=123")); err != nil {
 		t.Error(err)

--- a/internal/seclang/parser_test.go
+++ b/internal/seclang/parser_test.go
@@ -5,7 +5,6 @@ package seclang
 
 import (
 	"bufio"
-	"context"
 	"embed"
 	"fmt"
 	"io/fs"
@@ -25,7 +24,7 @@ func TestInterruption(t *testing.T) {
 	if err := p.FromString(`SecAction "id:1,deny,log,phase:1"`); err != nil {
 		t.Error("Could not create from string")
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	if tx.ProcessRequestHeaders() == nil {
 		t.Error("Transaction not interrupted")
 	}

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -4,7 +4,6 @@
 package seclang
 
 import (
-	"context"
 	"io"
 	"regexp"
 	"strings"
@@ -26,7 +25,7 @@ func TestRuleMatch(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessConnection("127.0.0.1", 0, "", 0)
 	tx.ProcessRequestHeaders()
 	if len(tx.MatchedRules) != 1 {
@@ -52,7 +51,7 @@ func TestRuleMatchWithRegex(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "id_test", "123")
 	tx.ProcessRequestHeaders()
 	if len(tx.MatchedRules) != 1 {
@@ -85,7 +84,7 @@ func TestSecMarkers(t *testing.T) {
 		t.Error("failed to compile some rule.")
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	defer tx.ProcessLogging()
 	tx.ProcessRequestHeaders()
 	if tx.Interrupted() {
@@ -112,7 +111,7 @@ func TestSecAuditLogs(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/test.php?id=1", "get", "http/1.1")
 	tx.ProcessRequestHeaders()
 	if _, err := tx.ProcessRequestBody(); err != nil {
@@ -144,7 +143,7 @@ func TestRuleLogging(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test1", "123")
 	tx.AddArgument("GET", "test2", "456")
 	tx.ProcessRequestHeaders()
@@ -181,7 +180,7 @@ func TestRuleChains(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test1", "123")
 	tx.AddArgument("GET", "test2", "456")
 	tx.ProcessRequestHeaders()
@@ -203,7 +202,7 @@ func TestTagsAreNotPrintedTwice(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test1", "123")
 	tx.AddArgument("GET", "test2", "456")
 	tx.ProcessRequestHeaders()
@@ -235,7 +234,7 @@ func TestStatusFromInterruptions(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test1", "123")
 	tx.AddArgument("GET", "test2", "456")
 	it := tx.ProcessRequestHeaders()
@@ -273,7 +272,7 @@ func TestLogsAreNotPrintedManyTimes(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test1", "123")
 	tx.AddArgument("GET", "test2", "456")
 	tx.AddArgument("GET", "test2", "789")
@@ -297,7 +296,7 @@ func TestSampleRxRule(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/test", "GET", "HTTP/1.1")
 	tx.AddRequestHeader("Content-Length", "15")
 	if it := tx.ProcessRequestHeaders(); it == nil {
@@ -313,7 +312,7 @@ func TestTxIssue147(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	// response body access is required
 	tx.ResponseBodyAccess = true
 	// we need a content-type header
@@ -355,7 +354,7 @@ func TestIssue176(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("Cookie", "sessionId=test")
 	it := tx.ProcessRequestHeaders()
 	if it == nil {
@@ -369,7 +368,7 @@ func TestIssue176(t *testing.T) {
 	//	if err != nil {
 	//		t.Error(err.Error())
 	//	}
-	//	tx = waf.NewTransaction(context.Background())
+	//	tx = waf.NewTransaction()
 	//	tx.AddArgument("GET", "Test1", "123")
 	//	it = tx.ProcessRequestHeaders()
 	//	if it == nil {
@@ -382,7 +381,7 @@ func TestIssue176(t *testing.T) {
 	//	if err != nil {
 	//		t.Error(err.Error())
 	//	}
-	//	tx = waf.NewTransaction(context.Background())
+	//	tx = waf.NewTransaction()
 	//	tx.AddArgument("GET", "Test2", "123")
 	//	it = tx.ProcessRequestHeaders()
 	//	if it != nil {
@@ -431,7 +430,7 @@ func TestRxCapture(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("Content-Type", "text/html; charset=utf-8")
 	it := tx.ProcessRequestHeaders()
 	if it != nil {
@@ -450,7 +449,7 @@ func TestUnicode(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("POST", "var", `ハローワールド`)
 	it, err := tx.ProcessRequestBody()
 	if err != nil {
@@ -502,7 +501,7 @@ func Test941310(t *testing.T) {
 	// 	return
 	// }
 	//
-	// tx := waf.NewTransaction(context.Background())
+	// tx := waf.NewTransaction()
 	// tx.AddArgument("POST", "var", `\\xbcscript\\xbealert(\xa2XSS\xa2)\xbc/script\xbe`)
 	// it, err := tx.ProcessRequestBody()
 	// if err != nil {
@@ -524,7 +523,7 @@ func TestArgumentNamesCaseSensitive(t *testing.T) {
 		return
 	}
 	/*
-		tx := waf.NewTransaction(context.Background())
+		tx := waf.NewTransaction()
 		tx.AddArgument("POST", "Test1", "Xyz")
 		it, err := tx.ProcessRequestBody()
 		if err != nil {
@@ -534,7 +533,7 @@ func TestArgumentNamesCaseSensitive(t *testing.T) {
 			t.Error("failed to test argument names case sensitive: same case nomatch")
 		}
 
-		tx = waf.NewTransaction(context.Background())
+		tx = waf.NewTransaction()
 		tx.AddArgument("POST", "TEST1", "Xyz")
 		it, err = tx.ProcessRequestBody()
 		if err != nil {
@@ -544,7 +543,7 @@ func TestArgumentNamesCaseSensitive(t *testing.T) {
 			t.Error("failed to test argument names case sensitive: Upper case argument name matched")
 		}
 
-		tx = waf.NewTransaction(context.Background())
+		tx = waf.NewTransaction()
 		tx.AddArgument("POST", "test1", "Xyz")
 		it, err = tx.ProcessRequestBody()
 		if err != nil {
@@ -567,7 +566,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("POST", "Test1", "Xyz")
 	it, err := tx.ProcessRequestBody()
 	if err != nil {
@@ -577,7 +576,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 		t.Errorf("failed to test arguments value match: Same case argument name, %+v\n", tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddArgument("POST", "TEST1", "Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -587,7 +586,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 		t.Errorf("failed to test arguments value match: Upper case argument name, %+v\n", tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddArgument("POST", "test1", "Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -597,7 +596,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 		t.Errorf("failed to test arguments value match: Lower case argument name, %+v\n", tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddArgument("POST", "test1", "xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -607,7 +606,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 		t.Error("failed to test arguments value: different value case")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddArgument("POST", "test1", "XYZ")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -629,7 +628,7 @@ func TestCookiesCaseSensitive(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "Test1=Xyz")
 	it, err := tx.ProcessRequestBody()
 	if err != nil {
@@ -639,7 +638,7 @@ func TestCookiesCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "TEST1=Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -649,7 +648,7 @@ func TestCookiesCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "test1=Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -659,7 +658,7 @@ func TestCookiesCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "test1=xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -669,7 +668,7 @@ func TestCookiesCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies value case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("cookie", "test1=XYZ")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -691,7 +690,7 @@ func TestHeadersCaseSensitive(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("Test1", "Xyz")
 	it, err := tx.ProcessRequestBody()
 	if err != nil {
@@ -701,7 +700,7 @@ func TestHeadersCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("TEST1", "Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -711,7 +710,7 @@ func TestHeadersCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("test1", "Xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -721,7 +720,7 @@ func TestHeadersCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("test1", "xyz")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -731,7 +730,7 @@ func TestHeadersCaseSensitive(t *testing.T) {
 		t.Error("failed to test cookies value case sensitive")
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddRequestHeader("test1", "XYZ")
 	it, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -753,7 +752,7 @@ func TestParameterPollution(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("POST", "test1", "xyz")
 	tx.AddArgument("POST", "Test1", "Xyz")
 	tx.AddArgument("POST", "TEST1", "XYZ")
@@ -772,7 +771,7 @@ func TestParameterPollution(t *testing.T) {
 			len(tx.MatchedRules), tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.AddArgument("POST", "test1", "xyz")
 	tx.AddArgument("POST", "Test1", "Xyz")
 	tx.AddArgument("POST", "tesT1", "Xyz")
@@ -804,7 +803,7 @@ func TestURIQueryParamCaseSensitive(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/url?Test1='SQLI", "POST", "HTTP/1.1")
 	_, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -824,7 +823,7 @@ func TestURIQueryParamCaseSensitive(t *testing.T) {
 			len(tx.MatchedRules), tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.ProcessURI("/test?test1='SQLI&Test1='SQLI&TEST1='SQLI", "POST", "HTTP/1.1")
 	_, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -861,7 +860,7 @@ func TestURIQueryParamNameCaseSensitive(t *testing.T) {
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.ProcessURI("/url?Test1='SQLI", "POST", "HTTP/1.1")
 	_, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -881,7 +880,7 @@ func TestURIQueryParamNameCaseSensitive(t *testing.T) {
 			len(tx.MatchedRules), tx.MatchedRules)
 	}
 
-	tx = waf.NewTransaction(context.Background())
+	tx = waf.NewTransaction()
 	tx.ProcessURI("/test?test1='SQLI&Test1='SQLI&TEST1='SQLI", "POST", "HTTP/1.1")
 	_, err = tx.ProcessRequestBody()
 	if err != nil {
@@ -948,7 +947,7 @@ SecRule REQUEST_URI|ARGS|REQUEST_HEADERS|!REQUEST_HEADERS:Referer|FILES|XML:/* "
 		return
 	}
 
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddRequestHeader("Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryABCDEFGIJKLMNOPQ")
 
 	body := strings.NewReader(`

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -92,7 +91,7 @@ func TestOperators(t *testing.T) {
 					if err := op.Init(opts); err != nil {
 						t.Error(err)
 					}
-					tx := waf.NewTransaction(context.Background())
+					tx := waf.NewTransaction()
 					tx.Capture = capVal
 					res := op.Evaluate(tx, data.Input)
 					// 1 = expected true

--- a/operators/pm_from_dataset_test.go
+++ b/operators/pm_from_dataset_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestPmFromDataset(t *testing.T) {
 		t.Error(err)
 	}
 	waf := corazawaf.NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.Capture = true
 	res := pm.Evaluate(tx, "test_1")
 	if !res {

--- a/operators/rbl_test.go
+++ b/operators/rbl_test.go
@@ -7,7 +7,6 @@
 package operators
 
 import (
-	"context"
 	"testing"
 
 	"github.com/foxcpp/go-mockdns"
@@ -62,7 +61,7 @@ func TestRbl(t *testing.T) {
 	})
 
 	t.Run("Valid hostname with TXT record", func(t *testing.T) {
-		tx := corazawaf.NewWAF().NewTransaction(context.Background())
+		tx := corazawaf.NewWAF().NewTransaction()
 		if !rbl.Evaluate(tx, "valid_txt") {
 			t.Errorf("Unexpected result for valid hostname")
 		}
@@ -78,7 +77,7 @@ func TestRbl(t *testing.T) {
 	})
 
 	t.Run("Blocked hostname", func(t *testing.T) {
-		tx := corazawaf.NewWAF().NewTransaction(context.Background())
+		tx := corazawaf.NewWAF().NewTransaction()
 		if !rbl.Evaluate(tx, "blocked") {
 			t.Fatal("Unexpected result for blocked hostname")
 		}

--- a/operators/restpath_test.go
+++ b/operators/restpath_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"context"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -13,7 +12,7 @@ import (
 
 func TestRestPath(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	exp := "/some-random/url-{id}/{name}"
 	path := "/some-random/url-123/juan"
 	rp := restpath{}

--- a/operators/rx_test.go
+++ b/operators/rx_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -52,7 +51,7 @@ func TestRx(t *testing.T) {
 				t.Error(err)
 			}
 			waf := corazawaf.NewWAF()
-			tx := waf.NewTransaction(context.Background())
+			tx := waf.NewTransaction()
 			tx.Capture = true
 			res := rx.Evaluate(tx, tt.input)
 			if res != tt.want {

--- a/operators/validate_byte_range_test.go
+++ b/operators/validate_byte_range_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	"context"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -46,7 +45,7 @@ func TestValidateByteRangeCase5(t *testing.T) {
 
 func getTransaction() *corazawaf.Transaction {
 	waf := corazawaf.NewWAF()
-	return waf.NewTransaction(context.Background())
+	return waf.NewTransaction()
 }
 
 func BenchmarkValidateByteRange(b *testing.B) {

--- a/testing/auditlog_test.go
+++ b/testing/auditlog_test.go
@@ -9,7 +9,6 @@
 package testing
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -42,7 +41,7 @@ func TestAuditLogMessages(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(file.Name())
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test", "test")
 	tx.ProcessRequestHeaders()
 	al := tx.AuditLog()
@@ -91,7 +90,7 @@ func TestAuditLogRelevantOnly(t *testing.T) {
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Error(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test", "test")
 	tx.ProcessRequestHeaders()
 	// now we read file
@@ -128,7 +127,7 @@ func TestAuditLogRelevantOnlyOk(t *testing.T) {
 	`); err != nil {
 		t.Error(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test", "test")
 	tx.ProcessRequestHeaders()
 	// now we read file
@@ -165,7 +164,7 @@ func TestAuditLogRelevantOnlyNoAuditlog(t *testing.T) {
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Error(err)
 	}
-	tx := waf.NewTransaction(context.Background())
+	tx := waf.NewTransaction()
 	tx.AddArgument("GET", "test", "test")
 	tx.ProcessRequestHeaders()
 	// now we read file

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -10,7 +10,6 @@ package coreruleset
 import (
 	"archive/zip"
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,7 +77,7 @@ func BenchmarkCRSSimpleGET(b *testing.B) {
 
 	b.ResetTimer() // only benchmark execution, not compilation
 	for i := 0; i < b.N; i++ {
-		tx := waf.NewTransaction(context.Background())
+		tx := waf.NewTransaction()
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
 		tx.ProcessURI("GET", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
 		tx.AddRequestHeader("Host", "localhost")
@@ -105,7 +104,7 @@ func BenchmarkCRSSimplePOST(b *testing.B) {
 
 	b.ResetTimer() // only benchmark execution, not compilation
 	for i := 0; i < b.N; i++ {
-		tx := waf.NewTransaction(context.Background())
+		tx := waf.NewTransaction()
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
 		tx.ProcessURI("POST", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
 		tx.AddRequestHeader("Host", "localhost")

--- a/testing/engine.go
+++ b/testing/engine.go
@@ -4,7 +4,6 @@
 package testing
 
 import (
-	"context"
 	b64 "encoding/base64"
 	"fmt"
 	"strconv"
@@ -282,7 +281,7 @@ func (t *Test) Request() string {
 func NewTest(name string, waf coraza.WAF) *Test {
 	t := &Test{
 		Name:           name,
-		transaction:    waf.NewTransaction(context.Background()),
+		transaction:    waf.NewTransaction(),
 		RequestHeaders: map[string]string{},
 		ResponseHeaders: map[string]string{
 			"Content-Type": "text/html",

--- a/waf.go
+++ b/waf.go
@@ -4,7 +4,6 @@
 package coraza
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -21,8 +20,8 @@ import (
 // concurrent safe
 type WAF interface {
 	// NewTransaction Creates a new initialized transaction for this WAF instance
-	NewTransaction(ctx context.Context) types.Transaction
-	NewTransactionWithID(ctx context.Context, id string) types.Transaction
+	NewTransaction() types.Transaction
+	NewTransactionWithID(id string) types.Transaction
 }
 
 // NewWAF creates a new WAF instance with the provided configuration.
@@ -100,11 +99,11 @@ type wafWrapper struct {
 }
 
 // NewTransaction implements the same method on WAF.
-func (w wafWrapper) NewTransaction(ctx context.Context) types.Transaction {
-	return w.waf.NewTransaction(ctx)
+func (w wafWrapper) NewTransaction() types.Transaction {
+	return w.waf.NewTransaction()
 }
 
 // NewTransactionWithID implements the same method on WAF.
-func (w wafWrapper) NewTransactionWithID(ctx context.Context, id string) types.Transaction {
-	return w.waf.NewTransactionWithID(ctx, id)
+func (w wafWrapper) NewTransactionWithID(id string) types.Transaction {
+	return w.waf.NewTransactionWithID(id)
 }


### PR DESCRIPTION
Context isn't used and won't be used in the short term. Although there are many use cases (e.g. deadlines for expensive analysis) the impact in the proxy-wasm env makes it not viable for V3 as goroutines can be spawn freely like in regular Go.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: