### PR TITLE
Passthrough string in url decode transformations when no decoding

### DIFF
--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -98,4 +99,10 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// WrapUnsafe wraps the provided buffer as a string. The buffer
+// must not be mutated after calling this function.
+func WrapUnsafe(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/transformations/url_decode.go
+++ b/transformations/url_decode.go
@@ -8,18 +8,20 @@ import (
 )
 
 func urlDecode(data string) (string, error) {
-	res, _, _ := doURLDecode(data)
-	// TODO add error?
-	return res, nil
+	for i := 0; i < len(data); i++ {
+		if data[i] == '%' || data[i] == '+' {
+			// TODO add error?
+			return doURLDecode(data, []byte(data), i), nil
+		}
+	}
+	return data, nil
 }
 
 // extracted from https://github.com/senghoo/modsecurity-go/blob/master/utils/urlencode.go
-func doURLDecode(input string) (string, bool, int) {
-	d := []byte(input)
+func doURLDecode(input string, d []byte, pos int) string {
 	inputLen := len(d)
-	var i, count, invalidCount, c int
-
-	changed := false
+	i := pos
+	c := pos
 
 	for i < inputLen {
 		if input[i] == '%' {
@@ -34,40 +36,32 @@ func doURLDecode(input string) (string, bool, int) {
 
 					d[c] = uni
 					c++
-					count++
 					i += 3
-					changed = true
 				} else {
 					/* Not a valid encoding, skip this % */
 					d[c] = input[i]
 					c++
 					i++
-					count++
-					invalidCount++
 				}
 			} else {
 				/* Not enough bytes available, copy the raw bytes. */
 				d[c] = input[i]
 				c++
 				i++
-				count++
-				invalidCount++
 			}
 		} else {
 			/* Character is not a percent sign. */
 			if input[i] == '+' {
 				d[c] = ' '
 				c++
-				changed = true
 			} else {
 				d[c] = input[i]
 				c++
 			}
-			count++
 			i++
 		}
 	}
 
-	return string(d[0:c]), changed, invalidCount
+	return string(d[0:c])
 
 }

--- a/transformations/url_decode.go
+++ b/transformations/url_decode.go
@@ -62,6 +62,6 @@ func doURLDecode(input string, d []byte, pos int) string {
 		}
 	}
 
-	return string(d[0:c])
+	return strings.WrapUnsafe(d[0:c])
 
 }

--- a/transformations/url_decode_uni.go
+++ b/transformations/url_decode_uni.go
@@ -8,17 +8,22 @@ import (
 )
 
 func urlDecodeUni(data string) (string, error) {
-	return inplaceUniDecode(data), nil
+	for i := 0; i < len(data); i++ {
+		if data[i] == '%' || data[i] == '+' {
+			return inplaceUniDecode(data, []byte(data), i), nil
+		}
+	}
+	return data, nil
 }
 
-func inplaceUniDecode(input string) string {
-	d := []byte(input)
+func inplaceUniDecode(input string, d []byte, pos int) string {
 	inputLen := len(d)
-	var i, count, c int
+	i := pos
+	c := pos
 	hmap := -1
 
 	for i < inputLen {
-		if input[i] == '%' {
+		if d[i] == '%' {
 			if (i+1 < inputLen) && ((input[i+1] == 'u') || (input[i+1] == 'U')) {
 				/* Character is a percent sign. */
 				/* IIS-specific %u encoding. */
@@ -62,7 +67,6 @@ func inplaceUniDecode(input string) string {
 							}
 						}
 						c++
-						count++
 						i += 6
 					} else {
 						/* Invalid data, skip %u. */
@@ -72,7 +76,6 @@ func inplaceUniDecode(input string) string {
 						d[c] = input[i]
 						c++
 						i++
-						count += 2
 					}
 				} else {
 					/* Not enough bytes (4 data bytes), skip %u. */
@@ -82,7 +85,6 @@ func inplaceUniDecode(input string) string {
 					d[c] = input[i]
 					i++
 					c++
-					count += 2
 				}
 			} else {
 				/* Standard URL encoding. */
@@ -98,21 +100,18 @@ func inplaceUniDecode(input string) string {
 					if strings.ValidHex(c1) && strings.ValidHex(c2) {
 						d[c] = strings.X2c(input[i+1:])
 						c++
-						count++
 						i += 3
 					} else {
 						/* Not a valid encoding, skip this % */
 						d[c] = input[i]
 						i++
 						c++
-						count++
 					}
 				} else {
 					/* Not enough bytes available, skip this % */
 					d[c] = input[i]
 					i++
 					c++
-					count++
 				}
 			}
 		} else {
@@ -125,7 +124,6 @@ func inplaceUniDecode(input string) string {
 				c++
 			}
 
-			count++
 			i++
 		}
 	}

--- a/transformations/url_decode_uni.go
+++ b/transformations/url_decode_uni.go
@@ -128,5 +128,5 @@ func inplaceUniDecode(input string, d []byte, pos int) string {
 		}
 	}
 
-	return string(d[0:c])
+	return strings.WrapUnsafe(d[0:c])
 }

--- a/transformations/url_decode_uni_test.go
+++ b/transformations/url_decode_uni_test.go
@@ -22,7 +22,9 @@ func BenchmarkURLDecode(b *testing.B) {
 			tt := tc
 			b.Run(fmt.Sprintf("%s/%s", mode, tt), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					f(tt)
+					if _, err := f(tt); err != nil {
+						b.Fatal(err)
+					}
 				}
 			})
 		}

--- a/transformations/url_decode_uni_test.go
+++ b/transformations/url_decode_uni_test.go
@@ -1,0 +1,30 @@
+package transformations
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkURLDecode(b *testing.B) {
+	tests := []string{
+		"",
+		"helloworld",
+		"hello+world",
+		"%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89",
+	}
+
+	for _, mode := range []string{"normal", "unicode"} {
+		f := urlDecode
+		if mode == "unicode" {
+			f = urlDecodeUni
+		}
+		for _, tc := range tests {
+			tt := tc
+			b.Run(fmt.Sprintf("%s/%s", mode, tt), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					f(tt)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Transformation cache will help a lot but anyways we shouldn't allocate where there's no need to

Also wraps the result buffer instead of copying

After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkURLDecode
BenchmarkURLDecode/normal/
BenchmarkURLDecode/normal/-10         	563965651	         2.112 ns/op
BenchmarkURLDecode/normal/helloworld
BenchmarkURLDecode/normal/helloworld-10         	212564259	         5.637 ns/op
BenchmarkURLDecode/normal/hello+world
BenchmarkURLDecode/normal/hello+world-10        	46705327	        25.33 ns/op
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10         	14283956	        84.26 ns/op
BenchmarkURLDecode/unicode/
BenchmarkURLDecode/unicode/-10                                                                       	568736440	         2.114 ns/op
BenchmarkURLDecode/unicode/helloworld
BenchmarkURLDecode/unicode/helloworld-10                                                             	213121411	         5.636 ns/op
BenchmarkURLDecode/unicode/hello+world
BenchmarkURLDecode/unicode/hello+world-10                                                            	46748011	        25.32 ns/op
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10        	12273687	        97.73 ns/op
PASS
```

No WrapUnsafe
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkURLDecode
BenchmarkURLDecode/normal/
BenchmarkURLDecode/normal/-10         	219029828	         5.482 ns/op
BenchmarkURLDecode/normal/helloworld
BenchmarkURLDecode/normal/helloworld-10         	45085591	        25.96 ns/op
BenchmarkURLDecode/normal/hello+world
BenchmarkURLDecode/normal/hello+world-10        	42104770	        27.85 ns/op
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10         	12552880	        95.92 ns/op
BenchmarkURLDecode/unicode/
BenchmarkURLDecode/unicode/-10                                                                       	219463183	         5.472 ns/op
BenchmarkURLDecode/unicode/helloworld
BenchmarkURLDecode/unicode/helloworld-10                                                             	46115858	        26.04 ns/op
BenchmarkURLDecode/unicode/hello+world
BenchmarkURLDecode/unicode/hello+world-10                                                            	43190130	        27.85 ns/op
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10        	10971687	       109.3 ns/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkURLDecode
BenchmarkURLDecode/normal/
BenchmarkURLDecode/normal/-10         	568033779	         2.110 ns/op
BenchmarkURLDecode/normal/helloworld
BenchmarkURLDecode/normal/helloworld-10         	212907738	         5.631 ns/op
BenchmarkURLDecode/normal/hello+world
BenchmarkURLDecode/normal/hello+world-10        	45469758	        25.55 ns/op
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/normal/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10         	12481731	        96.75 ns/op
BenchmarkURLDecode/unicode/
BenchmarkURLDecode/unicode/-10                                                                       	568933278	         2.110 ns/op
BenchmarkURLDecode/unicode/helloworld
BenchmarkURLDecode/unicode/helloworld-10                                                             	213502885	         5.636 ns/op
BenchmarkURLDecode/unicode/hello+world
BenchmarkURLDecode/unicode/hello+world-10                                                            	46644056	        25.55 ns/op
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89
BenchmarkURLDecode/unicode/%E3%83%8F%E3%83%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89-10        	10664019	       112.8 ns/op
PASS
```