### PR TITLE
Use slice for collections instead of array

### DIFF
--- a/bodyprocessors/bodyprocessors.go
+++ b/bodyprocessors/bodyprocessors.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 // Options are used by BodyProcessors to provide some settings
@@ -34,8 +33,8 @@ type Options struct {
 // Hook to some variable and return data based on special
 // expressions like XPATH, JQ, etc.
 type BodyProcessor interface {
-	ProcessRequest(reader io.Reader, collection [types.VariablesCount]collection.Collection, options Options) error
-	ProcessResponse(reader io.Reader, collection [types.VariablesCount]collection.Collection, options Options) error
+	ProcessRequest(reader io.Reader, collection []collection.Collection, options Options) error
+	ProcessResponse(reader io.Reader, collection []collection.Collection, options Options) error
 }
 
 type bodyProcessorWrapper = func() BodyProcessor

--- a/bodyprocessors/json.go
+++ b/bodyprocessors/json.go
@@ -9,14 +9,13 @@ import (
 	"strconv"
 
 	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 type jsonBodyProcessor struct {
 }
 
-func (js *jsonBodyProcessor) ProcessRequest(reader io.Reader, collections [types.VariablesCount]collection.Collection, _ Options) error {
+func (js *jsonBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, _ Options) error {
 	col := (collections[variables.ArgsPost]).(*collection.Map)
 	data, err := readJSON(reader)
 	if err != nil {
@@ -35,7 +34,7 @@ func (js *jsonBodyProcessor) ProcessRequest(reader io.Reader, collections [types
 	return nil
 }
 
-func (js *jsonBodyProcessor) ProcessResponse(reader io.Reader, collections [types.VariablesCount]collection.Collection, _ Options) error {
+func (js *jsonBodyProcessor) ProcessResponse(reader io.Reader, collections []collection.Collection, _ Options) error {
 	col := (collections[variables.ResponseArgs]).(*collection.Map)
 	data, err := readJSON(reader)
 	if err != nil {

--- a/bodyprocessors/multipart.go
+++ b/bodyprocessors/multipart.go
@@ -14,14 +14,13 @@ import (
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/environment"
-	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 type multipartBodyProcessor struct {
 }
 
-func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, options Options) error {
 	mimeType := options.Mime
 	storagePath := options.StoragePath
 	mediaType, params, err := mime.ParseMediaType(mimeType)
@@ -95,7 +94,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, collections 
 	return nil
 }
 
-func (mbp *multipartBodyProcessor) ProcessResponse(reader io.Reader, collection [types.VariablesCount]collection.Collection, options Options) error {
+func (mbp *multipartBodyProcessor) ProcessResponse(reader io.Reader, collection []collection.Collection, options Options) error {
 	return nil
 }
 

--- a/bodyprocessors/multipart_test.go
+++ b/bodyprocessors/multipart_test.go
@@ -55,8 +55,8 @@ Content-Type: text/html
 	}
 }
 
-func createCollections() [types.VariablesCount]collection.Collection {
-	collections := [types.VariablesCount]collection.Collection{}
+func createCollections() []collection.Collection {
+	collections := make([]collection.Collection, types.VariablesCount)
 	collections[variables.Files] = collection.NewMap(variables.Files)
 	collections[variables.FilesTmpNames] = collection.NewMap(variables.FilesTmpNames)
 	collections[variables.FilesSizes] = collection.NewMap(variables.FilesSizes)

--- a/bodyprocessors/urlencoded.go
+++ b/bodyprocessors/urlencoded.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/url"
-	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 type urlencodedBodyProcessor struct {
 }
 
-func (*urlencodedBodyProcessor) ProcessRequest(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (*urlencodedBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, options Options) error {
 	buf := new(strings.Builder)
 	if _, err := io.Copy(buf, reader); err != nil {
 		return err
@@ -34,7 +33,7 @@ func (*urlencodedBodyProcessor) ProcessRequest(reader io.Reader, collections [ty
 	return nil
 }
 
-func (*urlencodedBodyProcessor) ProcessResponse(reader io.Reader, collection [types.VariablesCount]collection.Collection, options Options) error {
+func (*urlencodedBodyProcessor) ProcessResponse(reader io.Reader, collection []collection.Collection, options Options) error {
 	return nil
 }
 

--- a/bodyprocessors/urlencoded_test.go
+++ b/bodyprocessors/urlencoded_test.go
@@ -17,11 +17,10 @@ func TestURLEncode(t *testing.T) {
 	argCol := collection.NewMap(variables.ArgsPost)
 	bodyCol := collection.NewSimple(variables.RequestBody)
 	bodyLenCol := collection.NewSimple(variables.RequestBodyLength)
-	cols := [types.VariablesCount]collection.Collection{
-		variables.ArgsPost:          argCol,
-		variables.RequestBody:       bodyCol,
-		variables.RequestBodyLength: bodyLenCol,
-	}
+	cols := make([]collection.Collection, types.VariablesCount)
+	cols[variables.ArgsPost] = argCol
+	cols[variables.RequestBody] = bodyCol
+	cols[variables.RequestBodyLength] = bodyLenCol
 	m := map[string]string{
 		"a": "1",
 		"b": "2",

--- a/bodyprocessors/xml.go
+++ b/bodyprocessors/xml.go
@@ -11,14 +11,13 @@ import (
 	"io"
 
 	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 type xmlBodyProcessor struct {
 }
 
-func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, options Options) error {
 	values, contents, err := readXML(reader)
 	if err != nil {
 		return err
@@ -29,7 +28,7 @@ func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections [types.Var
 	return nil
 }
 
-func (*xmlBodyProcessor) ProcessResponse(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (*xmlBodyProcessor) ProcessResponse(reader io.Reader, collections []collection.Collection, options Options) error {
 
 	return nil
 }

--- a/bodyprocessors/xml_tinygo.go
+++ b/bodyprocessors/xml_tinygo.go
@@ -22,16 +22,15 @@ import (
 	"io"
 
 	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 type xmlBodyProcessor struct{}
 
-func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, options Options) error {
 	return errors.New("not implemented")
 }
 
-func (*xmlBodyProcessor) ProcessResponse(reader io.Reader, collections [types.VariablesCount]collection.Collection, options Options) error {
+func (*xmlBodyProcessor) ProcessResponse(reader io.Reader, collections []collection.Collection, options Options) error {
 	return errors.New("not implemented")
 }
 

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -42,7 +42,7 @@ type Transaction struct {
 	Interruption *types.Interruption
 
 	// Contains all Collections, including persistent
-	Collections [types.VariablesCount]collection.Collection
+	Collections []collection.Collection
 
 	// This is used to store log messages
 	Logdata string

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -191,6 +191,7 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 			TmpPath:     w.TmpDir,
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 		})
+		tx.Collections = make([]collection.Collection, types.VariablesCount)
 		tx.Variables.UrlencodedError = collection.NewSimple(variables.UrlencodedError)
 		tx.Collections[variables.UrlencodedError] = tx.Variables.UrlencodedError
 		tx.Variables.ResponseContentType = collection.NewSimple(variables.ResponseContentType)


### PR DESCRIPTION
Function calls accepting collections as a parameter are copying the entire array each invocation. We had a similar issue in libinjection-go where the array was many many thousands of elements and a huge problem, but 92 is still too big for always being copied on function call. This switches to a slice which is more idiomatic in Go, though in a follow up will look at changing to a struct pointer which should be faster than a slice for fixed content like this. Because collections are pooled since #464 there isn't extra allocation overhead for switching from array to slice