### PR TITLE
Fix: adds http-server and coreruleset tests to coverage command, enabling them in CI

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -86,6 +86,12 @@ func Coverage() error {
 	if err := sh.RunV("go", "test", "-race", "-coverprofile=build/coverage.txt", "-covermode=atomic", "-coverpkg=./...", "./..."); err != nil {
 		return err
 	}
+	if err := sh.RunV("go", "test", "-race", "-coverprofile=build/coverage.txt", "-covermode=atomic", "-coverpkg=./...", "./examples/http-server"); err != nil {
+		return err
+	}
+	if err := sh.RunV("go", "test", "-coverprofile=build/coverage.txt", "-covermode=atomic", "-coverpkg=./...", "./testing/coreruleset"); err != nil {
+		return err
+	}
 	// This is not actually running tests with tinygo, but with the tag that includes its code so we can calculate coverage
 	// for it.
 	if err := sh.RunV("go", "test", "-race", "-tags=tinygo", "-coverprofile=build/coverage-tinygo.txt", "-covermode=atomic", "-coverpkg=./...", "./..."); err != nil {


### PR DESCRIPTION
Newly introduced tests about the example HTTP server and CRS are only executed by running `mage test`, not `mage coverage`. It leads to not actually running these tests inside the CI (example of green CI with a broken commit test [here](https://github.com/corazawaf/coraza/actions/runs/3384997844/jobs/5622631559)).

This PR proposes to add them also in the `coverage` command.

For `/testing/coreruleset` I had to remove the `-race` flag because it was leading to fail the test with the following error:
```
{"level":"fatal","caller":"/Users/user/go/pkg/mod/github.com/coreruleset/go-ftw@v0.4.0/runner/run.go:144","error":"read tcp 127.0.0.1:65384->127.0.0.1:59909: i/o timeout","time":"2022-11-03T12:48:58+01:00","message":"failed sending request to destination &{DestAddr:127.0.0.1 Port:59909 Protocol:http}"}
```