### PR TITLE
Initialize operators in each file and add build tags for excluding them

### DIFF
--- a/operators/begins_with.go
+++ b/operators/begins_with.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.beginsWith
+
 package operators
 
 import (
@@ -29,4 +31,8 @@ func newBeginsWith(options rules.OperatorOptions) (rules.Operator, error) {
 func (o *beginsWith) Evaluate(tx rules.TransactionState, value string) bool {
 	data := o.data.Expand(tx)
 	return strings.HasPrefix(value, data)
+}
+
+func init() {
+	Register("beginsWith", newBeginsWith)
 }

--- a/operators/contains.go
+++ b/operators/contains.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.contains
+
 package operators
 
 import (
@@ -29,4 +31,8 @@ func newContains(options rules.OperatorOptions) (rules.Operator, error) {
 func (o *contains) Evaluate(tx rules.TransactionState, value string) bool {
 	data := o.data.Expand(tx)
 	return strings.Contains(value, data)
+}
+
+func init() {
+	Register("contains", newContains)
 }

--- a/operators/detect_sqli.go
+++ b/operators/detect_sqli.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.detectSQLi
+
 package operators
 
 import (
@@ -24,4 +26,8 @@ func (o *detectSQLi) Evaluate(tx rules.TransactionState, value string) bool {
 	}
 	tx.CaptureField(0, string(fingerprint))
 	return true
+}
+
+func init() {
+	Register("detectSQLi", newDetectSQLi)
 }

--- a/operators/detect_xss.go
+++ b/operators/detect_xss.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.detectXSS
+
 package operators
 
 import (
@@ -19,4 +21,8 @@ func newDetectXSS(rules.OperatorOptions) (rules.Operator, error) {
 
 func (o *detectXSS) Evaluate(_ rules.TransactionState, value string) bool {
 	return libinjection.IsXSS(value)
+}
+
+func init() {
+	Register("detectXSS", newDetectXSS)
 }

--- a/operators/ends_with.go
+++ b/operators/ends_with.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.endsWith
+
 package operators
 
 import (
@@ -29,4 +31,8 @@ func newEndsWith(options rules.OperatorOptions) (rules.Operator, error) {
 func (o *endsWith) Evaluate(tx rules.TransactionState, value string) bool {
 	data := o.data.Expand(tx)
 	return strings.HasSuffix(value, data)
+}
+
+func init() {
+	Register("endsWith", newEndsWith)
 }

--- a/operators/eq.go
+++ b/operators/eq.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.eq
+
 package operators
 
 import (
@@ -30,4 +32,8 @@ func (o *eq) Evaluate(tx rules.TransactionState, value string) bool {
 	d1, _ := strconv.Atoi(o.data.Expand(tx))
 	d2, _ := strconv.Atoi(value)
 	return d1 == d2
+}
+
+func init() {
+	Register("eq", newEq)
 }

--- a/operators/ge.go
+++ b/operators/ge.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.ge
+
 package operators
 
 import (
@@ -30,4 +32,8 @@ func (o *ge) Evaluate(tx rules.TransactionState, value string) bool {
 	v, _ := strconv.Atoi(value)
 	data, _ := strconv.Atoi(o.data.Expand(tx))
 	return v >= data
+}
+
+func init() {
+	Register("ge", newGE)
 }

--- a/operators/geo_lookup.go
+++ b/operators/geo_lookup.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.geoLookup
+
 package operators
 
 import (
@@ -9,4 +11,8 @@ import (
 
 func newGeoLookup(rules.OperatorOptions) (rules.Operator, error) {
 	return &unconditionalMatch{}, nil
+}
+
+func init() {
+	Register("geoLookup", newGeoLookup)
 }

--- a/operators/gt.go
+++ b/operators/gt.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.gt
+
 package operators
 
 import (
@@ -30,4 +32,8 @@ func (o *gt) Evaluate(tx rules.TransactionState, value string) bool {
 	v, _ := strconv.Atoi(value)
 	k, _ := strconv.Atoi(o.data.Expand(tx))
 	return k < v
+}
+
+func init() {
+	Register("gt", newGT)
 }

--- a/operators/inspect_file.go
+++ b/operators/inspect_file.go
@@ -1,8 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !tinygo
-// +build !tinygo
+//go:build !tinygo && !coraza.disabled_operators.inspectFile
+// +build !tinygo,!coraza.disabled_operators.inspectFile
 
 package operators
 
@@ -37,4 +37,8 @@ func (o *inspectFile) Evaluate(tx rules.TransactionState, value string) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	Register("inspectFile", newInspectFile)
 }

--- a/operators/inspect_file_tinygo.go
+++ b/operators/inspect_file_tinygo.go
@@ -15,3 +15,7 @@ type inspectFile struct{}
 func newInspectFile(rules.OperatorOptions) (rules.Operator, error) {
 	return &unconditionalMatch{}, nil
 }
+
+func init() {
+	Register("inspectFile", newInspectFile)
+}

--- a/operators/ip_match.go
+++ b/operators/ip_match.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.ipMatch
+
 package operators
 
 import (
@@ -49,4 +51,8 @@ func (o *ipMatch) Evaluate(tx rules.TransactionState, value string) bool {
 		}
 	}
 	return false
+}
+
+func init() {
+	Register("ipMatch", newIPMatch)
 }

--- a/operators/ip_match_from_dataset.go
+++ b/operators/ip_match_from_dataset.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.ipMatchFromDataset
+
 package operators
 
 import (
@@ -23,4 +25,8 @@ func newIPMatchFromDataset(options rules.OperatorOptions) (rules.Operator, error
 		Arguments: datasetParsed,
 	}
 	return newIPMatch(opts)
+}
+
+func init() {
+	Register("ipMatchFromDataset", newIPMatchFromDataset)
 }

--- a/operators/ip_match_from_file.go
+++ b/operators/ip_match_from_file.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.ipMatchFromFile
+
 package operators
 
 import (
@@ -38,4 +40,8 @@ func newIPMatchFromFile(options rules.OperatorOptions) (rules.Operator, error) {
 		Arguments: dataParsed.String(),
 	}
 	return newIPMatch(opts)
+}
+
+func init() {
+	Register("ipMatchFromFile", newIPMatchFromFile)
 }

--- a/operators/le.go
+++ b/operators/le.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.le
+
 package operators
 
 import (
@@ -29,4 +31,8 @@ func (o *le) Evaluate(tx rules.TransactionState, value string) bool {
 	d, _ := strconv.Atoi(o.data.Expand(tx))
 	v, _ := strconv.Atoi(value)
 	return v <= d
+}
+
+func init() {
+	Register("le", newLE)
 }

--- a/operators/lt.go
+++ b/operators/lt.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.lt
+
 package operators
 
 import (
@@ -31,4 +33,8 @@ func (o *lt) Evaluate(tx rules.TransactionState, value string) bool {
 	data, _ := strconv.Atoi(vv)
 	v, _ := strconv.Atoi(value)
 	return v < data
+}
+
+func init() {
+	Register("lt", newLT)
 }

--- a/operators/no_match.go
+++ b/operators/no_match.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.noMatch
+
 package operators
 
 import (
@@ -16,3 +18,7 @@ func newNoMatch(options rules.OperatorOptions) (rules.Operator, error) {
 }
 
 func (*noMatch) Evaluate(tx rules.TransactionState, value string) bool { return false }
+
+func init() {
+	Register("noMatch", newNoMatch)
+}

--- a/operators/operators.go
+++ b/operators/operators.go
@@ -11,37 +11,6 @@ import (
 
 var operators = map[string]rules.OperatorFactory{}
 
-func init() {
-	Register("beginsWith", newBeginsWith)
-	Register("rx", newRX)
-	Register("eq", newEq)
-	Register("contains", newContains)
-	Register("endsWith", newEndsWith)
-	Register("inspectFile", newInspectFile)
-	Register("ge", newGE)
-	Register("gt", newGT)
-	Register("le", newLE)
-	Register("lt", newLT)
-	Register("unconditionalMatch", newUnconditionalMatch)
-	Register("within", newWithin)
-	Register("pmFromFile", newPMFromFile)
-	Register("pm", newPM)
-	Register("validateByteRange", newValidateByteRange)
-	Register("validateUrlEncoding", newValidateURLEncoding)
-	Register("streq", newStrEq)
-	Register("ipMatch", newIPMatch)
-	Register("ipMatchFromFile", newIPMatchFromFile)
-	Register("ipMatchFromDataset", newIPMatchFromDataset)
-	Register("rbl", newRBL)
-	Register("validateUtf8Encoding", newValidateUTF8Encoding)
-	Register("noMatch", newNoMatch)
-	Register("validateNid", newValidateNID)
-	Register("geoLookup", newGeoLookup)
-	Register("detectSQLi", newDetectSQLi)
-	Register("detectXSS", newDetectXSS)
-	Register("restpath", newRESTPath)
-}
-
 // Get returns an operator by name
 func Get(name string, options rules.OperatorOptions) (rules.Operator, error) {
 	if op, ok := operators[name]; ok {

--- a/operators/pm.go
+++ b/operators/pm.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.pm
+
 package operators
 
 import (
@@ -64,4 +66,8 @@ func pmEvaluate(matcher ahocorasick.AhoCorasick, tx rules.TransactionState, valu
 	}
 
 	return numMatches > 0
+}
+
+func init() {
+	Register("pm", newPM)
 }

--- a/operators/pm_from_dataset.go
+++ b/operators/pm_from_dataset.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.pmFromDataset
+
 package operators
 
 import (

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.pmFromFile
+
 package operators
 
 import (
@@ -43,4 +45,8 @@ func newPMFromFile(options rules.OperatorOptions) (rules.Operator, error) {
 	})
 
 	return &pm{matcher: builder.Build(lines)}, nil
+}
+
+func init() {
+	Register("pmFromFile", newPMFromFile)
 }

--- a/operators/rbl.go
+++ b/operators/rbl.go
@@ -1,8 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !tinygo
-// +build !tinygo
+//go:build !tinygo && !coraza.disabled_operators.rbl
+// +build !tinygo,!coraza.disabled_operators.rbl
 
 package operators
 
@@ -83,4 +83,8 @@ func (o *rbl) Evaluate(tx rules.TransactionState, ipAddr string) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+func init() {
+	Register("rbl", newRBL)
 }

--- a/operators/rbl_tinygo.go
+++ b/operators/rbl_tinygo.go
@@ -13,3 +13,7 @@ import (
 func newRBL(rules.OperatorOptions) (rules.Operator, error) {
 	return &unconditionalMatch{}, nil
 }
+
+func init() {
+	Register("rbl", newRBL)
+}

--- a/operators/restpath.go
+++ b/operators/restpath.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.restpath
+
 package operators
 
 import (
@@ -48,4 +50,8 @@ func (o *restpath) Evaluate(tx rules.TransactionState, value string) bool {
 		}
 	}
 	return true
+}
+
+func init() {
+	Register("restpath", newRESTPath)
 }

--- a/operators/rx.go
+++ b/operators/rx.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.rx
+
 package operators
 
 import (
@@ -41,4 +43,8 @@ func (o *rx) Evaluate(tx rules.TransactionState, value string) bool {
 	}
 
 	return true
+}
+
+func init() {
+	Register("rx", newRX)
 }

--- a/operators/streq.go
+++ b/operators/streq.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.streq
+
 package operators
 
 import (
@@ -25,4 +27,8 @@ func newStrEq(options rules.OperatorOptions) (rules.Operator, error) {
 func (o *streq) Evaluate(tx rules.TransactionState, value string) bool {
 	data := o.data.Expand(tx)
 	return data == value
+}
+
+func init() {
+	Register("streq", newStrEq)
 }

--- a/operators/unconditional_match.go
+++ b/operators/unconditional_match.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.unconditionalMatch
+
 package operators
 
 import (
@@ -14,3 +16,7 @@ func newUnconditionalMatch(rules.OperatorOptions) (rules.Operator, error) {
 }
 
 func (*unconditionalMatch) Evaluate(rules.TransactionState, string) bool { return true }
+
+func init() {
+	Register("unconditionalMatch", newUnconditionalMatch)
+}

--- a/operators/validate_byte_range.go
+++ b/operators/validate_byte_range.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.validateByteRange
+
 package operators
 
 import (
@@ -95,4 +97,8 @@ func addRange(ranges []byteRange, start uint64, end uint64) ([]byteRange, error)
 		start: byte(start),
 		end:   byte(end),
 	}), nil
+}
+
+func init() {
+	Register("validateByteRange", newValidateByteRange)
 }

--- a/operators/validate_nid.go
+++ b/operators/validate_nid.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.validateNid
+
 package operators
 
 import (
@@ -136,3 +138,7 @@ var (
 	_ validateNidFunction = nidCl
 	_ validateNidFunction = nidUs
 )
+
+func init() {
+	Register("validateNid", newValidateNID)
+}

--- a/operators/validate_url_encoding.go
+++ b/operators/validate_url_encoding.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.validateUrlEncoding
+
 package operators
 
 import (
@@ -69,4 +71,8 @@ func validateURLEncodingInternal(input string, inputLen int) int {
 		}
 	}
 	return 1
+}
+
+func init() {
+	Register("validateUrlEncoding", newValidateURLEncoding)
 }

--- a/operators/validate_utf8_encoding.go
+++ b/operators/validate_utf8_encoding.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.validateUtf8Encoding
+
 package operators
 
 import (
@@ -19,4 +21,8 @@ func newValidateUTF8Encoding(rules.OperatorOptions) (rules.Operator, error) {
 
 func (o *validateUtf8Encoding) Evaluate(_ rules.TransactionState, value string) bool {
 	return !utf8.ValidString(value)
+}
+
+func init() {
+	Register("validateUtf8Encoding", newValidateUTF8Encoding)
 }

--- a/operators/within.go
+++ b/operators/within.go
@@ -1,6 +1,8 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !coraza.disabled_operators.within
+
 package operators
 
 import (
@@ -27,4 +29,8 @@ func newWithin(options rules.OperatorOptions) (rules.Operator, error) {
 func (o *within) Evaluate(tx rules.TransactionState, value string) bool {
 	data := o.data.Expand(tx)
 	return strings.Contains(data, value)
+}
+
+func init() {
+	Register("within", newWithin)
 }


### PR DESCRIPTION
We allow users to replace the implementation of operators, and take advantage of this heavily in `coraza-proxy-wasm` to optimize `rx`, `pm`, and libinjection. Unfortunately, all the replaced code still gets compiled into the binary with no alternative since the code for registration does get executed, then replaced. Providing build tags can allow excluding these along with their dependencies.

When trying this with `coraza-proxy-wasm`, the binary goes from 8.5MB to 8MB. It's a relatively significant savings for literal no-op code, but it's also not a huge deal so happy to abandon this if it seems like too much complexity. Or also could consider a compromise of only adding the build tag to those specific operators.