### PR TITLE
Cache transformations within a phase

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -403,7 +403,7 @@ func (r *Rule) AddTransformation(name string, t rules.Transformation) error {
 	}
 	r.transformations = append(r.transformations, ruleTransformationParams{name, t})
 	// TODO: smarter fingerprints than name concatenation
-	r.transformationsID += name + "|"
+	r.transformationsID += name
 	return nil
 }
 

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -104,6 +104,8 @@ type Transaction struct {
 	audit bool
 
 	variables TransactionVariables
+
+	transformationCache map[transformationKey]transformationValue
 }
 
 func (tx *Transaction) ID() string {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -190,6 +190,7 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 		})
 		tx.variables = *NewTransactionVariables()
+		tx.transformationCache = map[transformationKey]transformationValue{}
 	}
 
 	// set capture variables

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -110,7 +110,41 @@ func BenchmarkCRSSimplePOST(b *testing.B) {
 		tx.AddRequestHeader("Accept", "application/json")
 		tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
 		tx.ProcessRequestHeaders()
-		if _, err := tx.ResponseBodyWriter().Write([]byte("parameters2=and&other2=Stuff")); err != nil {
+		if _, err := tx.RequestBodyWriter().Write([]byte("parameters2=and&other2=Stuff")); err != nil {
+			b.Error(err)
+		}
+		if _, err := tx.ProcessRequestBody(); err != nil {
+			b.Error(err)
+		}
+		tx.AddResponseHeader("Content-Type", "application/json")
+		tx.ProcessResponseHeaders(200, "OK")
+		if _, err := tx.ProcessResponseBody(); err != nil {
+			b.Error(err)
+		}
+		tx.ProcessLogging()
+		if err := tx.Close(); err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkCRSLargePOST(b *testing.B) {
+	waf := crsWAF(b)
+
+	postPayload := []byte(fmt.Sprintf("parameters2=and&other2=%s", strings.Repeat("a", 10000)))
+
+	b.ReportAllocs()
+	b.ResetTimer() // only benchmark execution, not compilation
+	for i := 0; i < b.N; i++ {
+		tx := waf.NewTransaction()
+		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
+		tx.ProcessURI("POST", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
+		tx.AddRequestHeader("Host", "localhost")
+		tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
+		tx.AddRequestHeader("Accept", "application/json")
+		tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+		tx.ProcessRequestHeaders()
+		if _, err := tx.RequestBodyWriter().Write(postPayload); err != nil {
 			b.Error(err)
 		}
 		if _, err := tx.ProcessRequestBody(); err != nil {

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -281,6 +281,7 @@ func crsWAF(t testing.TB) coraza.WAF {
 		t.Fatal(err)
 	}
 	conf := coraza.NewWAFConfig().
+		WithRootFS(crsReader).
 		WithDirectives(string(rec)).
 		WithDirectives("Include crs-setup.conf.example").
 		WithDirectives("Include rules/*.conf")


### PR DESCRIPTION
We currently compute the same transformation per variable many many times per phase. This adds a cache to reduce this repetitive computation. It notably reduces allocations by half in the CRS benchmarks, which has some performance impact here and will have bigger performance impact where GC is slower like wasm.

After
```
BenchmarkCRSLargePOST
BenchmarkCRSLargePOST-10    	      12	  95202174 ns/op	 3631520 B/op	   45437 allocs/op
BenchmarkCRSSimplePOST
BenchmarkCRSSimplePOST-10    	     631	   1887620 ns/op	 1294996 B/op	   45180 allocs/op
```

Before
```
BenchmarkCRSLargePOST
BenchmarkCRSLargePOST-10    	      12	  97733875 ns/op	 7036534 B/op	   46887 allocs/op
BenchmarkCRSSimplePOST
BenchmarkCRSSimplePOST-10    	     631	   1883263 ns/op	 1302137 B/op
```