### PR TITLE
chore: implements idempotency for phase calling.

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -5,6 +5,7 @@ package corazawaf
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -744,6 +745,12 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 		// Rule engine is disabled
 		return nil
 	}
+
+	if tx.interruption != nil {
+		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a prexisting interruption")
+		return tx.interruption
+	}
+
 	tx.WAF.Rules.Eval(types.PhaseRequestHeaders, tx)
 	return tx.interruption
 }
@@ -763,6 +770,12 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 	if tx.RuleEngine == types.RuleEngineOff {
 		return nil, nil
 	}
+
+	if tx.interruption != nil {
+		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a prexisting interruption")
+		return tx.interruption, nil
+	}
+
 	// we won't process empty request bodies or disabled RequestBodyAccess
 	if !tx.RequestBodyAccess || tx.RequestBodyBuffer.Size() == 0 {
 		tx.WAF.Rules.Eval(types.PhaseRequestBody, tx)
@@ -815,7 +828,7 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 	}
 	bodyprocessor, err := bodyprocessors.Get(rbp)
 	if err != nil {
-		tx.generateReqbodyError(fmt.Errorf("Invalid body processor"))
+		tx.generateReqbodyError(errors.New("invalid body processor"))
 		tx.WAF.Rules.Eval(types.PhaseRequestBody, tx)
 		return tx.interruption, nil
 	}
@@ -839,13 +852,18 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 //
 // note: Remember to check for a possible intervention.
 func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Interruption {
-	c := strconv.Itoa(code)
-	tx.variables.responseStatus.Set(c)
-	tx.variables.responseProtocol.Set(proto)
-
 	if tx.RuleEngine == types.RuleEngineOff {
 		return nil
 	}
+
+	if tx.interruption != nil {
+		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a prexisting interruption")
+		return tx.interruption
+	}
+
+	c := strconv.Itoa(code)
+	tx.variables.responseStatus.Set(c)
+	tx.variables.responseProtocol.Set(proto)
 
 	tx.WAF.Rules.Eval(types.PhaseResponseHeaders, tx)
 	return tx.interruption
@@ -875,8 +893,14 @@ func (tx *Transaction) ResponseBodyWriter() io.Writer {
 // note Remember to check for a possible intervention.
 func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 	if tx.RuleEngine == types.RuleEngineOff {
+		return nil, nil
+	}
+
+	if tx.interruption != nil {
+		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a prexisting interruption")
 		return tx.interruption, nil
 	}
+
 	if !tx.ResponseBodyAccess || !tx.IsResponseBodyProcessable() {
 		tx.WAF.Logger.Debug("[%s] Skipping response body processing (Access: %t)", tx.id, tx.ResponseBodyAccess)
 		tx.WAF.Rules.Eval(types.PhaseResponseBody, tx)

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -747,7 +747,7 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 	}
 
 	if tx.interruption != nil {
-		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a prexisting interruption")
+		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
 
@@ -772,7 +772,7 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 	}
 
 	if tx.interruption != nil {
-		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a prexisting interruption")
+		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}
 
@@ -857,7 +857,7 @@ func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Int
 	}
 
 	if tx.interruption != nil {
-		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a prexisting interruption")
+		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
 
@@ -897,7 +897,7 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 	}
 
 	if tx.interruption != nil {
-		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a prexisting interruption")
+		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -857,7 +857,7 @@ func TestProcessorsIdempotency(t *testing.T) {
 				t.Fatalf("unexpected number of log entries, want %d, have %d", want, have)
 			}
 
-			expectedMessage := fmt.Sprintf("[ERROR] Calling %s but there is a prexisting interruption\n", processor)
+			expectedMessage := fmt.Sprintf("[ERROR] Calling %s but there is a preexisting interruption\n", processor)
 
 			if want, have := expectedMessage, l.entries[0]; want != have {
 				t.Fatalf("unexpected message, want %q, have %q", want, have)


### PR DESCRIPTION
Currently if there is an interruption in a previous phase and one call a ulterior phase, it will do the entire analysis, possible not returning the former interruption. While this is a programatic error, given the nature of the library we should let the user know this is happening.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: