### PR TITLE
Allocate transformation cache value on heap

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -160,11 +160,11 @@ func (r *Rule) Status() int {
 // Evaluate will evaluate the current rule for the indicated transaction
 // If the operator matches, actions will be evaluated, and it will return
 // the matched variables, keys and values (MatchData)
-func (r *Rule) Evaluate(tx rules.TransactionState, cache map[transformationKey]transformationValue) []types.MatchData {
+func (r *Rule) Evaluate(tx rules.TransactionState, cache map[transformationKey]*transformationValue) []types.MatchData {
 	return r.doEvaluate(tx.(*Transaction), cache)
 }
 
-func (r *Rule) doEvaluate(tx *Transaction, cache map[transformationKey]transformationValue) []types.MatchData {
+func (r *Rule) doEvaluate(tx *Transaction, cache map[transformationKey]*transformationValue) []types.MatchData {
 	if r.Capture {
 		tx.Capture = true
 	}
@@ -291,7 +291,7 @@ func (r *Rule) doEvaluate(tx *Transaction, cache map[transformationKey]transform
 	return matchedValues
 }
 
-func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]transformationValue) ([]string, []error) {
+func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]*transformationValue) ([]string, []error) {
 	if r.MultiMatch {
 		// TODO in the future, we don't need to run every transformation
 		// We could try for each until found
@@ -320,7 +320,7 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 				ars, es := r.executeTransformations(arg.Value())
 				args := []string{ars}
 				errs := es
-				cache[key] = transformationValue{
+				cache[key] = &transformationValue{
 					args: args,
 					errs: es,
 				}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -105,7 +105,7 @@ type Transaction struct {
 
 	variables TransactionVariables
 
-	transformationCache map[transformationKey]transformationValue
+	transformationCache map[transformationKey]*transformationValue
 }
 
 func (tx *Transaction) ID() string {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -190,7 +190,7 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 		})
 		tx.variables = *NewTransactionVariables()
-		tx.transformationCache = map[transformationKey]transformationValue{}
+		tx.transformationCache = map[transformationKey]*transformationValue{}
 	}
 
 	// set capture variables


### PR DESCRIPTION
Previously I thought TinyGo problems were solved by #553 but I hadn't let the bench run long enough to see it get slower over time, an indication of memory leak.

It seems like there is a bug in TinyGo - https://github.com/tinygo-org/tinygo/issues/3358

The issue only happens with largeish values it looks like - so using a pointer for the value appears to make the problem go away. This is not ideal as it means heap allocation, something we wanted to avoid with this cache. But performance does seem to be a bit better on FTW (and presumably more so with larger payloads) with this change compared to without a transformation cache, so we can live with it until debugging further. The heap allocated object is a fixed, smallish size (it contains a couple of slices, not data itself) so it's not related to payload size as a saving grace