### PR TITLE
Passthrough non-transformed strings (to some degree) in cssDecode

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package coraza
 
 import (

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -98,4 +99,10 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// WrapUnsafe wraps the provided buffer as a string. The buffer
+// must not be mutated after calling this function.
+func WrapUnsafe(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/transformations/css_decode.go
+++ b/transformations/css_decode.go
@@ -4,18 +4,25 @@
 package transformations
 
 import (
+	"strings"
+
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 func cssDecode(data string) (string, error) {
-	return cssDecodeInplace(data), nil
+	if i := strings.IndexByte(data, '\\'); i != -1 {
+		// TODO: This will transform even if the backslash isn't followed by hex,
+		// but keep it simple for now.
+		return cssDecodeInplace(data, i), nil
+	}
+	return data, nil
 }
 
-func cssDecodeInplace(input string) string {
-	// TODO the following shall be int64?
-	var c, i, j, count int
+func cssDecodeInplace(input string, pos int) string {
 	d := []byte(input)
 	inputLen := len(d)
+	i := pos
+	c := pos
 
 	for i < inputLen {
 		/* Is the character a backslash? */
@@ -25,7 +32,7 @@ func cssDecodeInplace(input string) string {
 				i++ /* We are not going to need the backslash. */
 
 				/* Check for 1-6 hex characters following the backslash */
-				j = 0
+				j := 0
 				for (j < 6) && (i+j < inputLen) && (utils.ValidHex(input[i+j])) {
 					j++
 				}
@@ -100,7 +107,6 @@ func cssDecodeInplace(input string) string {
 					}
 
 					/* Move over. */
-					count++
 					i += j
 				case input[i] == '\n':
 					/* No hexadecimal digits after backslash */
@@ -113,7 +119,6 @@ func cssDecodeInplace(input string) string {
 					d[c] = input[i]
 					i++
 					c++
-					count++
 				}
 			} else {
 				/* No characters after backslash. */
@@ -127,7 +132,6 @@ func cssDecodeInplace(input string) string {
 			d[c] = input[i]
 			c++
 			i++
-			count++
 		}
 	}
 

--- a/transformations/css_decode.go
+++ b/transformations/css_decode.go
@@ -138,7 +138,7 @@ func cssDecodeInplace(input string, pos int) string {
 	/* Terminate output string. */
 	d = d[:c]
 
-	return string(d)
+	return utils.WrapUnsafe(d)
 }
 
 /**

--- a/transformations/css_decode_test.go
+++ b/transformations/css_decode_test.go
@@ -1,0 +1,25 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func BenchmarkCSSDecode(b *testing.B) {
+	tests := []string{
+		"",
+		"hello world",
+		"test\\a\\b\\f\\n\\r\\t\\v\\?\\'\\\"\\\u0000\\12\\123\\1234\\12345\\123456\\ff01\\ff5e\\\n\\\u0000  string",
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := cssDecode(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkCSSDecode
BenchmarkCSSDecode/#00
BenchmarkCSSDecode/#00-10         	463445419	         2.597 ns/op
BenchmarkCSSDecode/hello_world
BenchmarkCSSDecode/hello_world-10 	319812020	         3.715 ns/op
BenchmarkCSSDecode/test\a\b\f\n\r\t\v\?\'\"\\x00\12\123\1234\12345\123456\ff01\ff5e\_\\x00__string
BenchmarkCSSDecode/test\a\b\f\n\r\t\v\?\'\"\\x00\12\123\1234\12345\123456\ff01\ff5e\_\\x00__string-10         	 9009106	       133.5 ns/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/transformations
BenchmarkCSSDecode
BenchmarkCSSDecode/#00
BenchmarkCSSDecode/#00-10         	264846192	         4.522 ns/op
BenchmarkCSSDecode/hello_world
BenchmarkCSSDecode/hello_world-10 	52190552	        22.95 ns/op
BenchmarkCSSDecode/test\a\b\f\n\r\t\v\?\'\"\\x00\12\123\1234\12345\123456\ff01\ff5e\_\\x00__string
BenchmarkCSSDecode/test\a\b\f\n\r\t\v\?\'\"\\x00\12\123\1234\12345\123456\ff01\ff5e\_\\x00__string-10         	 8262039	       145.9 ns/op
PASS
```