### PR TITLE
remove old TODO

### DIFF
--- a/operators/pm.go
+++ b/operators/pm.go
@@ -13,9 +13,6 @@ import (
 	"github.com/corazawaf/coraza/v3/rules"
 )
 
-// TODO according to coraza researchs, re2 matching is faster than ahocorasick
-// maybe we should switch in the future
-// pm is always lowercase
 type pm struct {
 	matcher ahocorasick.AhoCorasick
 }


### PR DESCRIPTION
Referencing https://github.com/corazawaf/coraza/pull/585

Our newest implementation of aho-corasick is faster than re2