### PR TITLE
fix: fixes side effects between calls when a file does not exist in parser

### DIFF
--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -58,6 +58,7 @@ func (p *Parser) FromFile(profilePath string) error {
 		p.currentDir = filepath.Dir(profilePath)
 		file, err := fs.ReadFile(p.root, profilePath)
 		if err != nil {
+			// we don't use defer for this as tinygo does not seem to like it
 			p.currentDir = originalDir
 			p.currentFile = ""
 			p.options.WAF.Logger.Error(err.Error())
@@ -66,6 +67,7 @@ func (p *Parser) FromFile(profilePath string) error {
 
 		err = p.FromString(string(file))
 		if err != nil {
+			// we don't use defer for this as tinygo does not seem to like it
 			p.currentDir = originalDir
 			p.currentFile = ""
 			p.options.WAF.Logger.Error(err.Error())
@@ -74,6 +76,7 @@ func (p *Parser) FromFile(profilePath string) error {
 		// restore the lastDir post processing all includes
 		p.currentDir = lastDir
 	}
+	// we don't use defer for this as tinygo does not seem to like it
 	p.currentDir = originalDir
 	p.currentFile = ""
 

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -36,10 +36,7 @@ type Parser struct {
 // If the path contains a *, it will be expanded to all
 // files in the directory matching the pattern
 func (p *Parser) FromFile(profilePath string) error {
-	defer func(originalDir string) {
-		p.currentDir = originalDir
-		p.currentFile = ""
-	}(p.currentDir)
+	originalDir := p.currentDir
 
 	var files []string
 	if strings.Contains(profilePath, "*") {
@@ -61,18 +58,25 @@ func (p *Parser) FromFile(profilePath string) error {
 		p.currentDir = filepath.Dir(profilePath)
 		file, err := fs.ReadFile(p.root, profilePath)
 		if err != nil {
+			p.currentDir = originalDir
+			p.currentFile = ""
 			p.options.WAF.Logger.Error(err.Error())
 			return fmt.Errorf("failed to readfile: %s", err.Error())
 		}
 
 		err = p.FromString(string(file))
 		if err != nil {
+			p.currentDir = originalDir
+			p.currentFile = ""
 			p.options.WAF.Logger.Error(err.Error())
 			return fmt.Errorf("failed to parse string: %s", err.Error())
 		}
 		// restore the lastDir post processing all includes
 		p.currentDir = lastDir
 	}
+	p.currentDir = originalDir
+	p.currentFile = ""
+
 	return nil
 }
 

--- a/internal/seclang/parser_test.go
+++ b/internal/seclang/parser_test.go
@@ -67,12 +67,22 @@ func TestErrorWithBackticks(t *testing.T) {
 	}
 }
 
-func TestDefaultConfigurationFile(t *testing.T) {
+func TestLoadConfigurationFile(t *testing.T) {
 	waf := coraza.NewWAF()
 	p := NewParser(waf)
 	err := p.FromFile("../../coraza.conf-recommended")
 	if err != nil {
-		t.Error(err)
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+
+	err = p.FromFile("../doesnotexist.conf")
+	if err == nil {
+		t.Error("expected not found error")
+	}
+
+	err = p.FromFile("./testdata/glob/*.conf")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
 	}
 }
 

--- a/internal/seclang/testdata/glob/rules1.conf
+++ b/internal/seclang/testdata/glob/rules1.conf
@@ -1,0 +1,3 @@
+# For response body tests
+SecResponseBodyAccess On
+SecResponseBodyMimeType text/plain text/html text/xml application/json

--- a/internal/seclang/testdata/glob/rules2.conf
+++ b/internal/seclang/testdata/glob/rules2.conf
@@ -1,0 +1,3 @@
+SecRule ARGS "@rx rule2"  "id:200, phase:2, log, msg:'Rule 200', \
+    logdata:'Matched Data: %{TX.0} found within %{MATCHED_VAR}'"
+


### PR DESCRIPTION
Currently parser mutates its state in order to resolve relative imports, however when an import file, it keeps the reference of the current directory relatively to the failing file, leading to an error in the next file (because the currentDir reference is stuck in the previous one).

At some point we need to change this, however it will require some changes in the parser and directives.