### PR TITLE
Replace ahocorasick with re2

### DIFF
--- a/operators/pm_from_dataset.go
+++ b/operators/pm_from_dataset.go
@@ -7,8 +7,8 @@ package operators
 
 import (
 	"fmt"
-
-	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+	"regexp"
+	"strings"
 
 	"github.com/corazawaf/coraza/v3/rules"
 )
@@ -19,12 +19,7 @@ func newPMFromDataset(options rules.OperatorOptions) (rules.Operator, error) {
 	if !ok {
 		return nil, fmt.Errorf("dataset %q not found", data)
 	}
-	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
-		AsciiCaseInsensitive: true,
-		MatchOnlyWholeWords:  false,
-		MatchKind:            ahocorasick.LeftMostLongestMatch,
-		DFA:                  true,
-	})
+	patterns := strings.Join(dataset[:], "|")
 
-	return &pm{matcher: builder.Build(dataset)}, nil
+	return &pm{matcher: regexp.MustCompile(patterns)}, nil
 }

--- a/operators/pm_from_file.go
+++ b/operators/pm_from_file.go
@@ -8,9 +8,8 @@ package operators
 import (
 	"bufio"
 	"bytes"
+	"regexp"
 	"strings"
-
-	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
 
 	"github.com/corazawaf/coraza/v3/rules"
 )
@@ -37,14 +36,9 @@ func newPMFromFile(options rules.OperatorOptions) (rules.Operator, error) {
 		lines = append(lines, strings.ToLower(l))
 	}
 
-	builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
-		AsciiCaseInsensitive: true,
-		MatchOnlyWholeWords:  false,
-		MatchKind:            ahocorasick.LeftMostLongestMatch,
-		DFA:                  false,
-	})
+	patterns := strings.Join(lines[:], "|")
 
-	return &pm{matcher: builder.Build(lines)}, nil
+	return &pm{matcher: regexp.MustCompile(patterns)}, nil
 }
 
 func init() {


### PR DESCRIPTION
According to https://github.com/corazawaf/coraza/blob/v3/dev/operators/pm.go#L16 

>  according to coraza researchs, re2 matching is faster than ahocorasick, maybe we should switch in the future

I'd like to help migrating from ahocorasick to re2.

Since that's my first time to kick off PR for this project, let me know if anything I need to update. (For example, how to do performance between ahocorasick and re2 as **according to coraza researchs**)

## Test

It seems like all the `go test -v` tests passed:
```sh
❯ go test -v
=== RUN   TestConfigRulesImmutable
--- PASS: TestConfigRulesImmutable (0.00s)
=== RUN   TestNewWAFLimits
=== RUN   TestNewWAFLimits/empty_limit
=== RUN   TestNewWAFLimits/memory_limit_bigger_than_limit
--- PASS: TestNewWAFLimits (0.00s)
    --- PASS: TestNewWAFLimits/empty_limit (0.00s)
    --- PASS: TestNewWAFLimits/memory_limit_bigger_than_limit (0.00s)
PASS
ok  	github.com/corazawaf/coraza/v3	0.658s
```