### PR TITLE
optimize rx operator

### DIFF
--- a/operators/rx.go
+++ b/operators/rx.go
@@ -28,21 +28,19 @@ func newRX(options rules.OperatorOptions) (rules.Operator, error) {
 }
 
 func (o *rx) Evaluate(tx rules.TransactionState, value string) bool {
-	match := o.re.FindStringSubmatch(value)
-	if len(match) == 0 {
-		return false
-	}
 
 	if tx.Capturing() {
+		match := o.re.FindStringSubmatch(value)
+		if len(match) == 0 {
+			return false
+		}
 		for i, c := range match {
-			if i == 9 {
-				return true
-			}
 			tx.CaptureField(i, c)
 		}
+		return true
+	} else {
+		return o.re.MatchString(value)
 	}
-
-	return true
 }
 
 func init() {

--- a/operators/rx_test.go
+++ b/operators/rx_test.go
@@ -5,6 +5,7 @@ package operators
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
@@ -68,4 +69,21 @@ func TestRx(t *testing.T) {
 			*/
 		})
 	}
+}
+
+func BenchmarkRxSubstringVsMatch(b *testing.B) {
+	str := "hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;"
+	rx, err := regexp.Compile("(h.*e.*l.*l.*o.*)")
+	if err != nil {
+		b.Error(err)
+	}
+	b.Run("Find all RX", func(b *testing.B) {
+		rx.FindStringSubmatch(str)
+	})
+	b.Run("Find only first", func(b *testing.B) {
+		rx.MatchString(str)
+	})
+	b.Run("Find only N", func(b *testing.B) {
+		rx.FindAllString(str, 3)
+	})
 }


### PR DESCRIPTION
There is no need to find all submatches if there is no capture.

```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/operators
BenchmarkRxSubstringVsMatch/Find_all_RX-10         	1000000000	         0.0000116 ns/op	       0 B/op	       0 allocs/op
BenchmarkRxSubstringVsMatch/Find_only_first-10     	1000000000	         0.0000119 ns/op	       0 B/op	       0 allocs/op
BenchmarkRxSubstringVsMatch/Find_only_N-10         	1000000000	         0.0000145 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/operators	0.666s

```