### PR TITLE
Copy rules slice when cloning config

### DIFF
--- a/config.go
+++ b/config.go
@@ -176,6 +176,9 @@ func (c *wafConfig) WithRootFS(fs fs.FS) WAFConfig {
 
 func (c *wafConfig) clone() *wafConfig {
 	ret := *c // copy
+	rules := make([]wafRule, len(c.rules))
+	copy(rules, c.rules)
+	ret.rules = rules
 	return &ret
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,57 @@
+package coraza
+
+import (
+	"testing"
+)
+
+func TestConfigRulesImmutable(t *testing.T) {
+	// Add enough directives so there is enough slice capacity to reuse the array for next append.
+	c := NewWAFConfig().
+		WithDirectives("SecRuleEngine On").
+		WithDirectives("SecRuleEngine On").
+		WithDirectives("SecRuleEngine On")
+
+	c1 := c.WithDirectives("SecRequestBodyAccess On")
+
+	waf1, err := NewWAF(c1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !waf1.(wafWrapper).waf.RequestBodyAccess {
+		t.Errorf("waf1: expected request body access to be enabled")
+	}
+
+	if waf1.(wafWrapper).waf.ResponseBodyAccess {
+		t.Errorf("waf1: expected response body access to be disabled")
+	}
+
+	c2 := c.WithDirectives("SecResponseBodyAccess On")
+
+	waf2, err := NewWAF(c2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if waf2.(wafWrapper).waf.RequestBodyAccess {
+		t.Errorf("waf1: expected request body access to be disabled")
+	}
+
+	if !waf2.(wafWrapper).waf.ResponseBodyAccess {
+		t.Errorf("waf1: expected response body access to be enabled")
+	}
+
+	// c1 should not have been affected
+	waf1, err = NewWAF(c1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !waf1.(wafWrapper).waf.RequestBodyAccess {
+		t.Errorf("waf1: expected request body access to be enabled")
+	}
+
+	if waf1.(wafWrapper).waf.ResponseBodyAccess {
+		t.Errorf("waf1: expected response body access to be disabled")
+	}
+}


### PR DESCRIPTION
clone is supposed to return an immutable copy of the config but forgot to deep copy its slice