### PR TITLE
WrapUnsafe in hash transformations

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package coraza
 
 import (

--- a/internal/strings/strings.go
+++ b/internal/strings/strings.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -98,4 +99,10 @@ func InSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+// WrapUnsafe wraps the provided buffer as a string. The buffer
+// must not be mutated after calling this function.
+func WrapUnsafe(buf []byte) string {
+	return *(*string)(unsafe.Pointer(&buf))
 }

--- a/transformations/md5.go
+++ b/transformations/md5.go
@@ -5,19 +5,26 @@ package transformations
 
 import (
 	"crypto/md5"
-	"io"
-
 	"github.com/corazawaf/coraza/v3/internal/strings"
+	"io"
 )
+
+var emptyMD5 string
 
 func md5T(data string) (string, error) {
 	if len(data) == 0 {
-		return "", nil
+		return emptyMD5, nil
 	}
+
 	h := md5.New()
 	_, err := io.WriteString(h, data)
 	if err != nil {
 		return data, err
 	}
 	return strings.WrapUnsafe(h.Sum(nil)), nil
+}
+
+func init() {
+	buf := md5.Sum(nil)
+	emptyMD5 = string(buf[:])
 }

--- a/transformations/md5.go
+++ b/transformations/md5.go
@@ -6,13 +6,18 @@ package transformations
 import (
 	"crypto/md5"
 	"io"
+
+	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 func md5T(data string) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
 	h := md5.New()
 	_, err := io.WriteString(h, data)
 	if err != nil {
 		return data, err
 	}
-	return string(h.Sum(nil)), nil
+	return strings.WrapUnsafe(h.Sum(nil)), nil
 }

--- a/transformations/md5.go
+++ b/transformations/md5.go
@@ -5,8 +5,9 @@ package transformations
 
 import (
 	"crypto/md5"
-	"github.com/corazawaf/coraza/v3/internal/strings"
 	"io"
+
+	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 var emptyMD5 string

--- a/transformations/md5_test.go
+++ b/transformations/md5_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func BenchmarkMD5(b *testing.B) {
+	tests := []string{
+		"",
+		"1234567890",
+	}
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := md5T(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/transformations/sha1.go
+++ b/transformations/sha1.go
@@ -10,9 +10,11 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
+var emptySHA1 string
+
 func sha1T(data string) (string, error) {
 	if len(data) == 0 {
-		return "", nil
+		return emptySHA1, nil
 	}
 	h := sha1.New()
 	_, err := io.WriteString(h, data)
@@ -20,4 +22,9 @@ func sha1T(data string) (string, error) {
 		return data, err
 	}
 	return strings.WrapUnsafe(h.Sum(nil)), nil
+}
+
+func init() {
+	buf := sha1.Sum(nil)
+	emptySHA1 = string(buf[:])
 }

--- a/transformations/sha1.go
+++ b/transformations/sha1.go
@@ -6,13 +6,18 @@ package transformations
 import (
 	"crypto/sha1"
 	"io"
+
+	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 func sha1T(data string) (string, error) {
+	if len(data) == 0 {
+		return "", nil
+	}
 	h := sha1.New()
 	_, err := io.WriteString(h, data)
 	if err != nil {
 		return data, err
 	}
-	return string(h.Sum(nil)), nil
+	return strings.WrapUnsafe(h.Sum(nil)), nil
 }

--- a/transformations/sha1_test.go
+++ b/transformations/sha1_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func BenchmarkSHA1(b *testing.B) {
+	tests := []string{
+		"",
+		"1234567890",
+	}
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, err := sha1T(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
After
```
BenchmarkSHA1
BenchmarkSHA1/#00
BenchmarkSHA1/#00-10         	555318814	         2.120 ns/op
BenchmarkSHA1/1234567890
BenchmarkSHA1/1234567890-10  	11032917	       108.5 ns/op
BenchmarkMD5
BenchmarkMD5/#00
BenchmarkMD5/#00-10         	563206208	         2.136 ns/op
BenchmarkMD5/1234567890
BenchmarkMD5/1234567890-10  	 7238055	       165.6 ns/op
```

Before
```
BenchmarkSHA1
BenchmarkSHA1/#00
BenchmarkSHA1/#00-10         	10593223	       110.5 ns/op
BenchmarkSHA1/1234567890
BenchmarkSHA1/1234567890-10  	10065594	       123.5 ns/op
BenchmarkMD5
BenchmarkMD5/#00
BenchmarkMD5/#00-10         	 7257741	       164.5 ns/op
BenchmarkMD5/1234567890
BenchmarkMD5/1234567890-10  	 6698254	       175.3 ns/op
```