### PR TITLE
expose ID

### DIFF
--- a/types/transaction.go
+++ b/types/transaction.go
@@ -175,6 +175,9 @@ type Transaction interface {
 	// MatchedRules returns the rules that have matched the requests with associated information.
 	MatchedRules() []MatchedRule
 
+	// ID returns the transaction ID.
+	ID() string
+
 	// Closer closes the transaction and releases any resources associated with it such as request/response bodies.
 	io.Closer
 }


### PR DESCRIPTION
Expose ID() function in types.Transaction.

It's sometimes useful for connectors to retrieve the transaction ID for audit.

It could be replaced by generating the ID at the connector and using waf.NewTransactionWithID("id")