### PR TITLE
Don't seek output file when reading from buffer

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -17,10 +17,6 @@ import (
 	"github.com/corazawaf/coraza/v3/types"
 )
 
-type nopCloser struct{}
-
-func (nopCloser) Close() error { return nil }
-
 // processRequest fills all transaction variables from an http.Request object
 // Most implementations of Coraza will probably use http.Request objects
 // so this will implement all phase 0, 1 and 2 variables

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -60,15 +60,36 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	return br.buffer.Write(data)
 }
 
+type bodyBufferReader struct {
+	pos int
+	br  *BodyBuffer
+}
+
+func (b *bodyBufferReader) Read(p []byte) (n int, err error) {
+	if environment.IsTinyGo || b.br.writer == nil {
+		buf := b.br.buffer.Bytes()
+		n = len(p)
+		if b.pos+n > len(buf) {
+			n = len(buf) - b.pos
+		}
+		if n == 0 {
+			return 0, io.EOF
+		}
+		copy(p, buf[b.pos:b.pos+n])
+		b.pos += n
+		return
+	}
+
+	n, err = b.br.writer.ReadAt(p, int64(b.pos))
+	b.pos += n
+	return
+}
+
 // Reader Returns a working reader for the body buffer in memory or file
 func (br *BodyBuffer) Reader() (io.Reader, error) {
-	if environment.IsTinyGo || br.writer == nil {
-		return bytes.NewReader(br.buffer.Bytes()), nil
-	}
-	if _, err := br.writer.Seek(0, 0); err != nil {
-		return nil, err
-	}
-	return br.writer, nil
+	return &bodyBufferReader{
+		br: br,
+	}, nil
 }
 
 // Size returns the current size of the body buffer

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -237,10 +237,10 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 		w.Header().Set("Content-Type", "text/plain")
 		switch {
 		case r.URL.Path == "/anything":
+			body, err := io.ReadAll(r.Body)
 			// Emulated httpbin behaviour: /anything endpoint acts as an echo server, writing back the request body
 			if r.Header.Get("Content-Type") == "application/x-www-form-urlencoded" {
 				// Tests 954120-1 and 954120-2 are the only two calling /anything with a POST and payload is urlencoded
-				body, _ := io.ReadAll(r.Body)
 				if err != nil {
 					t.Fatalf("handler can not read request body: %v", err)
 				}
@@ -250,7 +250,7 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 				}
 				fmt.Fprintf(w, urldecodedBody)
 			} else {
-				_, err = io.Copy(w, r.Body)
+				_, err = w.Write(body)
 			}
 
 		case strings.HasPrefix(r.URL.Path, "/base64/"):


### PR DESCRIPTION
Currently, the buffer file is seeked as soon as `Reader` is called, but is particularly problematic as even in our middleware code, it's natural to call `Reader`, then `ProcessRequestBody`, then actually read from the reader when there is no interruption. Currently, the reader will not return the body for a disk buffer as it would have already been consumed by `ProcessRequestBody`, the seek won't be at 0 anymore - I guess in general we don't have much test coverage that triggers disk buffer writes, FTW would catch it if the payloads were big enough for that and assuming the response body is verified.

Instead, we should keep a separate iterator independent from the file write position. We can follow up with optimizations to implement more interfaces like `Len()` but want to keep the bug fix simple for now. 

The API tweaks in #560 look like a good direction but I'd like to get this merged before to notably have the unit test to make sure it stays fixed