### PR TITLE
Revert "Cache transformations within a phase (#537)"

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,3 @@
-// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
-// SPDX-License-Identifier: Apache-2.0
-
 package coraza
 
 import (

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/types"
-	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 // RuleGroup is a collection of rules
@@ -100,10 +99,6 @@ func (rg *RuleGroup) Eval(phase types.RulePhase, tx *Transaction) bool {
 	tx.LastPhase = phase
 	usedRules := 0
 	ts := time.Now().UnixNano()
-	transformationCache := tx.transformationCache
-	for k := range transformationCache {
-		delete(transformationCache, k)
-	}
 RulesLoop:
 	for _, r := range tx.WAF.Rules.GetRules() {
 		if tx.interruption != nil && phase != types.PhaseLogging {
@@ -141,7 +136,7 @@ RulesLoop:
 		tx.variables.matchedVars.Reset()
 		tx.variables.matchedVarsNames.Reset()
 
-		r.Evaluate(tx, transformationCache)
+		r.Evaluate(tx)
 		tx.Capture = false // we reset captures
 		usedRules++
 	}
@@ -158,16 +153,4 @@ func NewRuleGroup() RuleGroup {
 	return RuleGroup{
 		rules: []*Rule{},
 	}
-}
-
-type transformationKey struct {
-	argKey            string
-	argIndex          int
-	argVariable       variables.RuleVariable
-	transformationsID int
-}
-
-type transformationValue struct {
-	args []string
-	errs []error
 }

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -104,8 +104,6 @@ type Transaction struct {
 	audit bool
 
 	variables TransactionVariables
-
-	transformationCache map[transformationKey]transformationValue
 }
 
 func (tx *Transaction) ID() string {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -190,7 +190,6 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 		})
 		tx.variables = *NewTransactionVariables()
-		tx.transformationCache = map[transformationKey]transformationValue{}
 	}
 
 	// set capture variables


### PR DESCRIPTION
I had intended to run coraza-proxy-wasm with this change to check it and didn't see an issue but must have missed rebuilding or similar. When updating coraza and checking, I found this change makes wasm 3-4x slower. Trimming down, it seems that computing the cache key takes significant time as well as the map lookup. The only hypothesis is that TinyGo's code for maps isn't as fast as Go's but will investigate more before trying again