### PR TITLE
Implement a simple sync.Pool for TinyGo

### DIFF
--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -12,22 +12,18 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
+	"github.com/corazawaf/coraza/v3/internal/sync"
 	"github.com/corazawaf/coraza/v3/loggers"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 // Initializing pool for transactions
-var transactionPool = sync.Pool{
-	// New optionally specifies a function to generate
-	// a value when Get would otherwise return nil.
-	New: func() interface{} { return new(Transaction) },
-}
+var transactionPool = sync.NewPool(func() interface{} { return new(Transaction) })
 
 // ErrorLogCallback is used to set a callback function to log errors
 // It is triggered when an error is raised by the WAF

--- a/internal/sync/pool.go
+++ b/internal/sync/pool.go
@@ -1,0 +1,11 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package sync
+
+// Pool is an interface matching Go's sync.Pool. We delegate normally but reimplement for TinyGo
+// since it does not have a pooling implementation.
+type Pool interface {
+	Get() interface{}
+	Put(x interface{})
+}

--- a/internal/sync/pool_std.go
+++ b/internal/sync/pool_std.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !tinygo
+// +build !tinygo
+
+package sync
+
+import "sync"
+
+func NewPool(new func() interface{}) Pool {
+	return &stdPool{
+		pool: sync.Pool{
+			New: new,
+		},
+	}
+}
+
+type stdPool struct {
+	pool sync.Pool
+}
+
+func (p *stdPool) Get() interface{} {
+	return p.pool.Get()
+}
+
+func (p *stdPool) Put(x interface{}) {
+	p.pool.Put(x)
+}

--- a/internal/sync/pool_tinygo.go
+++ b/internal/sync/pool_tinygo.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tinygo
+// +build tinygo
+
+package sync
+
+func NewPool(new func() interface{}) Pool {
+	return &tinygoPool{
+		new: new,
+	}
+}
+
+// TinyGo is not concurrent, so we do not need a complicated implementation. We just want to reuse memory.
+type tinygoPool struct {
+	pool []interface{}
+	new  func() interface{}
+}
+
+func (p *tinygoPool) Get() interface{} {
+	if len(p.pool) == 0 {
+		return p.new()
+	}
+	x := p.pool[len(p.pool)-1]
+	p.pool = p.pool[:len(p.pool)-1]
+	return x
+}
+
+func (p *tinygoPool) Put(x interface{}) {
+	p.pool = append(p.pool, x)
+}

--- a/internal/sync/pool_tinygo_test.go
+++ b/internal/sync/pool_tinygo_test.go
@@ -31,6 +31,6 @@ func TestNewPool(t *testing.T) {
 	}
 
 	if want, have := 2, *(y.(*int)); want != have {
-		t.Error("unexpected pool value, want: %d, have: %d", want, have)
+		t.Errorf("unexpected pool value, want: %d, have: %d", want, have)
 	}
 }

--- a/internal/sync/pool_tinygo_test.go
+++ b/internal/sync/pool_tinygo_test.go
@@ -18,7 +18,7 @@ func TestNewPool(t *testing.T) {
 
 	x, ok := p.Get().(*int)
 	if !ok {
-		t.Fatal("failed to cast first got element")
+		t.Fatal("failed to cast got element")
 		return
 	}
 
@@ -31,6 +31,6 @@ func TestNewPool(t *testing.T) {
 	}
 
 	if want, have := 2, *(y.(*int)); want != have {
-		t.Error("unexpected pool value")
+		t.Error("unexpected pool value, want: %d, have: %d", want, have)
 	}
 }

--- a/internal/sync/pool_tinygo_test.go
+++ b/internal/sync/pool_tinygo_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build tinygo
+// +build tinygo
+
+package sync
+
+import (
+	"testing"
+)
+
+func TestNewPool(t *testing.T) {
+	p := NewPool(func() interface{} {
+		n := int(1)
+		return &n
+	})
+
+	x, ok := p.Get().(*int)
+	if !ok {
+		t.Fatal("failed to cast first got element")
+		return
+	}
+
+	*x = 2
+	p.Put(x)
+
+	y := p.Get()
+	if want, have := x, y; want != have {
+		t.Errorf("unexpected pool value, want %p, have %p", want, have)
+	}
+
+	if want, have := 2, *(y.(*int)); want != have {
+		t.Error("unexpected pool value")
+	}
+}


### PR DESCRIPTION
TinyGo doesn't seem to implement any sort of pooling

https://github.com/tinygo-org/tinygo/blob/release/src/sync/pool.go#L18

I will probably propose using this simple implementation there too, but in the meantime it's fairly simple for us to have two implementations and could be worth it