### PR TITLE
Exports IsRuleEngineOff

### DIFF
--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -79,6 +79,7 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	http.ResponseWriter,
 	func(types.Transaction, *http.Request) error,
 ) { // nolint:gocyclo
+
 	i := &rwInterceptor{w: w, tx: tx, proto: r.Proto}
 
 	responseProcessor := func(tx types.Transaction, r *http.Request) error {

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -112,6 +112,11 @@ func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {
 			}
 		}()
 
+		// Early return, Coraza is not going to process any rule
+		if tx.IsRuleEngineOff() {
+			return
+		}
+
 		// ProcessRequest is just a wrapper around ProcessConnection, ProcessURI,
 		// ProcessRequestHeaders and ProcessRequestBody.
 		// It fails if any of these functions returns an error and it stops on interruption.

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -89,6 +89,18 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		}
 	}
 
+	// Calling tx.RuleEngineStatus() and tx.RequestBodyAccessible() is possible to
+	// anticipate some checks performed inside ProcessRequestBody(), avoiding
+	// to call the latter if no inspections are going to happen.
+	// It is performed here as a matter of example. It is recommended to avoid doing it
+	// if not strictly needed for server/proxy side actions.
+	switch {
+	case tx.RuleEngineStatus() == types.RuleEngineOff:
+		return nil, nil
+	case !tx.RequestBodyAccessible():
+		return tx.Interruption(), nil
+	}
+
 	return tx.ProcessRequestBody()
 }
 

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -89,18 +89,6 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		}
 	}
 
-	// Calling tx.RuleEngineStatus() and tx.RequestBodyAccessible() is possible to
-	// anticipate some checks performed inside ProcessRequestBody(), avoiding
-	// to call the latter if no inspections are going to happen.
-	// It is performed here as a matter of example. It is recommended to avoid doing it
-	// if not strictly needed for server/proxy side actions.
-	switch {
-	case tx.RuleEngineStatus() == types.RuleEngineOff:
-		return nil, nil
-	case !tx.RequestBodyAccessible():
-		return tx.Interruption(), nil
-	}
-
 	return tx.ProcessRequestBody()
 }
 

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -101,6 +101,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 }
 
 func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {
+
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		tx := waf.NewTransaction()
 		defer func() {
@@ -114,6 +115,9 @@ func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {
 
 		// Early return, Coraza is not going to process any rule
 		if tx.IsRuleEngineOff() {
+			// response writer is not going to be wrapped, but used as-is
+			// to generate the response
+			h.ServeHTTP(w, r)
 			return
 		}
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -244,17 +244,19 @@ func createWAF(t *testing.T) coraza.WAF {
 	return waf
 }
 
+type httpTest struct {
+	http2            bool
+	reqURI           string
+	reqBody          string
+	respHeaders      map[string]string
+	respBody         string
+	expectedProto    string
+	expectedStatus   int
+	expectedRespBody string
+}
+
 func TestHttpServer(t *testing.T) {
-	tests := map[string]struct {
-		http2            bool
-		reqURI           string
-		reqBody          string
-		respHeaders      map[string]string
-		respBody         string
-		expectedProto    string
-		expectedStatus   int
-		expectedRespBody string
-	}{
+	tests := map[string]httpTest{
 		"no blocking": {
 			reqURI:         "/hello",
 			expectedProto:  "HTTP/1.1",
@@ -302,71 +304,120 @@ func TestHttpServer(t *testing.T) {
 	// Perform tests
 	for name, tCase := range tests {
 		t.Run(name, func(t *testing.T) {
-			serverErrC := make(chan error, 1)
-			defer close(serverErrC)
+			runAgainstWaf(t, tCase, createWAF(t))
 
-			// Spin up the test server
-			ts := httptest.NewUnstartedServer(WrapHandler(createWAF(t), t.Logf, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-				if want, have := tCase.expectedProto, req.Proto; want != have {
-					t.Errorf("unexpected proto, want: %s, have: %s", want, have)
-				}
-
-				w.Header().Set("Content-Type", "text/plain")
-				w.Header().Add("coraza-middleware", "true")
-				for k, v := range tCase.respHeaders {
-					w.Header().Set(k, v)
-				}
-				w.WriteHeader(201)
-				_, err := w.Write([]byte(tCase.respBody))
-				if err != nil {
-					serverErrC <- err
-				}
-			})))
-			if tCase.http2 {
-				ts.EnableHTTP2 = true
-				ts.StartTLS()
-			} else {
-				ts.Start()
-			}
-			defer ts.Close()
-
-			var reqBody io.Reader
-			if tCase.reqBody != "" {
-				reqBody = strings.NewReader(tCase.reqBody)
-			}
-			req, _ := http.NewRequest("POST", ts.URL+tCase.reqURI, reqBody)
-			// TODO(jcchavezs): Fix it once the discussion in https://github.com/corazawaf/coraza/issues/438 is settled
-			req.Header.Add("content-type", "application/x-www-form-urlencoded")
-			res, err := ts.Client().Do(req)
-			if err != nil {
-				t.Fatalf("unexpected error when performing the request: %v", err)
-			}
-
-			if want, have := tCase.expectedStatus, res.StatusCode; want != have {
-				t.Errorf("unexpected status code, want: %d, have: %d", want, have)
-			}
-
-			resBody, err := io.ReadAll(res.Body)
-			if err != nil {
-				t.Fatalf("unexpected error when reading the response body: %v", err)
-			}
-
-			if want, have := tCase.expectedRespBody, string(resBody); want != have {
-				t.Errorf("unexpected response body, want: %q, have %q", want, have)
-			}
-
-			err = res.Body.Close()
-			if err != nil {
-				t.Errorf("failed to close the body: %v", err)
-			}
-
-			select {
-			case err = <-serverErrC:
-				t.Errorf("unexpected error from server when writing response body: %v", err)
-			default:
-				return
-			}
 		})
+	}
+}
+
+func TestHttpServerWithRuleEngineOff(t *testing.T) {
+	tests := map[string]httpTest{
+		"no blocking true negative": {
+			reqURI:           "/hello",
+			expectedProto:    "HTTP/1.1",
+			expectedStatus:   201,
+			respBody:         "Hello!",
+			expectedRespBody: "Hello!",
+		},
+		"no blocking true positive header phase": {
+			reqURI:           "/hello?id=0",
+			expectedProto:    "HTTP/1.1",
+			expectedStatus:   201,
+			respBody:         "Downstream works!",
+			expectedRespBody: "Downstream works!",
+		},
+		"no blocking true positive body phase": {
+			reqURI:           "/hello",
+			reqBody:          "eval('cat /etc/passwd')",
+			expectedProto:    "HTTP/1.1",
+			expectedStatus:   201,
+			respBody:         "Waf is Off!",
+			expectedRespBody: "Waf is Off!",
+		},
+	}
+	// Perform tests
+	for name, tCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			waf, err := coraza.NewWAF(coraza.NewWAFConfig().
+				WithDirectives(`
+			SecRuleEngine Off
+			SecRequestBodyAccess On
+			SecRule ARGS:id "@eq 0" "id:1, phase:1,deny, status:403,msg:'Invalid id',log,auditlog"
+			SecRule REQUEST_BODY "@contains eval" "id:100, phase:2,deny, status:403,msg:'Invalid request body',log,auditlog"
+			`).WithErrorLogger(errLogger(t)).WithDebugLogger(&debugLogger{t: t}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			runAgainstWaf(t, tCase, waf)
+		})
+	}
+}
+
+func runAgainstWaf(t *testing.T, tCase httpTest, waf coraza.WAF) {
+	t.Helper()
+	serverErrC := make(chan error, 1)
+	defer close(serverErrC)
+
+	// Spin up the test server
+	ts := httptest.NewUnstartedServer(WrapHandler(waf, t.Logf, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if want, have := tCase.expectedProto, req.Proto; want != have {
+			t.Errorf("unexpected proto, want: %s, have: %s", want, have)
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Add("coraza-middleware", "true")
+		for k, v := range tCase.respHeaders {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(201)
+		_, err := w.Write([]byte(tCase.respBody))
+		if err != nil {
+			serverErrC <- err
+		}
+	})))
+	if tCase.http2 {
+		ts.EnableHTTP2 = true
+		ts.StartTLS()
+	} else {
+		ts.Start()
+	}
+	defer ts.Close()
+
+	var reqBody io.Reader
+	if tCase.reqBody != "" {
+		reqBody = strings.NewReader(tCase.reqBody)
+	}
+	req, _ := http.NewRequest("POST", ts.URL+tCase.reqURI, reqBody)
+	// TODO(jcchavezs): Fix it once the discussion in https://github.com/corazawaf/coraza/issues/438 is settled
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+	res, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error when performing the request: %v", err)
+	}
+
+	if want, have := tCase.expectedStatus, res.StatusCode; want != have {
+		t.Errorf("unexpected status code, want: %d, have: %d", want, have)
+	}
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unexpected error when reading the response body: %v", err)
+	}
+
+	if want, have := tCase.expectedRespBody, string(resBody); want != have {
+		t.Errorf("unexpected response body, want: %q, have %q", want, have)
+	}
+
+	err = res.Body.Close()
+	if err != nil {
+		t.Errorf("failed to close the body: %v", err)
+	}
+
+	select {
+	case err = <-serverErrC:
+		t.Errorf("unexpected error from server when writing response body: %v", err)
+	default:
+		return
 	}
 }
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -43,6 +43,22 @@ func TestProcessRequest(t *testing.T) {
 	}
 }
 
+func TestProcessRequestEngineOff(t *testing.T) {
+	req, _ := http.NewRequest("POST", "https://www.coraza.io/test", strings.NewReader("test=456"))
+	waf := corazawaf.NewWAF()
+	waf.RuleEngine = types.RuleEngineOff
+	tx := waf.NewTransaction()
+	if _, err := processRequest(tx, req); err != nil {
+		t.Fatal(err)
+	}
+	if tx.Variables().RequestMethod().String() != "POST" {
+		t.Fatal("failed to set request from request object")
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestProcessRequestMultipart(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/some", nil)
 	if err := multipartRequest(t, req); err != nil {

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -940,16 +940,19 @@ func (tx *Transaction) ProcessLogging() {
 }
 
 // RuleEngineStatus returns the status of the rule engine for the transaction
+// Note that it returns the current status of the engine, later rules may still change it via ctl actions
 func (tx *Transaction) RuleEngineStatus() types.RuleEngineStatus {
 	return tx.RuleEngine
 }
 
 // RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
+// Note that it returns the current status, later rules may still change it via ctl actions
 func (tx *Transaction) RequestBodyAccessible() bool {
 	return tx.RequestBodyAccess
 }
 
 // ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
+// Note that it returns the current status, later rules may still change it via ctl actions
 func (tx *Transaction) ResponseBodyAccessible() bool {
 	return tx.ResponseBodyAccess
 }

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -939,6 +939,11 @@ func (tx *Transaction) ProcessLogging() {
 	}
 }
 
+// RuleEngineStatus returns the status of the rule engine for the transaction
+func (tx *Transaction) RuleEngineStatus() types.RuleEngineStatus {
+	return tx.RuleEngine
+}
+
 // RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
 func (tx *Transaction) RequestBodyAccessible() bool {
 	return tx.RequestBodyAccess

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -939,40 +939,17 @@ func (tx *Transaction) ProcessLogging() {
 	}
 }
 
-// RuleEngineStatus returns the status of the rule engine for the transaction
-//
-// It is suggested to perform early checks on the status only if the API consumer
-// requires it for specific server/proxy actions (such as avoiding proxy side buffering).
-// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
-//
-// Three values can be returned:
-// types.RuleEngineOn: no early assumptions have to be made at all
-// types.RuleEngineDetectionOnly: it may be possible to assume that no disruptive actions will be performed
-// types.RuleEngineOff: it is safe to assume that no rules will be processed
-//
-// Note that it returns the current status of the engine, later rules may still change it via ctl actions
-func (tx *Transaction) RuleEngineStatus() types.RuleEngineStatus {
-	return tx.RuleEngine
+// IsEngineRuleOff will return true if RuleEngine is set to Off
+func (tx *Transaction) IsEngineRuleOff() bool {
+	return tx.RuleEngine == types.RuleEngineOff
 }
 
 // RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
-//
-// It is suggested to perform early checks only if the API consumer requires them for specific
-// server/proxy actions (such as avoiding proxy side buffering).
-// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
-//
-// Note that it returns the current status, later rules may still change it via ctl actions
 func (tx *Transaction) RequestBodyAccessible() bool {
 	return tx.RequestBodyAccess
 }
 
 // ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
-//
-// It is suggested to perform early checks only if the API consumer requires them for specific
-// server/proxy actions (such as avoiding proxy side buffering).
-// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
-//
-// Note that it returns the current status, later rules may still change it via ctl actions.
 func (tx *Transaction) ResponseBodyAccessible() bool {
 	return tx.ResponseBodyAccess
 }

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -940,19 +940,39 @@ func (tx *Transaction) ProcessLogging() {
 }
 
 // RuleEngineStatus returns the status of the rule engine for the transaction
+//
+// It is suggested to perform early checks on the status only if the API consumer
+// requires it for specific server/proxy actions (such as avoiding proxy side buffering).
+// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
+//
+// Three values can be returned:
+// types.RuleEngineOn: no early assumptions have to be made at all
+// types.RuleEngineDetectionOnly: it may be possible to assume that no disruptive actions will be performed
+// types.RuleEngineOff: it is safe to assume that no rules will be processed
+//
 // Note that it returns the current status of the engine, later rules may still change it via ctl actions
 func (tx *Transaction) RuleEngineStatus() types.RuleEngineStatus {
 	return tx.RuleEngine
 }
 
 // RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
+//
+// It is suggested to perform early checks only if the API consumer requires them for specific
+// server/proxy actions (such as avoiding proxy side buffering).
+// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
+//
 // Note that it returns the current status, later rules may still change it via ctl actions
 func (tx *Transaction) RequestBodyAccessible() bool {
 	return tx.RequestBodyAccess
 }
 
 // ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
-// Note that it returns the current status, later rules may still change it via ctl actions
+//
+// It is suggested to perform early checks only if the API consumer requires them for specific
+// server/proxy actions (such as avoiding proxy side buffering).
+// Otherwise do not use this method in order to avoid any risk of performing wrong early assumptions.
+//
+// Note that it returns the current status, later rules may still change it via ctl actions.
 func (tx *Transaction) ResponseBodyAccessible() bool {
 	return tx.ResponseBodyAccess
 }

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -939,8 +939,8 @@ func (tx *Transaction) ProcessLogging() {
 	}
 }
 
-// IsEngineRuleOff will return true if RuleEngine is set to Off
-func (tx *Transaction) IsEngineRuleOff() bool {
+// IsRuleEngineOff will return true if RuleEngine is set to Off
+func (tx *Transaction) IsRuleEngineOff() bool {
 	return tx.RuleEngine == types.RuleEngineOff
 }
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -103,13 +103,25 @@ type Transaction interface {
 	// delivered prior to the execution of this method.
 	ProcessLogging()
 
-	// RuleEngineStatus returns the status of the rule engine for the transaction
-	RuleEngineStatus() RuleEngineStatus
+	// IsEngineRuleOff will return true if RuleEngine is set to Off
+	IsEngineRuleOff() bool
 
 	// RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
+	//
+	// This can be used to perform checks just before calling request body related functions.
+	// In order to avoid any risk of performing wrong early assumptions, perform early checks on this value
+	// only if the API consumer requires them for specific server/proxy actions
+	// (such as avoiding proxy side buffering).
+	// Note: it returns the current status, later rules may still change it via ctl actions.
 	RequestBodyAccessible() bool
 
 	// ResponseBodyAccessible will return true if ResponseBody access has been enabled by ResponseBodyAccess
+	//
+	// This can be used to perform checks just before calling response body related functions.
+	// In order to avoid any risk of performing wrong early assumptions, perform early checks on this value
+	// only if the API consumer requires them for specific server/proxy actions
+	// (such as avoiding proxy side buffering).
+	// Note: it returns the current status, later rules may still change it via ctl actions.
 	ResponseBodyAccessible() bool
 
 	// Interrupted will return true if the transaction was interrupted

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -103,6 +103,9 @@ type Transaction interface {
 	// delivered prior to the execution of this method.
 	ProcessLogging()
 
+	// RuleEngineStatus returns the status of the rule engine for the transaction
+	RuleEngineStatus() RuleEngineStatus
+
 	// RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
 	RequestBodyAccessible() bool
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -103,8 +103,8 @@ type Transaction interface {
 	// delivered prior to the execution of this method.
 	ProcessLogging()
 
-	// IsEngineRuleOff will return true if RuleEngine is set to Off
-	IsEngineRuleOff() bool
+	// IsRuleEngineOff will return true if RuleEngine is set to Off
+	IsRuleEngineOff() bool
 
 	// RequestBodyAccessible will return true if RequestBody access has been enabled by RequestBodyAccess
 	//


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/pull/499, Just like `RequestBodyAccess` and `ResponseBodyAccess`, connectors could benefit from retrieving the current status of the engine. I also added a note to explicitly tell that it is the **current** status per-transaction basis in order to be aware of using it without making wrong assumptions. 