### PR TITLE
Have cmdLine operate on bytes and passthrough non-transformed

### DIFF
--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -98,4 +99,10 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// WrapUnsafe wraps the provided buffer as a string. The buffer
+// must not be mutated after calling this function.
+func WrapUnsafe(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/transformations/cmd_line_test.go
+++ b/transformations/cmd_line_test.go
@@ -1,0 +1,23 @@
+package transformations
+
+import "testing"
+
+func BenchmarkCMDLine(b *testing.B) {
+	tests := []string{
+		"",
+		"test",
+		"C^OMMAND /C DIR",
+		"\"command\" /c DiR",
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := cmdLine(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
ModSecurity operates on bytes (not passing locale here)
