### PR TITLE
Export Request/Response BodyAccess values

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -939,6 +939,16 @@ func (tx *Transaction) ProcessLogging() {
 	}
 }
 
+// RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
+func (tx *Transaction) RequestBodyAccessible() bool {
+	return tx.RequestBodyAccess
+}
+
+// ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
+func (tx *Transaction) ResponseBodyAccessible() bool {
+	return tx.ResponseBodyAccess
+}
+
 // Interrupted will return true if the transaction was interrupted
 func (tx *Transaction) Interrupted() bool {
 	return tx.interruption != nil

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -103,6 +103,12 @@ type Transaction interface {
 	// delivered prior to the execution of this method.
 	ProcessLogging()
 
+	// RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
+	RequestBodyAccessible() bool
+
+	// ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
+	ResponseBodyAccessible() bool
+
 	// Interrupted will return true if the transaction was interrupted
 	Interrupted() bool
 


### PR DESCRIPTION
Related to https://github.com/corazawaf/coraza/issues/497 and its port (https://github.com/corazawaf/coraza-proxy-wasm/issues/68).

This PR proposes to add `RequestBodyAccessible()` and `ResponseBodyAccessible()` returning, just like the name explicit, `RequestBodyAccess` and `ResponseBodyAccess` booleans. 

I think that would be nice to be aware of `RequestBodyAccess` and `ResponseBodyAccess` statuses from the connectors. It would permit optimizing bodies' actions such as avoiding buffering the bodies if they are not going to be analyzed.

