### PR TITLE
Fix: Adjust parser activation rules in coraza.conf-recommended

### DIFF
--- a/coraza.conf-recommended
+++ b/coraza.conf-recommended
@@ -18,21 +18,21 @@ SecRequestBodyAccess On
 # Enable XML request body parser.
 # Initiate XML Processor in case of xml content-type
 #
-SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
+SecRule REQUEST_HEADERS:Content-Type "^(?:application(?:/soap\+|/)|text/)xml" \
      "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
 
 # Enable JSON request body parser.
 # Initiate JSON Processor in case of JSON content-type; change accordingly
 # if your application does not use 'application/json'
 #
-SecRule REQUEST_HEADERS:Content-Type "application/json" \
+SecRule REQUEST_HEADERS:Content-Type "^application/json" \
      "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
 # Sample rule to enable JSON request body parser for more subtypes.
 # Uncomment or adapt this rule if you want to engage the JSON
 # Processor for "+json" subtypes
 #
-#SecRule REQUEST_HEADERS:Content-Type "^application/.+[+]json$" \
+#SecRule REQUEST_HEADERS:Content-Type "^application/[a-z0-9.-]+[+]json" \
 #     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
 # Maximum request body size we will accept for buffering. If you support


### PR DESCRIPTION
This PR proposes to port [modsecurity.conf-recommended fix](https://github.com/SpiderLabs/ModSecurity/commit/622eb9e6c860ade1e2195d316dfbd86ce5710445) to coraza.conf-recommended.
This fix follows a vulnerability discovered by Terjanq documented [here](https://terjanq.medium.com/waf-bypasses-via-0days-d4ef1f212ec#:~:text=a%20backend%20server.-,XML%20request%20body%20processor,-The%20regular%20expression): regexes for parser activation rules may interpret the content-type differently than the server. It can lead to a complete WAF bypass.

