### PR TITLE
Support evaluation of rules in multiple phases

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -48,6 +48,11 @@ jobs:
       - uses: codecov/codecov-action@v2
         if: ${{ matrix.go-version == '1.19.x' }}
         with:
+          files: build/coverage-ftw-multiphase.txt
+          flags: ftw-multiphase
+      - uses: codecov/codecov-action@v2
+        if: ${{ matrix.go-version == '1.19.x' }}
+        with:
           files: build/coverage-tinygo.txt
           flags: tinygo
       - name: SonarCloud Scan

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ func main() {
 ```
 [Examples/http-server](./examples/http-server/) provides an example to practice with Coraza.
 
+### Build tags
+
+Go build tags can tweak certain functionality at compile-time. These are for advanced use cases only and do not
+have compatibility guarantees across minor versions - use with care.
+
+- coraza.disabled_operators.* - excludes the specified operator from compilation. Particularly useful if overriding
+the operator with `operators.Register` to reduce binary size / startup overhead.
+- `coraza.rule.multiphase_valuation` - enables evaluation of rule variables in the phases that they are ready, not
+only the phase the rule is defined for.
+
 ## Tools
 
 * [Go FTW](https://github.com/coreruleset/go-ftw): Rule testing engine

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -203,6 +203,9 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 			// TODO(anuraaga): Support skipping variables based on phase for rule chains too.
 			if multiphaseEvaluation && !r.HasChain && r.ParentID_ == 0 {
 				min := minPhase(v.Variable)
+				// When multiphase evaluation is enabled, any variable is evaluated at its
+				// earliest possible phase, so we skip it if the rule refers to other phases
+				// to avoid double-evaluation.
 				if min != types.PhaseUnknown && min != phase {
 					continue
 				}

--- a/internal/corazawaf/rule_option_default.go
+++ b/internal/corazawaf/rule_option_default.go
@@ -1,0 +1,11 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !coraza.rule.multiphase_evaluation
+
+package corazawaf
+
+// multiphaseEvaluation indicates whether we should evaluate rules that match against variables
+// ready in multiple phases in each of those phases. CRS sets the phase for many rules to the
+// maximum phase of all variables, which means that earlier variables have evaluation deferred.
+const multiphaseEvaluation = false

--- a/internal/corazawaf/rule_option_multiphase.go
+++ b/internal/corazawaf/rule_option_multiphase.go
@@ -1,0 +1,8 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build coraza.rule.multiphase_evaluation
+
+package corazawaf
+
+const multiphaseEvaluation = true

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -37,6 +37,8 @@ func (rg *RuleGroup) Add(rule *Rule) error {
 	for _, v := range rule.variables {
 		min := minPhase(v.Variable)
 		if min != 0 {
+			// We infer the earliest phase a variable used by the rule may be evaluated for use when
+			// multiphase evaluation is enabled
 			rule.inferredPhases[min] = true
 			numInferred++
 		}
@@ -122,6 +124,7 @@ RulesLoop:
 		}
 		// Rules with phase 0 will always run
 		if r.Phase_ != 0 && r.Phase_ != phase {
+			// Execute the rule in inferred phases too if multiphase evaluation is enabled
 			if !multiphaseEvaluation || !r.inferredPhases[phase] {
 				continue
 			}

--- a/magefile.go
+++ b/magefile.go
@@ -74,6 +74,10 @@ func Test() error {
 	if err := sh.RunV("go", "test", "./testing/coreruleset"); err != nil {
 		return err
 	}
+	// Execute FTW tests with multiphase evaluation enabled as well
+	if err := sh.RunV("go", "test", "-tags=coraza.rule.multiphase_evaluation", "./testing/coreruleset"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/magefile.go
+++ b/magefile.go
@@ -96,6 +96,10 @@ func Coverage() error {
 	if err := sh.RunV("go", "test", "-coverprofile=build/coverage-ftw.txt", "-covermode=atomic", "-coverpkg=./...", "./testing/coreruleset"); err != nil {
 		return err
 	}
+	// Execute FTW tests with multiphase evaluation enabled as well
+	if err := sh.RunV("go", "test", "-coverprofile=build/coverage-ftw-multiphase.txt", "-covermode=atomic", "-coverpkg=./...", "-tags=coraza.rule.multiphase_evaluation", "./testing/coreruleset"); err != nil {
+		return err
+	}
 	// This is not actually running tests with tinygo, but with the tag that includes its code so we can calculate coverage
 	// for it.
 	if err := sh.RunV("go", "test", "-race", "-tags=tinygo", "-coverprofile=build/coverage-tinygo.txt", "-covermode=atomic", "-coverpkg=./...", "./..."); err != nil {

--- a/types/phase.go
+++ b/types/phase.go
@@ -12,6 +12,8 @@ import (
 type RulePhase int
 
 const (
+	// PhaseUnknown represents a phase unrecognized by Coraza
+	PhaseUnknown RulePhase = 0
 	// PhaseRequestHeaders will process once the request headers are received
 	PhaseRequestHeaders RulePhase = 1
 	// PhaseRequestBody will process once the request body is received
@@ -43,7 +45,7 @@ func ParseRulePhase(phase string) (RulePhase, error) {
 		i, _ = strconv.Atoi(phase)
 	}
 	if i > 5 || i < 1 {
-		return 0, fmt.Errorf("invalid phase %s", phase)
+		return PhaseUnknown, fmt.Errorf("invalid phase %s", phase)
 	}
 	return RulePhase(i), nil
 }


### PR DESCRIPTION
For coraza-proxy-wasm, we have been discussing evaluation escape because Envoy will send request headers upstream before waiting for request body. As we execute phase 1 when headers are available, phase 2 rules will not have been run by then. Unfortunately, many rules in CRS are set to phase 2 but match against both phase 1 and phase 2 variables, for example the log4shell rule. Malicious headers can be sent upstream without checking them.

As we do have a good idea of when variables are ready for many of them, it is possible for us to infer which phases the rule should run. Connectors should generally know when their server/proxy will send headers before body or not, so this opts in as a build tag for now. It could be a runtime flag in the future if we find a use case for it, e.g. a server that can have both modes based on some configuration. Or maybe we find this behavior to be good anyways and we remove the flag, who knows.

The two problematic variables are `Args` and `ArgsNames` - they mutate between phase 1 and 2. I had initially thought we could just evaluate them twice but found a single rule that relies on idempotency

https://github.com/coreruleset/coreruleset/blob/6eeea4243fdf3ddd0b1a0263bdee63a4f57ca55e/rules/REQUEST-921-PROTOCOL-ATTACK.conf#L442

Though it means in concept, a variable can only be matched once as even custom rules could rely on idempotency, so these variables are still evaluated at phase 2. It means is still possible for e.g. `Args` that match during headers to escape - while a general split of rules in CRS would be a huge undertaking, perhaps just changing e.g. `ARGS` to `ARGS_GET|ARGS_POST` would still be reasonable.

The rules that get executed in multiple phases are in https://gist.github.com/anuraaga/91223f9ae7f7b7251b86b0411fadb9b4. 944150, log4shell is there. And in general we can expect all these rules to allow bypass of headers currently with Envoy.

There are a couple of expectations that provide motivation for this change

- It would likely be overopinionated to require connectors to block headers before receiving a body. Proxies may not have a lifecycle that follows this and become unable to use Coraza / CRS if we require it
- There is already a phase 1 and 2. If evaluation of phase 1 doesn't actually mean phase 1 information is safe because phase 2 rules are required, there is no meaning in a phase 1 and we'd expect to only have a request/response phase. The intent of the phases must be to allow headers to be considered safe at phase 1 it seems

Also note that initially I considered splitting the rules themselves at the seclang level to not need library code change - but I realized this would need IDs assigned to the split rules and FTW would be difficult to make work in that world. As this change ended up relatively small, I think the library change behind a build tag should be OK

@fzipi @jcchavezs @jptosso @M4tteoP will be good to discuss this. Though hopefully we can be relatively optimistic on merging given the default behavior without a build tag is unchanged and it can all be reverted if needed