### PR TITLE
Switch from operator Init mutator to operator factory

### DIFF
--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -188,11 +188,6 @@ func (p *RuleParser) ParseOperator(operator string) error {
 		op = op[2:]
 	}
 
-	opfn, err := operators.Get(op)
-	if err != nil {
-		return err
-	}
-
 	opts := rules.OperatorOptions{
 		Arguments: opdata,
 		Path: []string{
@@ -201,7 +196,7 @@ func (p *RuleParser) ParseOperator(operator string) error {
 		},
 		Root: p.options.Config.Get("parser_root", io.OSFS{}).(fs.FS),
 	}
-	err = opfn.Init(opts)
+	opfn, err := operators.Get(op, opts)
 	if err != nil {
 		return err
 	}

--- a/operators/begins_with.go
+++ b/operators/begins_with.go
@@ -16,15 +16,14 @@ type beginsWith struct {
 
 var _ rules.Operator = (*beginsWith)(nil)
 
-func (o *beginsWith) Init(options rules.OperatorOptions) error {
+func newBeginsWith(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &beginsWith{data: m}, nil
 }
 
 func (o *beginsWith) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/contains.go
+++ b/operators/contains.go
@@ -16,15 +16,14 @@ type contains struct {
 
 var _ rules.Operator = (*contains)(nil)
 
-func (o *contains) Init(options rules.OperatorOptions) error {
+func newContains(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &contains{data: m}, nil
 }
 
 func (o *contains) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/detect_sqli.go
+++ b/operators/detect_sqli.go
@@ -11,7 +11,11 @@ import (
 
 type detectSQLi struct{}
 
-func (o *detectSQLi) Init(options rules.OperatorOptions) error { return nil }
+var _ rules.Operator = (*detectSQLi)(nil)
+
+func newDetectSQLi(rules.OperatorOptions) (rules.Operator, error) {
+	return &detectSQLi{}, nil
+}
 
 func (o *detectSQLi) Evaluate(tx rules.TransactionState, value string) bool {
 	res, fingerprint := libinjection.IsSQLi(value)

--- a/operators/detect_xss.go
+++ b/operators/detect_xss.go
@@ -13,7 +13,9 @@ type detectXSS struct{}
 
 var _ rules.Operator = (*detectXSS)(nil)
 
-func (o *detectXSS) Init(rules.OperatorOptions) error { return nil }
+func newDetectXSS(rules.OperatorOptions) (rules.Operator, error) {
+	return &detectXSS{}, nil
+}
 
 func (o *detectXSS) Evaluate(_ rules.TransactionState, value string) bool {
 	return libinjection.IsXSS(value)

--- a/operators/ends_with.go
+++ b/operators/ends_with.go
@@ -16,15 +16,14 @@ type endsWith struct {
 
 var _ rules.Operator = (*endsWith)(nil)
 
-func (o *endsWith) Init(options rules.OperatorOptions) error {
+func newEndsWith(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &endsWith{data: m}, nil
 }
 
 func (o *endsWith) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/eq.go
+++ b/operators/eq.go
@@ -16,15 +16,14 @@ type eq struct {
 
 var _ rules.Operator = (*eq)(nil)
 
-func (o *eq) Init(options rules.OperatorOptions) error {
+func newEq(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &eq{data: m}, nil
 }
 
 func (o *eq) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/ge.go
+++ b/operators/ge.go
@@ -16,15 +16,14 @@ type ge struct {
 
 var _ rules.Operator = (*ge)(nil)
 
-func (o *ge) Init(options rules.OperatorOptions) error {
+func newGE(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &ge{data: m}, nil
 }
 
 func (o *ge) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/geo_lookup.go
+++ b/operators/geo_lookup.go
@@ -7,11 +7,6 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type geoLookup struct{}
-
-var _ rules.Operator = (*geoLookup)(nil)
-
-func (*geoLookup) Init(rules.OperatorOptions) error { return nil }
-
-// kept for compatibility, it requires a plugin.
-func (*geoLookup) Evaluate(rules.TransactionState, string) bool { return true }
+func newGeoLookup(rules.OperatorOptions) (rules.Operator, error) {
+	return &unconditionalMatch{}, nil
+}

--- a/operators/gt.go
+++ b/operators/gt.go
@@ -16,15 +16,14 @@ type gt struct {
 
 var _ rules.Operator = (*gt)(nil)
 
-func (o *gt) Init(options rules.OperatorOptions) error {
+func newGT(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &gt{data: m}, nil
 }
 
 func (o *gt) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/inspect_file.go
+++ b/operators/inspect_file.go
@@ -20,9 +20,8 @@ type inspectFile struct {
 
 var _ rules.Operator = (*inspectFile)(nil)
 
-func (o *inspectFile) Init(options rules.OperatorOptions) error {
-	o.path = options.Arguments
-	return nil
+func newInspectFile(options rules.OperatorOptions) (rules.Operator, error) {
+	return &inspectFile{path: options.Arguments}, nil
 }
 
 func (o *inspectFile) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/inspect_file_test.go
+++ b/operators/inspect_file_test.go
@@ -8,28 +8,38 @@ package operators
 
 import (
 	_ "fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
 func TestInspectFile(t *testing.T) {
-	ipf := &inspectFile{}
-	opts := rules.OperatorOptions{
-		Arguments: "",
+	tests := []struct {
+		path   string
+		exists bool
+	}{
+		{
+			// TODO(anuraaga): Don't have this rely on OS details.
+			path:   "/bin/echo",
+			exists: true,
+		},
+		{
+			path:   filepath.Join(t.TempDir(), "nonexistent.txt"),
+			exists: false,
+		},
 	}
-	opts.Arguments = "/bin/echo"
-	if err := ipf.Init(opts); err != nil {
-		t.Error("cannot init inspectfile operator")
-	}
-	if !ipf.Evaluate(nil, "test") {
-		t.Errorf("/bin/echo returned exit code other than 0")
-	}
-	opts.Arguments = "/bin/nonexistant"
-	if err := ipf.Init(opts); err != nil {
-		t.Error("cannot init inspectfile operator")
-	}
-	if ipf.Evaluate(nil, "test") {
-		t.Errorf("/bin/nonexistant returned an invalid exit code")
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.path, func(t *testing.T) {
+			ipf, err := newInspectFile(rules.OperatorOptions{Arguments: tt.path})
+			if err != nil {
+				t.Error("cannot init inspectfile operator")
+			}
+			if want, have := tt.exists, ipf.Evaluate(nil, ""); want != have {
+				t.Errorf("inspectfile path %s: want %v, have %v", tt.path, want, have)
+			}
+		})
 	}
 }

--- a/operators/inspect_file_tinygo.go
+++ b/operators/inspect_file_tinygo.go
@@ -12,6 +12,6 @@ import (
 
 type inspectFile struct{}
 
-func (*inspectFile) Init(rules.OperatorOptions) error { return nil }
-
-func (*inspectFile) Evaluate(rules.TransactionState, string) bool { return true }
+func newInspectFile(rules.OperatorOptions) (rules.Operator, error) {
+	return &unconditionalMatch{}, nil
+}

--- a/operators/ip_match.go
+++ b/operators/ip_match.go
@@ -11,16 +11,16 @@ import (
 )
 
 type ipMatch struct {
-	subnets []*net.IPNet
+	subnets []net.IPNet
 }
 
 var _ rules.Operator = (*ipMatch)(nil)
 
-func (o *ipMatch) Init(options rules.OperatorOptions) error {
+func newIPMatch(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
-	subnets := strings.Split(data, ",")
-	for _, sb := range subnets {
+	var subnets []net.IPNet
+	for _, sb := range strings.Split(data, ",") {
 		sb = strings.TrimSpace(sb)
 		if sb == "" {
 			continue
@@ -36,9 +36,9 @@ func (o *ipMatch) Init(options rules.OperatorOptions) error {
 		if err != nil {
 			continue
 		}
-		o.subnets = append(o.subnets, subnet)
+		subnets = append(subnets, *subnet)
 	}
-	return nil
+	return &ipMatch{subnets: subnets}, nil
 }
 
 func (o *ipMatch) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/ip_match_from_dataset.go
+++ b/operators/ip_match_from_dataset.go
@@ -10,28 +10,17 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type ipMatchFromDataset struct {
-	matcher *ipMatch
-}
-
-var _ rules.Operator = (*ipMatchFromDataset)(nil)
-
-func (o *ipMatchFromDataset) Init(options rules.OperatorOptions) error {
+func newIPMatchFromDataset(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 	dataset, ok := options.Datasets[data]
 	if !ok || len(dataset) == 0 {
-		return fmt.Errorf("dataset %q not found", data)
+		return nil, fmt.Errorf("dataset %q not found", data)
 	}
 
 	datasetParsed := strings.Join(dataset, ",")
 
-	o.matcher = &ipMatch{}
 	opts := rules.OperatorOptions{
 		Arguments: datasetParsed,
 	}
-	return o.matcher.Init(opts)
-}
-
-func (o *ipMatchFromDataset) Evaluate(tx rules.TransactionState, value string) bool {
-	return o.matcher.Evaluate(tx, value)
+	return newIPMatch(opts)
 }

--- a/operators/ip_match_from_dataset_test.go
+++ b/operators/ip_match_from_dataset_test.go
@@ -14,7 +14,6 @@ func TestIpMatchFromDataset(t *testing.T) {
 	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
 	addrfail := []string{"127.0.0.2", "192.168.1.1"}
 
-	ipm := &ipMatchFromDataset{}
 	opts := rules.OperatorOptions{
 		Arguments: "test_1",
 		Datasets: map[string][]string{
@@ -22,7 +21,8 @@ func TestIpMatchFromDataset(t *testing.T) {
 		},
 	}
 
-	if err := ipm.Init(opts); err != nil {
+	ipm, err := newIPMatchFromDataset(opts)
+	if err != nil {
 		t.Error("Cannot init ipmatchfromfile operator")
 	}
 	for _, ok := range addrok {
@@ -39,14 +39,14 @@ func TestIpMatchFromDataset(t *testing.T) {
 }
 
 func TestIpMatchFromEmptyDataset(t *testing.T) {
-	ipm := &ipMatchFromDataset{}
 	opts := rules.OperatorOptions{
 		Arguments: "test_1",
 		Datasets: map[string][]string{
 			"test_1": {},
 		},
 	}
-	if err := ipm.Init(opts); err == nil {
+	_, err := newIPMatchFromDataset(opts)
+	if err == nil {
 		t.Error("Empty dataset not checked")
 	}
 }

--- a/operators/ip_match_from_file.go
+++ b/operators/ip_match_from_file.go
@@ -11,18 +11,12 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type ipMatchFromFile struct {
-	ipMatcher *ipMatch
-}
-
-var _ rules.Operator = (*ipMatchFromFile)(nil)
-
-func (o *ipMatchFromFile) Init(options rules.OperatorOptions) error {
+func newIPMatchFromFile(options rules.OperatorOptions) (rules.Operator, error) {
 	path := options.Arguments
 
 	data, err := loadFromFile(path, options.Path, options.Root)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	dataParsed := strings.Builder{}
@@ -40,15 +34,8 @@ func (o *ipMatchFromFile) Init(options rules.OperatorOptions) error {
 		dataParsed.WriteString(l)
 	}
 
-	o.ipMatcher = &ipMatch{}
 	opts := rules.OperatorOptions{
 		Arguments: dataParsed.String(),
 	}
-	return o.ipMatcher.Init(opts)
+	return newIPMatch(opts)
 }
-
-func (o *ipMatchFromFile) Evaluate(tx rules.TransactionState, value string) bool {
-	return o.ipMatcher.Evaluate(tx, value)
-}
-
-var _ rules.Operator = (*ipMatchFromFile)(nil)

--- a/operators/ip_match_from_file_test.go
+++ b/operators/ip_match_from_file_test.go
@@ -4,6 +4,7 @@
 package operators
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/io"
@@ -14,13 +15,13 @@ func TestFromFile(t *testing.T) {
 	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
 	addrfail := []string{"127.0.0.2", "192.168.1.1"}
 
-	ipm := &ipMatchFromFile{}
 	opts := rules.OperatorOptions{
-		Arguments: "./testdata/op/netranges.dat",
+		Arguments: filepath.Join("testdata", "op", "netranges.dat"),
 		Path:      []string{"."},
 		Root:      io.OSFS{},
 	}
-	if err := ipm.Init(opts); err != nil {
+	ipm, err := newIPMatchFromFile(opts)
+	if err != nil {
 		t.Error("Cannot init ipmatchfromfile operator")
 	}
 	for _, ok := range addrok {

--- a/operators/ip_match_test.go
+++ b/operators/ip_match_test.go
@@ -14,11 +14,11 @@ func TestOneAddress(t *testing.T) {
 	addrok := "127.0.0.1"
 	addrfail := "127.0.0.2"
 	cidr := "127.0.0.1/32"
-	ipm := &ipMatch{}
 	opts := rules.OperatorOptions{
 		Arguments: cidr,
 	}
-	if err := ipm.Init(opts); err != nil {
+	ipm, err := newIPMatch(opts)
+	if err != nil {
 		t.Error("Cannot init ipmatchtest operator")
 	}
 	if !ipm.Evaluate(nil, addrok) {
@@ -33,11 +33,11 @@ func TestMultipleAddress(t *testing.T) {
 	addrok := []string{"127.0.0.1", "192.168.0.1", "192.168.0.253"}
 	addrfail := []string{"127.0.0.2", "192.168.1.1"}
 	cidr := "127.0.0.1, 192.168.0.0/24"
-	ipm := &ipMatch{}
 	opts := rules.OperatorOptions{
 		Arguments: cidr,
 	}
-	if err := ipm.Init(opts); err != nil {
+	ipm, err := newIPMatch(opts)
+	if err != nil {
 		t.Error("Cannot init ipmatchtest operator")
 	}
 	for _, ok := range addrok {

--- a/operators/le.go
+++ b/operators/le.go
@@ -16,14 +16,13 @@ type le struct {
 
 var _ rules.Operator = (*le)(nil)
 
-func (o *le) Init(options rules.OperatorOptions) error {
+func newLE(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &le{data: m}, nil
 }
 
 func (o *le) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/lt.go
+++ b/operators/lt.go
@@ -16,15 +16,14 @@ type lt struct {
 
 var _ rules.Operator = (*lt)(nil)
 
-func (o *lt) Init(options rules.OperatorOptions) error {
+func newLT(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &lt{data: m}, nil
 }
 
 func (o *lt) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/no_match.go
+++ b/operators/no_match.go
@@ -11,6 +11,8 @@ type noMatch struct{}
 
 var _ rules.Operator = (*noMatch)(nil)
 
-func (*noMatch) Init(options rules.OperatorOptions) error { return nil }
+func newNoMatch(options rules.OperatorOptions) (rules.Operator, error) {
+	return &noMatch{}, nil
+}
 
 func (*noMatch) Evaluate(tx rules.TransactionState, value string) bool { return false }

--- a/operators/operators.go
+++ b/operators/operators.go
@@ -9,50 +9,49 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type operatorsWrapper = func() rules.Operator
-
-var operators = map[string]operatorsWrapper{}
+var operators = map[string]rules.OperatorFactory{}
 
 func init() {
-	Register("beginsWith", func() rules.Operator { return &beginsWith{} })
-	Register("rx", func() rules.Operator { return &rx{} })
-	Register("eq", func() rules.Operator { return &eq{} })
-	Register("contains", func() rules.Operator { return &contains{} })
-	Register("endsWith", func() rules.Operator { return &endsWith{} })
-	Register("inspectFile", func() rules.Operator { return &inspectFile{} })
-	Register("ge", func() rules.Operator { return &ge{} })
-	Register("gt", func() rules.Operator { return &gt{} })
-	Register("le", func() rules.Operator { return &le{} })
-	Register("lt", func() rules.Operator { return &lt{} })
-	Register("unconditionalMatch", func() rules.Operator { return &unconditionalMatch{} })
-	Register("within", func() rules.Operator { return &within{} })
-	Register("pmFromFile", func() rules.Operator { return &pmFromFile{} })
-	Register("pm", func() rules.Operator { return &pm{} })
-	Register("validateByteRange", func() rules.Operator { return &validateByteRange{} })
-	Register("validateUrlEncoding", func() rules.Operator { return &validateURLEncoding{} })
-	Register("streq", func() rules.Operator { return &streq{} })
-	Register("ipMatch", func() rules.Operator { return &ipMatch{} })
-	Register("ipMatchFromFile", func() rules.Operator { return &ipMatchFromFile{} })
-	Register("ipMatchFromDataset", func() rules.Operator { return &ipMatchFromDataset{} })
-	Register("rbl", func() rules.Operator { return &rbl{} })
-	Register("validateUtf8Encoding", func() rules.Operator { return &validateUtf8Encoding{} })
-	Register("noMatch", func() rules.Operator { return &noMatch{} })
-	Register("validateNid", func() rules.Operator { return &validateNid{} })
-	Register("geoLookup", func() rules.Operator { return &geoLookup{} })
-	Register("detectSQLi", func() rules.Operator { return &detectSQLi{} })
-	Register("detectXSS", func() rules.Operator { return &detectXSS{} })
+	Register("beginsWith", newBeginsWith)
+	Register("rx", newRX)
+	Register("eq", newEq)
+	Register("contains", newContains)
+	Register("endsWith", newEndsWith)
+	Register("inspectFile", newInspectFile)
+	Register("ge", newGE)
+	Register("gt", newGT)
+	Register("le", newLE)
+	Register("lt", newLT)
+	Register("unconditionalMatch", newUnconditionalMatch)
+	Register("within", newWithin)
+	Register("pmFromFile", newPMFromFile)
+	Register("pm", newPM)
+	Register("validateByteRange", newValidateByteRange)
+	Register("validateUrlEncoding", newValidateURLEncoding)
+	Register("streq", newStrEq)
+	Register("ipMatch", newIPMatch)
+	Register("ipMatchFromFile", newIPMatchFromFile)
+	Register("ipMatchFromDataset", newIPMatchFromDataset)
+	Register("rbl", newRBL)
+	Register("validateUtf8Encoding", newValidateUTF8Encoding)
+	Register("noMatch", newNoMatch)
+	Register("validateNid", newValidateNID)
+	Register("geoLookup", newGeoLookup)
+	Register("detectSQLi", newDetectSQLi)
+	Register("detectXSS", newDetectXSS)
+	Register("restpath", newRESTPath)
 }
 
 // Get returns an operator by name
-func Get(name string) (rules.Operator, error) {
+func Get(name string, options rules.OperatorOptions) (rules.Operator, error) {
 	if op, ok := operators[name]; ok {
-		return op(), nil
+		return op(options)
 	}
 	return nil, fmt.Errorf("operator %s not found", name)
 }
 
 // Register registers a new operator
 // If the operator already exists it will be overwritten
-func Register(name string, op func() rules.Operator) {
+func Register(name string, op rules.OperatorFactory) {
 	operators[name] = op
 }

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -4,7 +4,6 @@
 package operators
 
 import (
-	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/rules"
 )
 

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -4,6 +4,7 @@
 package operators
 
 import (
+	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -45,6 +46,15 @@ func TestOperators(t *testing.T) {
 		t.Fatalf("failed to walk test files: %s", err.Error())
 	}
 
+	notImplemented := []string{
+		"containsWord",
+		"strmatch",
+		"verifyCC",
+		"verifycpf",
+		"verifyssn",
+		"verifysvnr",
+	}
+
 	captureMatrix := map[string]bool{
 		"with capture":    true,
 		"without capture": false,
@@ -54,8 +64,8 @@ func TestOperators(t *testing.T) {
 	for _, f := range files {
 		cases := unmarshalTests(t, f)
 		for _, data := range cases {
-			if data.Name == "containsWord" {
-				t.Skip("containsWord is not implemented")
+			if utils.InSlice("containsWord", notImplemented) {
+				continue
 			}
 			for capName, capVal := range captureMatrix {
 				t.Run(data.Name+" "+capName, func(t *testing.T) {
@@ -88,6 +98,7 @@ func TestOperators(t *testing.T) {
 					op, err := Get(data.Name, opts)
 					if err != nil {
 						t.Error(err)
+						return
 					}
 					tx := waf.NewTransaction()
 					tx.Capture = capVal

--- a/operators/operators_test.go
+++ b/operators/operators_test.go
@@ -54,6 +54,9 @@ func TestOperators(t *testing.T) {
 	for _, f := range files {
 		cases := unmarshalTests(t, f)
 		for _, data := range cases {
+			if data.Name == "containsWord" {
+				t.Skip("containsWord is not implemented")
+			}
 			for capName, capVal := range captureMatrix {
 				t.Run(data.Name+" "+capName, func(t *testing.T) {
 					// UNMARSHALL does not transform \u0000 to binary
@@ -77,18 +80,13 @@ func TestOperators(t *testing.T) {
 						data.Param = p
 					}
 
-					op, err := Get(data.Name)
-					if err != nil {
-						t.Logf("skipped error: %s", err.Error())
-						return
-					}
-
 					opts := rules.OperatorOptions{
 						Arguments: data.Param,
 						Path:      []string{"op"},
 						Root:      os.DirFS("testdata"),
 					}
-					if err := op.Init(opts); err != nil {
+					op, err := Get(data.Name, opts)
+					if err != nil {
 						t.Error(err)
 					}
 					tx := waf.NewTransaction()

--- a/operators/pm.go
+++ b/operators/pm.go
@@ -20,7 +20,7 @@ type pm struct {
 
 var _ rules.Operator = (*pm)(nil)
 
-func (o *pm) Init(options rules.OperatorOptions) error {
+func newPM(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	data = strings.ToLower(data)
@@ -33,8 +33,7 @@ func (o *pm) Init(options rules.OperatorOptions) error {
 	})
 
 	// TODO this operator is supposed to support snort data syntax: "@pm A|42|C|44|F"
-	o.matcher = builder.Build(dict)
-	return nil
+	return &pm{matcher: builder.Build(dict)}, nil
 }
 
 func (o *pm) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/pm_from_dataset.go
+++ b/operators/pm_from_dataset.go
@@ -11,20 +11,11 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-// TODO according to coraza researchs, re2 matching is faster than ahocorasick
-// maybe we should switch in the future
-// pmFromDataset is always lowercase
-type pmFromDataset struct {
-	matcher ahocorasick.AhoCorasick
-}
-
-var _ rules.Operator = (*pmFromDataset)(nil)
-
-func (o *pmFromDataset) Init(options rules.OperatorOptions) error {
+func newPMFromDataset(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 	dataset, ok := options.Datasets[data]
 	if !ok {
-		return fmt.Errorf("dataset %q not found", data)
+		return nil, fmt.Errorf("dataset %q not found", data)
 	}
 	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
 		AsciiCaseInsensitive: true,
@@ -33,10 +24,5 @@ func (o *pmFromDataset) Init(options rules.OperatorOptions) error {
 		DFA:                  true,
 	})
 
-	o.matcher = builder.Build(dataset)
-	return nil
-}
-
-func (o *pmFromDataset) Evaluate(tx rules.TransactionState, value string) bool {
-	return pmEvaluate(o.matcher, tx, value)
+	return &pm{matcher: builder.Build(dataset)}, nil
 }

--- a/operators/pm_from_dataset_test.go
+++ b/operators/pm_from_dataset_test.go
@@ -12,15 +12,14 @@ import (
 )
 
 func TestPmFromDataset(t *testing.T) {
-	pm := &pmFromDataset{}
 	opts := rules.OperatorOptions{
 		Arguments: "test_1",
 		Datasets: map[string][]string{
 			"test_1": {"test_1", "test_2"},
 		},
 	}
-
-	if err := pm.Init(opts); err != nil {
+	pm, err := newPMFromDataset(opts)
+	if err != nil {
 		t.Error(err)
 	}
 	waf := corazawaf.NewWAF()
@@ -31,7 +30,8 @@ func TestPmFromDataset(t *testing.T) {
 		t.Error("pmFromDataset failed")
 	}
 	opts.Datasets = map[string][]string{}
-	if err := pm.Init(opts); err == nil {
+
+	if _, err = newPMFromDataset(opts); err == nil {
 		t.Error(fmt.Errorf("pmFromDataset should have failed"))
 	}
 }

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -13,18 +13,12 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type pmFromFile struct {
-	matcher ahocorasick.AhoCorasick
-}
-
-var _ rules.Operator = (*pmFromFile)(nil)
-
-func (o *pmFromFile) Init(options rules.OperatorOptions) error {
+func newPMFromFile(options rules.OperatorOptions) (rules.Operator, error) {
 	path := options.Arguments
 
 	data, err := loadFromFile(path, options.Path, options.Root)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var lines []string
@@ -48,10 +42,5 @@ func (o *pmFromFile) Init(options rules.OperatorOptions) error {
 		DFA:                  false,
 	})
 
-	o.matcher = builder.Build(lines)
-	return nil
-}
-
-func (o *pmFromFile) Evaluate(tx rules.TransactionState, value string) bool {
-	return pmEvaluate(o.matcher, tx, value)
+	return &pm{matcher: builder.Build(lines)}, nil
 }

--- a/operators/rbl.go
+++ b/operators/rbl.go
@@ -24,13 +24,13 @@ type rbl struct {
 
 var _ rules.Operator = (*rbl)(nil)
 
-func (o *rbl) Init(options rules.OperatorOptions) error {
+func newRBL(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
-	o.service = data
-	o.resolver = net.DefaultResolver
-	// TODO validate hostname
-	return nil
+	return &rbl{
+		service:  data,
+		resolver: net.DefaultResolver,
+	}, nil
 }
 
 // https://github.com/mrichman/godnsbl

--- a/operators/rbl_tinygo.go
+++ b/operators/rbl_tinygo.go
@@ -10,8 +10,6 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-type rbl struct{}
-
-func (o *rbl) Init(_ rules.OperatorOptions) error { return nil }
-
-func (o *rbl) Evaluate(_ rules.TransactionState, _ string) bool { return true }
+func newRBL(rules.OperatorOptions) (rules.Operator, error) {
+	return &unconditionalMatch{}, nil
+}

--- a/operators/restpath.go
+++ b/operators/restpath.go
@@ -23,14 +23,16 @@ type restpath struct {
 
 var _ rules.Operator = (*restpath)(nil)
 
-func (o *restpath) Init(options rules.OperatorOptions) error {
+func newRESTPath(options rules.OperatorOptions) (rules.Operator, error) {
 	data := strings.ReplaceAll(options.Arguments, "/", "\\/")
 	for _, token := range rePathTokenRe.FindAllStringSubmatch(data, -1) {
 		data = strings.Replace(data, token[0], fmt.Sprintf("(?P<%s>.*)", token[1]), 1)
 	}
 	re, err := regexp.Compile(data)
-	o.re = re
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &restpath{re: re}, nil
 }
 
 func (o *restpath) Evaluate(tx rules.TransactionState, value string) bool {
@@ -46,10 +48,4 @@ func (o *restpath) Evaluate(tx rules.TransactionState, value string) bool {
 		}
 	}
 	return true
-}
-
-func init() {
-	Register("restpath", func() rules.Operator {
-		return &restpath{}
-	})
 }

--- a/operators/restpath_test.go
+++ b/operators/restpath_test.go
@@ -15,10 +15,10 @@ func TestRestPath(t *testing.T) {
 	tx := waf.NewTransaction()
 	exp := "/some-random/url-{id}/{name}"
 	path := "/some-random/url-123/juan"
-	rp := restpath{}
-	if err := rp.Init(rules.OperatorOptions{
+	rp, err := newRESTPath(rules.OperatorOptions{
 		Arguments: exp,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Error(err)
 	}
 	if !rp.Evaluate(tx, path) {

--- a/operators/rx.go
+++ b/operators/rx.go
@@ -15,12 +15,14 @@ type rx struct {
 
 var _ rules.Operator = (*rx)(nil)
 
-func (o *rx) Init(options rules.OperatorOptions) error {
+func newRX(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	re, err := regexp.Compile(data)
-	o.re = re
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &rx{re: re}, nil
 }
 
 func (o *rx) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/rx_test.go
+++ b/operators/rx_test.go
@@ -43,11 +43,11 @@ func TestRx(t *testing.T) {
 		tt := tc
 		t.Run(fmt.Sprintf("%s/%s", tt.pattern, tt.input), func(t *testing.T) {
 
-			rx := &rx{}
 			opts := rules.OperatorOptions{
 				Arguments: tt.pattern,
 			}
-			if err := rx.Init(opts); err != nil {
+			rx, err := newRX(opts)
+			if err != nil {
 				t.Error(err)
 			}
 			waf := corazawaf.NewWAF()

--- a/operators/streq.go
+++ b/operators/streq.go
@@ -12,15 +12,14 @@ type streq struct {
 	data macro.Macro
 }
 
-func (o *streq) Init(options rules.OperatorOptions) error {
+func newStrEq(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &streq{data: m}, nil
 }
 
 func (o *streq) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/unconditional_match.go
+++ b/operators/unconditional_match.go
@@ -9,6 +9,8 @@ import (
 
 type unconditionalMatch struct{}
 
-func (*unconditionalMatch) Init(rules.OperatorOptions) error { return nil }
+func newUnconditionalMatch(rules.OperatorOptions) (rules.Operator, error) {
+	return &unconditionalMatch{}, nil
+}
 
 func (*unconditionalMatch) Evaluate(rules.TransactionState, string) bool { return true }

--- a/operators/validate_byte_range_test.go
+++ b/operators/validate_byte_range_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestValidateByteRangeCase4(t *testing.T) {
 	ranges := "0-255"
-	op := &validateByteRange{}
 	opts := rules.OperatorOptions{
 		Arguments: ranges,
 	}
-	if err := op.Init(opts); err != nil {
+	op, err := newValidateByteRange(opts)
+	if err != nil {
 		t.Error("Cannot init byte range operator")
 	}
 	tx := getTransaction()
@@ -27,16 +27,12 @@ func TestValidateByteRangeCase4(t *testing.T) {
 
 func TestValidateByteRangeCase5(t *testing.T) {
 	ranges := "9,10,13,32-126,128-255"
-	op := &validateByteRange{}
 	opts := rules.OperatorOptions{
 		Arguments: ranges,
 	}
-	if err := op.Init(opts); err != nil {
+	op, err := newValidateByteRange(opts)
+	if err != nil {
 		t.Error("Cannot init byte range operator")
-	}
-	if len(op.data) != 5 || op.data[0].start != 9 || op.data[1].start != 10 || op.data[2].start != 13 || op.data[3].start != 32 ||
-		op.data[3].end != 126 || op.data[4].start != 128 || op.data[4].end != 255 {
-		t.Error("Invalid range length", len(op.data))
 	}
 	if op.Evaluate(nil, "/\ufffdindex.html?test=test1") {
 		t.Error("Invalid byte between ranges (negative)", []byte("/\ufffdindex.html?test=test1"))
@@ -50,11 +46,11 @@ func getTransaction() *corazawaf.Transaction {
 
 func BenchmarkValidateByteRange(b *testing.B) {
 	ranges := "9,10,13,32-126,128-255"
-	op := &validateByteRange{}
 	opts := rules.OperatorOptions{
 		Arguments: ranges,
 	}
-	if err := op.Init(opts); err != nil {
+	op, err := newValidateByteRange(opts)
+	if err != nil {
 		b.Error("Cannot init byte range operator")
 	}
 	b.ResetTimer()

--- a/operators/validate_nid.go
+++ b/operators/validate_nid.go
@@ -21,27 +21,27 @@ type validateNid struct {
 
 var _ rules.Operator = (*validateNid)(nil)
 
-func (o *validateNid) Init(options rules.OperatorOptions) error {
+func newValidateNID(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	spl := strings.SplitN(data, " ", 2)
 	if len(spl) != 2 {
-		return fmt.Errorf("invalid @validateNid argument")
+		return nil, fmt.Errorf("invalid @validateNid argument")
 	}
+	var fn validateNidFunction
 	switch spl[0] {
 	case "cl":
-		o.fn = nidCl
+		fn = nidCl
 	case "us":
-		o.fn = nidUs
+		fn = nidUs
 	default:
-		return fmt.Errorf("invalid @validateNid argument")
+		return nil, fmt.Errorf("invalid @validateNid argument")
 	}
 	re, err := regexp.Compile(spl[1])
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.re = re
-	return err
+	return &validateNid{fn: fn, re: re}, nil
 }
 
 func (o *validateNid) Evaluate(tx rules.TransactionState, value string) bool {

--- a/operators/validate_nid_test.go
+++ b/operators/validate_nid_test.go
@@ -10,13 +10,12 @@ import (
 )
 
 func TestVaildateNid(t *testing.T) {
-	vn := &validateNid{}
 	notOk := []string{"cl11.111.111-1", "us16100407-2", "clc 12345", "uss 1234567"}
 	for _, no := range notOk {
 		opts := rules.OperatorOptions{
 			Arguments: no,
 		}
-		err := vn.Init(opts)
+		_, err := newValidateNID(opts)
 		if err == nil {
 			t.Errorf("Wrong valid data for %s", no)
 		}

--- a/operators/validate_url_encoding.go
+++ b/operators/validate_url_encoding.go
@@ -11,7 +11,9 @@ type validateURLEncoding struct{}
 
 var _ rules.Operator = (*validateURLEncoding)(nil)
 
-func (o *validateURLEncoding) Init(rules.OperatorOptions) error { return nil }
+func newValidateURLEncoding(rules.OperatorOptions) (rules.Operator, error) {
+	return &validateURLEncoding{}, nil
+}
 
 func (o *validateURLEncoding) Evaluate(_ rules.TransactionState, value string) bool {
 	if len(value) == 0 {

--- a/operators/validate_utf8_encoding.go
+++ b/operators/validate_utf8_encoding.go
@@ -13,7 +13,9 @@ type validateUtf8Encoding struct{}
 
 var _ rules.Operator = (*validateUtf8Encoding)(nil)
 
-func (o *validateUtf8Encoding) Init(rules.OperatorOptions) error { return nil }
+func newValidateUTF8Encoding(rules.OperatorOptions) (rules.Operator, error) {
+	return &validateUtf8Encoding{}, nil
+}
 
 func (o *validateUtf8Encoding) Evaluate(_ rules.TransactionState, value string) bool {
 	return !utf8.ValidString(value)

--- a/operators/within.go
+++ b/operators/within.go
@@ -14,15 +14,14 @@ type within struct {
 	data macro.Macro
 }
 
-func (o *within) Init(options rules.OperatorOptions) error {
+func newWithin(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
 
 	m, err := macro.NewMacro(data)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	o.data = m
-	return nil
+	return &within{data: m}, nil
 }
 
 func (o *within) Evaluate(tx rules.TransactionState, value string) bool {

--- a/rules/operator.go
+++ b/rules/operator.go
@@ -22,11 +22,10 @@ type OperatorOptions struct {
 
 // Operator interface is used to define rule @operators
 type Operator interface {
-	// Init is used during compilation to setup and cache
-	// the operator
-	Init(OperatorOptions) error
 	// Evaluate is used during the rule evaluation,
 	// it returns true if the operator succeeded against
 	// the input data for the transaction
 	Evaluate(TransactionState, string) bool
 }
+
+type OperatorFactory func(options OperatorOptions) (Operator, error)


### PR DESCRIPTION
Operators are instantiated and then immediately invoke `Init` with options - it is easier to reason about if we instead use an operator factory that accepts the options when instantiating. Notably, operators can be immutable, and we don't need types for same-operator, different options format pattern