### PR TITLE
Passthrough non-transformed strings in compressWhitespace

### DIFF
--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -98,4 +99,10 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// WrapUnsafe wraps the provided buffer as a string. The buffer
+// must not be mutated after calling this function.
+func WrapUnsafe(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/transformations/compress_whitespace.go
+++ b/transformations/compress_whitespace.go
@@ -4,30 +4,46 @@
 package transformations
 
 import (
-	"unicode"
+	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 func compressWhitespace(value string) (string, error) {
-	var a []byte
-	i := 0
-	inWhiteSpace := false
-	length := len(value)
+	for i := 0; i < len(value); i++ {
+		if isLatinSpace(value[i]) {
+			return doCompressWhitespace(value, i), nil
+		}
+	}
+	return value, nil
+}
 
-	for i < length {
-		if unicode.IsSpace(rune(value[i])) {
+func doCompressWhitespace(input string, pos int) string {
+	// The output may be significantly different length than input, so we don't preallocate
+	ret := []byte(input[0:pos])
+
+	inWhiteSpace := false
+	for i := pos; i < len(input); {
+		if isLatinSpace(input[i]) {
 			if inWhiteSpace {
 				i++
 				continue
 			} else {
 				inWhiteSpace = true
-				a = append(a, ' ')
+				ret = append(ret, ' ')
 			}
 		} else {
 			inWhiteSpace = false
-			a = append(a, value[i])
+			ret = append(ret, input[i])
 		}
 		i++
 	}
 
-	return string(a), nil
+	return strings.WrapUnsafe(ret)
+}
+
+func isLatinSpace(c byte) bool { // copied from unicode.IsSpace
+	switch c {
+	case '\t', '\n', '\v', '\f', '\r', ' ', 0x85, 0xA0:
+		return true
+	}
+	return false
 }

--- a/transformations/compress_whitespace_test.go
+++ b/transformations/compress_whitespace_test.go
@@ -1,0 +1,24 @@
+package transformations
+
+import "testing"
+
+func BenchmarkCompressWhitespace(b *testing.B) {
+	tests := []string{
+		"",
+		"test",
+		"test case",
+		"test    case",
+		"\ttest  c\n\ras\t  ",
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := compressWhitespace(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkCompressWhitespace
BenchmarkCompressWhitespace/#00
BenchmarkCompressWhitespace/#00-10         	571122726	         2.125 ns/op
BenchmarkCompressWhitespace/test
BenchmarkCompressWhitespace/test-10        	248496358	         4.828 ns/op
BenchmarkCompressWhitespace/test_case
BenchmarkCompressWhitespace/test_case-10   	29280343	        40.49 ns/op
BenchmarkCompressWhitespace/test____case
BenchmarkCompressWhitespace/test____case-10         	25941014	        46.05 ns/op
BenchmarkCompressWhitespace/_test__c__as___
BenchmarkCompressWhitespace/_test__c__as___-10      	17068617	        70.48 ns/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkCompressWhitespace
BenchmarkCompressWhitespace/#00
BenchmarkCompressWhitespace/#00-10         	447815151	         2.590 ns/op
BenchmarkCompressWhitespace/test
BenchmarkCompressWhitespace/test-10        	32739363	        36.20 ns/op
BenchmarkCompressWhitespace/test_case
BenchmarkCompressWhitespace/test_case-10   	16433900	        72.80 ns/op
BenchmarkCompressWhitespace/test____case
BenchmarkCompressWhitespace/test____case-10         	14380442	        83.88 ns/op
BenchmarkCompressWhitespace/_test__c__as___
BenchmarkCompressWhitespace/_test__c__as___-10      	12626217	        96.18 ns/op
PASS
```