### PR TITLE
chore: idempotency on ProcessX functions

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -749,7 +749,9 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 		// Phase already evaluated
 		tx.WAF.Logger.Error("ProcessRequestHeaders has already been called")
 		return tx.interruption
-	} else if tx.interruption != nil {
+	}
+	
+	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
@@ -778,7 +780,9 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 		// Phase already evaluated
 		tx.WAF.Logger.Error("ProcessRequestBody has already been called")
 		return tx.interruption, nil
-	} else if tx.interruption != nil {
+	}
+	
+	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}
@@ -867,7 +871,9 @@ func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Int
 		// Phase already evaluated
 		tx.WAF.Logger.Error("ProcessResponseHeaders has already been called")
 		return tx.interruption
-	} else if tx.interruption != nil {
+	} 
+	
+	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
@@ -911,7 +917,9 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 		// Phase already evaluated
 		tx.WAF.Logger.Error("ProcessResponseBody has already been called")
 		return tx.interruption, nil
-	} else if tx.interruption != nil {
+	}
+	
+	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -750,7 +750,7 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 		tx.WAF.Logger.Error("ProcessRequestHeaders has already been called")
 		return tx.interruption
 	}
-	
+
 	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a preexisting interruption")
 		return tx.interruption
@@ -781,7 +781,7 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 		tx.WAF.Logger.Error("ProcessRequestBody has already been called")
 		return tx.interruption, nil
 	}
-	
+
 	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a preexisting interruption")
 		return tx.interruption, nil
@@ -871,8 +871,8 @@ func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Int
 		// Phase already evaluated
 		tx.WAF.Logger.Error("ProcessResponseHeaders has already been called")
 		return tx.interruption
-	} 
-	
+	}
+
 	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a preexisting interruption")
 		return tx.interruption
@@ -918,7 +918,7 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 		tx.WAF.Logger.Error("ProcessResponseBody has already been called")
 		return tx.interruption, nil
 	}
-	
+
 	if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a preexisting interruption")
 		return tx.interruption, nil

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -745,8 +745,11 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 		// Rule engine is disabled
 		return nil
 	}
-
-	if tx.interruption != nil {
+	if tx.LastPhase >= types.PhaseRequestHeaders {
+		// Phase already evaluated
+		tx.WAF.Logger.Error("ProcessRequestHeaders has already been called")
+		return tx.interruption
+	} else if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
@@ -771,7 +774,11 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 		return nil, nil
 	}
 
-	if tx.interruption != nil {
+	if tx.LastPhase >= types.PhaseRequestBody {
+		// Phase already evaluated
+		tx.WAF.Logger.Error("ProcessRequestBody has already been called")
+		return tx.interruption, nil
+	} else if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessRequestBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}
@@ -856,7 +863,11 @@ func (tx *Transaction) ProcessResponseHeaders(code int, proto string) *types.Int
 		return nil
 	}
 
-	if tx.interruption != nil {
+	if tx.LastPhase >= types.PhaseResponseHeaders {
+		// Phase already evaluated
+		tx.WAF.Logger.Error("ProcessResponseHeaders has already been called")
+		return tx.interruption
+	} else if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseHeaders but there is a preexisting interruption")
 		return tx.interruption
 	}
@@ -896,7 +907,11 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 		return nil, nil
 	}
 
-	if tx.interruption != nil {
+	if tx.LastPhase >= types.PhaseResponseBody {
+		// Phase already evaluated
+		tx.WAF.Logger.Error("ProcessResponseBody has already been called")
+		return tx.interruption, nil
+	} else if tx.interruption != nil {
 		tx.WAF.Logger.Error("Calling ProcessResponseBody but there is a preexisting interruption")
 		return tx.interruption, nil
 	}


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/pull/571 working on idempotency: avoids calling twice any of the `ProcessX` functions. I think it is more about making explicit an implicit requirement that was addressed by the connectors' logic, rather than a design change. What do you think?