### PR TITLE
Fix CRS Regression tests - Go 1.18

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -51,7 +51,7 @@ jobs:
           files: build/coverage-tinygo.txt
           flags: tinygo
       - name: SonarCloud Scan
-        if: ${{ matrix.go-version == '1.17.x' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ matrix.go-version == '1.19.x' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -19,11 +19,13 @@ import (
 
 // Backport to Go 1.18 implementation of WriterTo in ReadCloser if readers have it.
 // Ref: https://github.com/golang/go/blob/master/src/io/io.go#L665
-type nopCloserWriterTo struct{ io.Reader }
+type nopCloser struct{}
 
-func (nopCloserWriterTo) Close() error { return nil }
-func (c nopCloserWriterTo) WriteTo(w io.Writer) (n int64, err error) {
-	return c.Reader.(io.WriterTo).WriteTo(w)
+func (nopCloser) Close() error { return nil }
+
+type readWriterTo interface {
+	io.Reader
+	io.WriterTo
 }
 
 // processRequest fills all transaction variables from an http.Request object
@@ -66,23 +68,28 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		if err != nil {
 			return tx.Interruption(), err
 		}
+		_ = req.Body.Close()
+
 		reader, err := tx.RequestBodyReader()
 		if err != nil {
 			return tx.Interruption(), err
 		}
 		// req.Body is transparently reinizialied with a new io.ReadCloser.
-		// The http handler will be able to read it
-		req.Body = io.NopCloser(reader)
-
+		// The http handler will be able to read it.
 		// Prior to Go 1.19 NopCloser does not implement WriterTo if the reader implements it.
 		// Ref: https://github.com/golang/go/issues/51566
 		// Ref: https://tip.golang.org/doc/go1.19#minor_library_changes
 		// Checking if it is not implemented (Go<1.19 or reader does not have it)
-		if _, ok := req.Body.(io.WriterTo); !ok {
-			// Checking if reader implements WriterTo
-			if _, ok := reader.(io.WriterTo); ok {
-				req.Body = nopCloserWriterTo{reader}
-			}
+		if wtr, ok := reader.(readWriterTo); ok {
+			req.Body = struct {
+				readWriterTo
+				io.Closer
+			}{wtr, nopCloser{}}
+		} else {
+			req.Body = struct {
+				io.Reader
+				io.Closer
+			}{reader, nopCloser{}}
 		}
 	}
 

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -74,6 +74,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// - https://tip.golang.org/doc/go1.19#minor_library_changes
 		// This avoid errors like "failed to process request: malformed chunked encoding" when
 		// using io.Copy
+                 // In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
 		if rwt, ok := reader.(io.WriterTo); ok {
 			req.Body = struct {
 				io.Reader

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -74,7 +74,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// - https://tip.golang.org/doc/go1.19#minor_library_changes
 		// This avoid errors like "failed to process request: malformed chunked encoding" when
 		// using io.Copy
-                 // In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
+                // In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
 		if rwt, ok := reader.(io.WriterTo); ok {
 			req.Body = struct {
 				io.Reader

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -74,7 +74,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// - https://tip.golang.org/doc/go1.19#minor_library_changes
 		// This avoid errors like "failed to process request: malformed chunked encoding" when
 		// using io.Copy
-                // In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
+		// In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
 		if rwt, ok := reader.(io.WriterTo); ok {
 			req.Body = struct {
 				io.Reader


### PR DESCRIPTION
## Context of the problem
CRS-related unit tests have been just added to the CI yesterday with https://github.com/corazawaf/coraza/pull/492.
Therefore, the PR  https://github.com/corazawaf/coraza/pull/483 just merged today related to CRS response body tests has not been checked by the CI, but only locally (where I'm currently running Go 1.19).

Inside the middleware, in order to make the request body readable again, we rely on `req.Body = io.NopCloser(reader)`.
In Go 1.18, unlike Go 1.19, `io.NopCloser` does not also implement `WriterTo` whenever its input does ([Ref](https://tip.golang.org/doc/go1.19#minor_library_changes)). This method is internally called by the Handler inside the test to echo the request body into the response body triggering CRS response body tests.

## Fix
This PR proposes to backport the new logic introduced in 1.19 to the middleware. It is going to be executed only by Go 1.18 and as soon as we move over from Go 1.18 we will be able to wipe the tweak off.

Please, join the conversation if you feel there are better ways to make the tweak! 🙏