### PR TITLE
Append request body

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -59,13 +59,13 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// body inspection, otherwise we just let the request follow its
 		// regular flow.
 		if req.Body != nil && req.Body != http.NoBody {
-			in, _, err := tx.ReadRequestBodyFrom(req.Body)
+			it, _, err := tx.ReadRequestBodyFrom(req.Body)
 			if err != nil {
 				return nil, fmt.Errorf("failed to append request body: %s", err.Error())
 			}
 
-			if in != nil {
-				return in, nil
+			if it != nil {
+				return it, nil
 			}
 
 			rbr, err := tx.RequestBodyReader()

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -59,7 +59,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// body inspection, otherwise we just let the request follow its
 		// regular flow.
 		if req.Body != nil && req.Body != http.NoBody {
-			in, _, err := tx.WriteRequestBodyFrom(req.Body)
+			in, _, err := tx.ReadRequestBodyFrom(req.Body)
 			if err != nil {
 				return nil, fmt.Errorf("failed to append request body: %s", err.Error())
 			}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -59,7 +59,7 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// body inspection, otherwise we just let the request follow its
 		// regular flow.
 		if req.Body != nil && req.Body != http.NoBody {
-			in, _, err := tx.AppendRequestBody(req.Body)
+			in, _, err := tx.WriteRequestBodyFrom(req.Body)
 			if err != nil {
 				return nil, fmt.Errorf("failed to append request body: %s", err.Error())
 			}

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -8,6 +8,7 @@
 package http
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -58,16 +59,21 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		// body inspection, otherwise we just let the request follow its
 		// regular flow.
 		if req.Body != nil && req.Body != http.NoBody {
-			_, err := io.Copy(tx.RequestBodyWriter(), req.Body)
+			in, _, err := tx.AppendRequestBody(req.Body)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to append request body: %s", err.Error())
 			}
 
-			reader, err := tx.RequestBodyReader()
-			if err != nil {
-				return nil, err
+			if in != nil {
+				return in, nil
 			}
-			reader = io.MultiReader(reader, req.Body)
+
+			rbr, err := tx.RequestBodyReader()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get the request body: %s", err.Error())
+			}
+
+			body := io.MultiReader(rbr, req.Body)
 			// req.Body is transparently reinizialied with a new io.ReadCloser.
 			// The http handler will be able to read it.
 			// Prior to Go 1.19 NopCloser does not implement WriterTo if the reader implements it.
@@ -76,24 +82,22 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 			// This avoid errors like "failed to process request: malformed chunked encoding" when
 			// using io.Copy.
 			// In Go 1.19 we just do `req.Body = io.NopCloser(reader)`
-			if rwt, ok := reader.(io.WriterTo); ok {
+			if rwt, ok := body.(io.WriterTo); ok {
 				req.Body = struct {
 					io.Reader
 					io.WriterTo
 					io.Closer
-				}{reader, rwt, req.Body}
+				}{body, rwt, req.Body}
 			} else {
 				req.Body = struct {
 					io.Reader
 					io.Closer
-				}{reader, req.Body}
+				}{body, req.Body}
 			}
 		}
-
-		return tx.ProcessRequestBody()
 	}
 
-	return nil, nil
+	return tx.ProcessRequestBody()
 }
 
 func WrapHandler(waf coraza.WAF, l Logger, h http.Handler) http.Handler {

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -45,6 +45,7 @@ func (br *BodyBuffer) WriteTo(w io.Writer) (int64, error) {
 
 // Write appends data to the body buffer by chunks
 // You may dump io.Readers using io.Copy(br, reader)
+// TODO(jcchavezs): Stop writing beyond the limit
 func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	if len(data) == 0 {
 		return 0, nil

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -25,6 +25,7 @@ type BodyBuffer struct {
 
 // Write appends data to the body buffer by chunks
 // You may dump io.Readers using io.Copy(br, reader)
+// TODO(jcchavezs): Stop writing beyond the limit
 func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	if len(data) == 0 {
 		return 0, nil

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -45,7 +45,6 @@ func (br *BodyBuffer) WriteTo(w io.Writer) (int64, error) {
 
 // Write appends data to the body buffer by chunks
 // You may dump io.Readers using io.Copy(br, reader)
-// TODO(jcchavezs): Stop writing beyond the limit
 func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	if len(data) == 0 {
 		return 0, nil

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -771,10 +771,6 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 	return tx.interruption
 }
 
-type Lenger interface {
-	Len() int
-}
-
 func (tx *Transaction) WriteRequestBody(b []byte) (*types.Interruption, int, error) {
 	if tx.RuleEngine == types.RuleEngineOff {
 		return nil, 0, nil
@@ -815,6 +811,10 @@ func (tx *Transaction) WriteRequestBody(b []byte) (*types.Interruption, int, err
 	}
 
 	return nil, int(w), nil
+}
+
+type Lenger interface {
+	Len() int
 }
 
 // ReadRequestBodyFrom writes bytes from a reader into the request body

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -174,8 +174,8 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 
 	// Always non-nil if buffers / collections were already initialized so we don't do any of them
 	// based on the presence of RequestBodyBuffer.
-	if tx.RequestBodyBuffer == nil {
-		tx.RequestBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
+	if tx.requestBodyBuffer == nil {
+		tx.requestBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath:     w.TmpDir,
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 		})

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -14,6 +14,7 @@ func TestNewTransaction(t *testing.T) {
 	waf.RequestBodyAccess = true
 	waf.ResponseBodyAccess = true
 	waf.RequestBodyLimit = 1044
+
 	tx := waf.NewTransactionWithID("test")
 	if !tx.RequestBodyAccess {
 		t.Error("Request body access not enabled")

--- a/internal/seclang/body_test.go
+++ b/internal/seclang/body_test.go
@@ -20,7 +20,7 @@ func TestRequestBodyAccessOff(t *testing.T) {
 	}
 	tx := waf.NewTransaction()
 	tx.ProcessURI("/", "POST", "http/1.1")
-	tx.RequestBodyBuffer.Write([]byte("test=123"))
+	tx.requestBodyBuffer.Write([]byte("test=123"))
 	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
 	tx.ProcessRequestHeaders()
 	tx.ProcessRequestBody()
@@ -39,7 +39,7 @@ func TestRequestBodyAccessOn(t *testing.T) {
 	}
 	tx := waf.NewTransaction()
 	tx.ProcessURI("/", "POST", "http/1.1")
-	if _, err := tx.RequestBodyBuffer.Write([]byte("test=123")); err != nil {
+	if _, _, err := tx.WriteRequestBody([]byte("test=123")); err != nil {
 		t.Error(err)
 	}
 	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -4,7 +4,6 @@
 package seclang
 
 import (
-	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -957,12 +956,17 @@ Content-Type: application/octet-stream
 
 BINARYDATA
 ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--`)
-	_, err = io.Copy(tx.RequestBodyBuffer, body)
+	it, _, err := tx.WriteRequestBodyFrom(body)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	it, err := tx.ProcessRequestBody()
+
+	if it != nil {
+		t.Fatal(err)
+	}
+
+	it, err = tx.ProcessRequestBody()
 	if err != nil {
 		t.Error(err)
 		return

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -956,7 +956,7 @@ Content-Type: application/octet-stream
 
 BINARYDATA
 ------WebKitFormBoundaryABCDEFGIJKLMNOPQ--`)
-	it, _, err := tx.WriteRequestBodyFrom(body)
+	it, _, err := tx.ReadRequestBodyFrom(body)
 	if err != nil {
 		t.Error(err)
 		return

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -110,7 +110,7 @@ func BenchmarkCRSSimplePOST(b *testing.B) {
 		tx.AddRequestHeader("Accept", "application/json")
 		tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
 		tx.ProcessRequestHeaders()
-		if _, err := tx.RequestBodyWriter().Write([]byte("parameters2=and&other2=Stuff")); err != nil {
+		if _, _, err := tx.WriteRequestBody([]byte("parameters2=and&other2=Stuff")); err != nil {
 			b.Error(err)
 		}
 		if _, err := tx.ProcessRequestBody(); err != nil {
@@ -144,7 +144,7 @@ func BenchmarkCRSLargePOST(b *testing.B) {
 		tx.AddRequestHeader("Accept", "application/json")
 		tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
 		tx.ProcessRequestHeaders()
-		if _, err := tx.RequestBodyWriter().Write(postPayload); err != nil {
+		if _, _, err := tx.WriteRequestBody(postPayload); err != nil {
 			b.Error(err)
 		}
 		if _, err := tx.ProcessRequestBody(); err != nil {

--- a/testing/engine.go
+++ b/testing/engine.go
@@ -134,7 +134,7 @@ func (t *Test) SetRequestBody(body interface{}) error {
 	if t.magic {
 		t.RequestHeaders["content-length"] = strconv.Itoa(lbody)
 	}
-	if _, err := t.transaction.RequestBodyWriter().Write([]byte(data)); err != nil {
+	if _, _, err := t.transaction.WriteRequestBody([]byte(data)); err != nil {
 		return err
 	}
 	return nil

--- a/testing/modsecurity_test.go
+++ b/testing/modsecurity_test.go
@@ -133,7 +133,7 @@ func BenchmarkModSecurityCRSSimplePOST(b *testing.B) {
 		if err := tx.ProcessRequestHeaders(); err != nil {
 			b.Error(err)
 		}
-		if err := tx.AppendRequestBody(body); err != nil {
+		if err := tx.WriteRequestBodyFrom(body); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessRequestBody(); err != nil {

--- a/testing/modsecurity_test.go
+++ b/testing/modsecurity_test.go
@@ -133,7 +133,7 @@ func BenchmarkModSecurityCRSSimplePOST(b *testing.B) {
 		if err := tx.ProcessRequestHeaders(); err != nil {
 			b.Error(err)
 		}
-		if err := tx.WriteRequestBodyFrom(body); err != nil {
+		if err := tx.ReadRequestBodyFrom(body); err != nil {
 			b.Error(err)
 		}
 		if err := tx.ProcessRequestBody(); err != nil {

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -84,7 +84,7 @@ type Transaction interface {
 	// Remember to check for a possible intervention.
 	ProcessRequestBody() (*Interruption, error)
 
-	// ReadRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// WriteRequestBody attempts to write data into the body up to the buffer limit and
 	// returns an interruption if the body is bigger than the limit and the action is to
 	// reject. This is specially convenient to resolve an interruption before copying
 	// the body into the request body buffer.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -88,6 +88,14 @@ type Transaction interface {
 	// Remember to check for a possible intervention.
 	ProcessRequestBody() (*Interruption, error)
 
+	// AppendRequestBody attempts to write data into the body up to the buffer limit and
+	// returns an interruption of the body is bigger than the limit and the action is to
+	// reject. This is specially convenient to resolve an interruption before copying
+	// the body into the RequestBodyWriter.
+	//
+	// It returns the corresponding interruption, the number of bytes written an error if any.
+	AppendRequestBody(io.Reader) (*Interruption, int, error)
+
 	// AddResponseHeader Adds a response header variable
 	//
 	// With this method it is possible to feed Coraza with a response header.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -63,12 +63,8 @@ type Transaction interface {
 	// note: Remember to check for a possible intervention.
 	ProcessRequestHeaders() *Interruption
 
-	// RequestBodyWriter returns a io.Writer for writing the request body to.
-	// Contents will be buffered until the transaction is closed.
-	RequestBodyWriter() io.Writer
-
 	// RequestBodyReader returns a reader for content that has been written by
-	// RequestBodyWriter. This can be useful for buffering the request body
+	// request body buffer. This can be useful for buffering the request body
 	// within the Transaction while also passing it further in an HTTP framework.
 	RequestBodyReader() (io.Reader, error)
 
@@ -88,13 +84,21 @@ type Transaction interface {
 	// Remember to check for a possible intervention.
 	ProcessRequestBody() (*Interruption, error)
 
-	// AppendRequestBody attempts to write data into the body up to the buffer limit and
-	// returns an interruption of the body is bigger than the limit and the action is to
+	// WriteRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// returns an interruption if the body is bigger than the limit and the action is to
 	// reject. This is specially convenient to resolve an interruption before copying
-	// the body into the RequestBodyWriter.
+	// the body into the request body buffer.
 	//
 	// It returns the corresponding interruption, the number of bytes written an error if any.
-	AppendRequestBody(io.Reader) (*Interruption, int, error)
+	WriteRequestBody(b []byte) (*Interruption, int, error)
+
+	// WriteRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// returns an interruption if the body is bigger than the limit and the action is to
+	// reject. This is specially convenient to resolve an interruption before copying
+	// the body into the request body buffer.
+	//
+	// It returns the corresponding interruption, the number of bytes written an error if any.
+	WriteRequestBodyFrom(io.Reader) (*Interruption, int, error)
 
 	// AddResponseHeader Adds a response header variable
 	//

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -84,7 +84,7 @@ type Transaction interface {
 	// Remember to check for a possible intervention.
 	ProcessRequestBody() (*Interruption, error)
 
-	// WriteRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// ReadRequestBodyFrom attempts to write data into the body up to the buffer limit and
 	// returns an interruption if the body is bigger than the limit and the action is to
 	// reject. This is specially convenient to resolve an interruption before copying
 	// the body into the request body buffer.
@@ -92,13 +92,13 @@ type Transaction interface {
 	// It returns the corresponding interruption, the number of bytes written an error if any.
 	WriteRequestBody(b []byte) (*Interruption, int, error)
 
-	// WriteRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// ReadRequestBodyFrom attempts to write data into the body up to the buffer limit and
 	// returns an interruption if the body is bigger than the limit and the action is to
 	// reject. This is specially convenient to resolve an interruption before copying
 	// the body into the request body buffer.
 	//
 	// It returns the corresponding interruption, the number of bytes written an error if any.
-	WriteRequestBodyFrom(io.Reader) (*Interruption, int, error)
+	ReadRequestBodyFrom(io.Reader) (*Interruption, int, error)
 
 	// AddResponseHeader Adds a response header variable
 	//


### PR DESCRIPTION
Currently we were blindly copying the request body from the upstream call to the
RequestBodyWriter and then back to the downstream handler in many cases wasting resources
because body was beyong what coraza should analyse and or request end up being rejected
due to the size. This method allows to early check conditions around the body size to be
able to resolve a rejecting before copying the the body (or part of it).

The design is similar to https://github.com/SpiderLabs/ModSecurity/blob/8c409149c9e03c36d3feb767f74a07405bc1a685/src/transaction.cc#L1038 as suggested by @M4tteoP 

Missing:
- tests multiwrite
- calling ProcessRequestBody if the limit is hit