### PR TITLE
Use pointer for arg key in cache key

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -5,10 +5,12 @@ package corazawaf
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"unsafe"
 
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
 	"github.com/corazawaf/coraza/v3/macro"
@@ -303,8 +305,11 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 			arg, errs := r.executeTransformations(arg.Value())
 			return []string{arg}, errs
 		default:
+			// NOTE: See comment on transformationKey struct to understand this hacky code
+			argKey := arg.Key()
+			argKeyPtr := (*reflect.StringHeader)(unsafe.Pointer(&argKey)).Data
 			key := transformationKey{
-				argKey:            arg.Key(),
+				argKey:            argKeyPtr,
 				argIndex:          argIdx,
 				argVariable:       arg.Variable(),
 				transformationsID: r.transformationsID,

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -161,7 +161,13 @@ func NewRuleGroup() RuleGroup {
 }
 
 type transformationKey struct {
-	argKey            string
+	// TODO(anuraaga): This is a big hack to support performance on TinyGo. TinyGo
+	// cannot efficiently compute a hashcode for a struct if it has embedded non-fixed
+	// size fields, for example string as we'd prefer to use here. A pointer is usable,
+	// and it works for us since we know that the arg key string is populated once per
+	// transaction phase and we would never have different string pointers with the same
+	// content.
+	argKey            uintptr
 	argIndex          int
 	argVariable       variables.RuleVariable
 	transformationsID int

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -166,7 +166,8 @@ type transformationKey struct {
 	// size fields, for example string as we'd prefer to use here. A pointer is usable,
 	// and it works for us since we know that the arg key string is populated once per
 	// transaction phase and we would never have different string pointers with the same
-	// content.
+	// content, or more problematically same pointer for different content, as the strings
+	// will be alive throughout the phase.
 	argKey            uintptr
 	argIndex          int
 	argVariable       variables.RuleVariable


### PR DESCRIPTION
It does happen to work and enables TinyGo to work well

See https://github.com/tinygo-org/tinygo/issues/3354 for context

I found that TinyGo does not handle map keys with embedded variable-length fields (basically just `string` I guess) well, converting to interface and using reflection, which causes allocations and general slowness.

The arg key string coincidentally has a stable pointer for our purposes here...so we can use it.

This is an alternative to #552 but is very hacky. If it seems like too much, we can give up on the cache for now. But I do think the cache is important for performance so maybe we can live with it. I would be surprised if FTW were to pass in the future if a bug was caused by the pointer stability property not being valid anymore, so that safety measure is there, I guess.