### PR TITLE
chore: makes sure body payload has a limit in tinygo.

### DIFF
--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -42,6 +42,9 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	if l > br.options.MemoryLimit {
 		if environment.IsTinyGo {
 			maxWritingDataLen := br.options.MemoryLimit - br.length
+			if maxWritingDataLen == 0 {
+				return 0, nil
+			}
 			br.length = br.options.MemoryLimit
 			return br.buffer.Write(data[:maxWritingDataLen])
 		} else {

--- a/internal/corazawaf/body_buffer_tinygo_test.go
+++ b/internal/corazawaf/body_buffer_tinygo_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tinygo
+// +build tinygo
+
+package corazawaf
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+func TestWriteOverLimit(t *testing.T) {
+	br := NewBodyBuffer(types.BodyBufferOptions{
+		MemoryLimit: 2,
+	})
+	defer br.Close()
+	n, err := br.Write([]byte{'a', 'b', 'c'})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+
+	if want, have := 2, n; want != have {
+		t.Errorf("unexpected number of bytes in write, want: %d, have: %d", want, have)
+	}
+
+	if want, have := "ab", br.buffer.String(); want != have {
+		t.Errorf("unexpected writen bytes, want: %q, have: %q", want, have)
+	}
+}

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -172,6 +172,9 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 
 	errorPath := filepath.Join(t.TempDir(), "error.log")
 	errorFile, err := os.Create(errorPath)
+	if err != nil {
+		t.Fatalf("failed to create error log: %v", err)
+	}
 	errorWriter := bufio.NewWriter(errorFile)
 	conf = conf.WithErrorLogger(func(rule types.MatchedRule) {
 		msg := rule.ErrorLog(0)
@@ -191,6 +194,7 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 	s := httptest.NewServer(txhttp.WrapHandler(waf, t.Logf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "hello!")
 	})))
+	defer s.Close()
 
 	tests, err := test.GetTestsFromFiles(filepath.Join(crspath, "tests", "regression", "tests", "**", "*.yaml"))
 	if err != nil {


### PR DESCRIPTION
Currently in tinygo envs, if the writing data was bigger than max limit of body, the entire body was still written. This PR truncates the body as in tinygo (as opposed to Go) we keep the entire body in memory. 

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: