### PR TITLE
Add infrastructure for and a couple of fuzz tests

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,3 +16,9 @@ jobs:
         with:
           go-version: '>=1.18.0'
       - run: go run mage.go fuzz
+      - run: |
+          gh issue create --title "$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER failed" \
+                          --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+        if: failure() && github.run_attempt == 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,18 @@
+name: Fuzz tests
+
+on:
+  schedule:
+    # https://crontab.guru/#05_14_*_*_*
+    - cron: '05 14 * * *'
+  workflow_dispatch:
+
+jobs:
+  fuzz:
+    name: Fuzz tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '>=1.18.0'
+      - run: go run mage.go fuzz

--- a/magefile.go
+++ b/magefile.go
@@ -101,6 +101,23 @@ func Coverage() error {
 	return sh.RunV("go", "tool", "cover", "-html=build/coverage.txt", "-o", "build/coverage.html")
 }
 
+// Fuzz runs fuzz tests
+func Fuzz() error {
+	// Go must be run once per test when fuzzing
+	transformationTests := []string{
+		"FuzzB64Decode",
+		"FuzzCMDLine",
+	}
+	for _, test := range transformationTests {
+		fmt.Println("Running", test)
+		if err := sh.RunV("go", "test", "-fuzz="+test, "-fuzztime=2m", "./transformations"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Doc runs godoc, access at http://localhost:6060
 func Doc() error {
 	return sh.RunV("go", "run", "golang.org/x/tools/cmd/godoc@latest", "-http=:6060")

--- a/transformations/base64decode_test.go
+++ b/transformations/base64decode_test.go
@@ -3,16 +3,21 @@
 
 package transformations
 
-import "testing"
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+var b64DecodeTests = []string{
+	"VGVzdENhc2U=",
+	"P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+	"VGVzdABDYXNl",
+}
 
 func BenchmarkB64Decode(b *testing.B) {
-	tests := []string{
-		"VGVzdENhc2U=",
-		"P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
-		"VGVzdABDYXNl",
-	}
-
-	for _, tt := range tests {
+	for _, tt := range b64DecodeTests {
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := base64decode(tt)
@@ -22,4 +27,25 @@ func BenchmarkB64Decode(b *testing.B) {
 			}
 		})
 	}
+}
+
+func FuzzB64Decode(f *testing.F) {
+	for _, tc := range b64DecodeTests {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, tc string) {
+		data, err := base64decode(tc)
+		// We decode base64 within non-base64 so there is no
+		// error case.
+		if err != nil {
+			t.Error(err)
+		}
+
+		refData, err := base64.StdEncoding.DecodeString(tc)
+		// The standard library decoder will fail on many inputs ours succeeds on, but when
+		// it doesn't and there are no newlines in the input, they should match.
+		if err == nil && !strings.ContainsAny(tc, "\n\r") && !bytes.Equal([]byte(data), refData) {
+			t.Errorf("mismatch with stdlib for input %s", tc)
+		}
+	})
 }

--- a/transformations/cmd_line_test.go
+++ b/transformations/cmd_line_test.go
@@ -3,17 +3,20 @@
 
 package transformations
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+var cmdLineTests = []string{
+	"",
+	"test",
+	"C^OMMAND /C DIR",
+	"\"command\" /c DiR",
+}
 
 func BenchmarkCMDLine(b *testing.B) {
-	tests := []string{
-		"",
-		"test",
-		"C^OMMAND /C DIR",
-		"\"command\" /c DiR",
-	}
-
-	for _, tc := range tests {
+	for _, tc := range cmdLineTests {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
@@ -23,4 +26,21 @@ func BenchmarkCMDLine(b *testing.B) {
 			}
 		})
 	}
+}
+
+func FuzzCMDLine(f *testing.F) {
+	for _, tc := range cmdLineTests {
+		f.Add(tc)
+	}
+	f.Fuzz(func(t *testing.T, tc string) {
+		data, err := cmdLine(tc)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Check simple expectations
+		if strings.ContainsAny(data, `\"'^,;'ABCDEFGHIJKLMNOPQRSTUVWXYZ`) {
+			t.Errorf("unexpected characters in output %s for input %s", data, tc)
+		}
+	})
 }


### PR DESCRIPTION
Being a security product, it seems like it will be good to run some fuzz tests especially on our string crunching code. This adds a couple of fuzz tests to start and a nightly run.