### PR TITLE
Return number bytes, not runes, in length transformation

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package coraza
 
 import (

--- a/transformations/length.go
+++ b/transformations/length.go
@@ -5,9 +5,8 @@ package transformations
 
 import (
 	"strconv"
-	"unicode/utf8"
 )
 
 func length(data string) (string, error) {
-	return strconv.Itoa(utf8.RuneCountInString(data)), nil
+	return strconv.Itoa(len(data)), nil
 }

--- a/transformations/length_test.go
+++ b/transformations/length_test.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func TestLength(t *testing.T) {
+	tests := []struct {
+		input  string
+		length string
+	}{
+		{
+			input:  "hello",
+			length: "5",
+		},
+		{
+			input:  "",
+			length: "0",
+		},
+		{
+			input:  "ハローワールド",
+			length: "21",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, err := length(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if have != tt.length {
+				t.Errorf("Expected %s, have %s", tt.length, have)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Doc says # of bytes

https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v3.x)#length

As does ModSec implementation

https://github.com/SpiderLabs/ModSecurity/blob/v3/master/src/actions/transformations/length.cc#L41