### PR TITLE
implements ReadResponseBodyFrom and WriteResponseBody

### DIFF
--- a/actions/append.go
+++ b/actions/append.go
@@ -27,7 +27,8 @@ func (a *appendFn) Evaluate(r rules.RuleMetadata, tx rules.TransactionState) {
 		return
 	}
 	data := a.data.Expand(tx)
-	if _, err := tx.ResponseBodyWriter().Write([]byte(data)); err != nil {
+	// TODO: elaborate on ContentInjection actions considering that the WAF may NOT buffer the whole response
+	if it, _, err := tx.WriteResponseBody([]byte(data)); it != nil || err != nil {
 		tx.DebugLogger().Error("append failed to write to response buffer: %s", err.Error())
 	}
 }

--- a/actions/prepend.go
+++ b/actions/prepend.go
@@ -35,15 +35,15 @@ func (a *prependFn) Evaluate(r rules.RuleMetadata, txS rules.TransactionState) {
 	data := a.data.Expand(tx)
 	buf := corazawaf.NewBodyBuffer(types.BodyBufferOptions{
 		TmpPath:     tx.WAF.TmpDir,
-		MemoryLimit: tx.WAF.RequestBodyInMemoryLimit,
-		Limit:       tx.WAF.RequestBodyLimit,
+		MemoryLimit: tx.WAF.ResponseBodyLimit,
+		Limit:       tx.WAF.ResponseBodyLimit,
 	})
 
 	_, err := buf.Write([]byte(data))
 	if err != nil {
 		tx.WAF.Logger.Debug("failed to write buffer while evaluating prepend action: %s", err.Error())
 	}
-	reader, err := tx.ResponseBodyBuffer.Reader()
+	reader, err := tx.ResponseBodyReader()
 	if err != nil {
 		tx.WAF.Logger.Debug("failed to read response body while evaluating prepend action: %s", err.Error())
 	}
@@ -51,8 +51,11 @@ func (a *prependFn) Evaluate(r rules.RuleMetadata, txS rules.TransactionState) {
 	if err != nil {
 		tx.WAF.Logger.Debug("failed to append response buffer while evaluating prepend action: %s", err.Error())
 	}
+	// TODO: elaborate on ContentInjection actions considering that the WAF may NOT buffer the whole response
 	// We overwrite the response body buffer with the new buffer
-	*tx.ResponseBodyBuffer = *buf
+	// TODO: implement the swap
+	// *tx.ResponseBodyBuffer = *buf
+
 	// Maybe in the future we could add the prepend function to the BodyBuffer
 }
 

--- a/examples/http-server/main_test.go
+++ b/examples/http-server/main_test.go
@@ -76,17 +76,16 @@ func TestHttpServer(t *testing.T) {
 			},
 			[]byte("beyond the limit script"),
 		},
-		// TODO(M4tteoP) uncomment after merging WriteRsponseBody logic
-		// {
-		// 	"positive for response body limit reject",
-		// 	"/",
-		// 	403,
-		// 	map[string]string{
-		// 		"DIRECTIVES_FILE": "./testdata/response-body-limits-reject.conf",
-		// 		"RESPONSE_BODY":   "response body beyond the limit",
-		// 	},
-		// 	nil,
-		// },
+		{
+			"positive for response body limit reject",
+			"/",
+			403,
+			map[string]string{
+				"DIRECTIVES_FILE": "./testdata/response-body-limits-reject.conf",
+				"RESPONSE_BODY":   "response body beyond the limit",
+			},
+			nil,
+		},
 	}
 	// Perform tests
 	for _, tc := range tests {

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -51,7 +51,7 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	if br.length == br.options.Limit || br.length >= (br.options.Limit-int64(len(data))) {
+	if br.length > br.options.Limit || br.length > (br.options.Limit-int64(len(data))) {
 		// Write has been called without checking the Limit, it should never happend. Raising an error.
 		// The buffers are private and populated only by WriteRequestBody, ReadRequestBodyFrom, and similar functions
 		// that have to perform limit checks before calling Write()

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -816,7 +816,7 @@ func (tx *Transaction) WriteRequestBody(b []byte) (*types.Interruption, int, err
 		return nil, 0, errors.New("Overflow reached while writing request body")
 	}
 
-	if tx.requestBodyBuffer.length+writingBytes > tx.RequestBodyLimit {
+	if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
 		tx.variables.inboundErrorData.Set("1")
 		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 			// We interrupt this transaction in case RequestBodyLimitAction is Reject
@@ -882,7 +882,7 @@ func (tx *Transaction) ReadRequestBodyFrom(r io.Reader) (*types.Interruption, in
 			// bytes.Buffer does not work with this kind of sizes. See comments in BodyBuffer Write(data []byte)
 			return nil, 0, errors.New("Overflow reached while writing request body")
 		}
-		if tx.requestBodyBuffer.length+writingBytes > tx.RequestBodyLimit {
+		if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
 			tx.variables.inboundErrorData.Set("1")
 			if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 				return setAndReturnBodyLimitInterruption(tx)
@@ -1062,7 +1062,7 @@ func (tx *Transaction) WriteResponseBody(b []byte) (*types.Interruption, int, er
 		writingBytes           = int64(len(b))
 		runProcessResponseBody = false
 	)
-	if tx.responseBodyBuffer.length+writingBytes > tx.ResponseBodyLimit {
+	if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
 		// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
 		tx.variables.outboundDataError.Set("1")
 		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
@@ -1114,7 +1114,7 @@ func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, i
 	)
 	if l, ok := r.(ByteLenger); ok {
 		writingBytes = int64(l.Len())
-		if tx.responseBodyBuffer.length+writingBytes > tx.ResponseBodyLimit {
+		if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
 			// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
 			tx.variables.outboundDataError.Set("1")
 			if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -773,12 +773,6 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 }
 
 func setAndReturnBodyLimitInterruption(tx *Transaction) (*types.Interruption, int, error) {
-	if tx.LastPhase <= types.PhaseRequestBody {
-		tx.variables.inboundErrorData.Set("1")
-	} else {
-		// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
-		tx.variables.outboundDataError.Set("1")
-	}
 	tx.DebugLogger().Warn("Disrupting transaction with body size above the configured limit (Action Reject)")
 	tx.interruption = &types.Interruption{
 		Status: 403,
@@ -822,7 +816,8 @@ func (tx *Transaction) WriteRequestBody(b []byte) (*types.Interruption, int, err
 		return nil, 0, errors.New("Overflow reached while writing request body")
 	}
 
-	if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
+	if tx.requestBodyBuffer.length+writingBytes > tx.RequestBodyLimit {
+		tx.variables.inboundErrorData.Set("1")
 		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 			// We interrupt this transaction in case RequestBodyLimitAction is Reject
 			return setAndReturnBodyLimitInterruption(tx)
@@ -887,7 +882,8 @@ func (tx *Transaction) ReadRequestBodyFrom(r io.Reader) (*types.Interruption, in
 			// bytes.Buffer does not work with this kind of sizes. See comments in BodyBuffer Write(data []byte)
 			return nil, 0, errors.New("Overflow reached while writing request body")
 		}
-		if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
+		if tx.requestBodyBuffer.length+writingBytes > tx.RequestBodyLimit {
+			tx.variables.inboundErrorData.Set("1")
 			if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 				return setAndReturnBodyLimitInterruption(tx)
 			}
@@ -1066,7 +1062,9 @@ func (tx *Transaction) WriteResponseBody(b []byte) (*types.Interruption, int, er
 		writingBytes           = int64(len(b))
 		runProcessResponseBody = false
 	)
-	if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
+	if tx.responseBodyBuffer.length+writingBytes > tx.ResponseBodyLimit {
+		// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
+		tx.variables.outboundDataError.Set("1")
 		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
 			// We interrupt this transaction in case ResponseBodyLimitAction is Reject
 			return setAndReturnBodyLimitInterruption(tx)
@@ -1116,7 +1114,9 @@ func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, i
 	)
 	if l, ok := r.(ByteLenger); ok {
 		writingBytes = int64(l.Len())
-		if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
+		if tx.responseBodyBuffer.length+writingBytes > tx.ResponseBodyLimit {
+			// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
+			tx.variables.outboundDataError.Set("1")
 			if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
 				return setAndReturnBodyLimitInterruption(tx)
 			}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -920,10 +920,10 @@ func (tx *Transaction) ReadRequestBodyFrom(r io.Reader) (*types.Interruption, in
 	return tx.interruption, int(w), err
 }
 
-// ProcessRequestBody Performs the request body (if any)
+// ProcessRequestBody Performs the analysis of the request body (if any)
 //
 // This method perform the analysis on the request body. It is optional to
-// call that function. If this API consumer already know that there isn't a
+// call that function. If this API consumer already knows that there isn't a
 // body for inspect it is recommended to skip this step.
 //
 // Remember to check for a possible intervention.
@@ -1035,8 +1035,8 @@ func (tx *Transaction) IsResponseBodyProcessable() bool {
 }
 
 // WriteResponseBody writes bytes from a slice of bytes into the response body,
-// it returns an interuption if the writing bytes go beyond the response body limit.
-// It won't copy the bytes if the body access isn't accesible.
+// it returns an interruption if the writing bytes go beyond the response body limit.
+// It won't copy the bytes if the body access isn't accessible.
 func (tx *Transaction) WriteResponseBody(b []byte) (*types.Interruption, int, error) {
 	if tx.RuleEngine == types.RuleEngineOff {
 		return nil, 0, nil
@@ -1087,8 +1087,8 @@ func (tx *Transaction) WriteResponseBody(b []byte) (*types.Interruption, int, er
 }
 
 // ReadResponseBodyFrom writes bytes from a reader into the response body
-// it returns an interuption if the writing bytes go beyond the response body limit.
-// It won't read the reader if the body access isn't accesible.
+// it returns an interruption if the writing bytes go beyond the response body limit.
+// It won't read the reader if the body access isn't accessible.
 func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, int, error) {
 	if tx.RuleEngine == types.RuleEngineOff {
 		return nil, 0, nil
@@ -1098,12 +1098,12 @@ func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, i
 		return nil, 0, nil
 	}
 
-	if tx.ResponseBodyLimit == tx.requestBodyBuffer.length {
-		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
+	if tx.ResponseBodyLimit == tx.responseBodyBuffer.length {
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
 			return tx.interruption, 0, nil
 		}
 
-		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionProcessPartial {
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial {
 			return nil, 0, nil
 		}
 	}
@@ -1152,10 +1152,10 @@ func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, i
 	return tx.interruption, int(w), err
 }
 
-// ProcessResponseBody Perform the response body (if any)
+// ProcessResponseBody Perform the analysis of the the response body (if any)
 //
-// This method perform the analysis on the request body. It is optional to
-// call that method. If this API consumer already know that there isn't a
+// This method perform the analysis on the response body. It is optional to
+// call that method. If this API consumer already knows that there isn't a
 // body for inspect it is recommended to skip this step.
 //
 // note Remember to check for a possible intervention.

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -70,7 +70,7 @@ type Transaction struct {
 	requestBodyBuffer *BodyBuffer
 
 	// Handles response body buffers
-	ResponseBodyBuffer *BodyBuffer
+	responseBodyBuffer *BodyBuffer
 
 	// Body processor used to parse JSON, XML, etc
 	bodyProcessor bodyprocessors.BodyProcessor
@@ -324,7 +324,7 @@ func (tx *Transaction) DebugLogger() loggers.DebugLogger {
 }
 
 func (tx *Transaction) ResponseBodyReader() (io.Reader, error) {
-	return tx.ResponseBodyBuffer.Reader()
+	return tx.responseBodyBuffer.Reader()
 }
 
 func (tx *Transaction) RequestBodyReader() (io.Reader, error) {
@@ -773,7 +773,12 @@ func (tx *Transaction) ProcessRequestHeaders() *types.Interruption {
 }
 
 func setAndReturnBodyLimitInterruption(tx *Transaction) (*types.Interruption, int, error) {
-	tx.variables.inboundErrorData.Set("1")
+	if tx.LastPhase <= types.PhaseRequestBody {
+		tx.variables.inboundErrorData.Set("1")
+	} else {
+		// TODO: figure out ErrorData vs DataError: https://github.com/corazawaf/coraza/issues/564
+		tx.variables.outboundDataError.Set("1")
+	}
 	tx.DebugLogger().Warn("Disrupting transaction with body size above the configured limit (Action Reject)")
 	tx.interruption = &types.Interruption{
 		Status: 403,
@@ -1033,8 +1038,118 @@ func (tx *Transaction) IsResponseBodyProcessable() bool {
 	return stringsutil.InSlice(ct, tx.WAF.ResponseBodyMimeTypes)
 }
 
-func (tx *Transaction) ResponseBodyWriter() io.Writer {
-	return tx.ResponseBodyBuffer
+// WriteResponseBody writes bytes from a slice of bytes into the response body,
+// it returns an interuption if the writing bytes go beyond the response body limit.
+// It won't copy the bytes if the body access isn't accesible.
+func (tx *Transaction) WriteResponseBody(b []byte) (*types.Interruption, int, error) {
+	if tx.RuleEngine == types.RuleEngineOff {
+		return nil, 0, nil
+	}
+
+	if !tx.ResponseBodyAccess {
+		return nil, 0, nil
+	}
+
+	if tx.ResponseBodyLimit == tx.responseBodyBuffer.length {
+		// tx.ResponseBodyLimit will never be zero so if this happened, we have an
+		// interruption for sure.
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
+			return tx.interruption, 0, nil
+		}
+
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial {
+			return nil, 0, nil
+		}
+	}
+
+	var (
+		writingBytes           = int64(len(b))
+		runProcessResponseBody = false
+	)
+	if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
+			// We interrupt this transaction in case ResponseBodyLimitAction is Reject
+			return setAndReturnBodyLimitInterruption(tx)
+		}
+
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial {
+			writingBytes = tx.ResponseBodyLimit - tx.responseBodyBuffer.length
+			runProcessResponseBody = true
+		}
+	}
+	w, err := tx.responseBodyBuffer.Write(b[:writingBytes])
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if runProcessResponseBody {
+		_, err = tx.ProcessResponseBody()
+	}
+	return tx.interruption, int(w), err
+}
+
+// ReadResponseBodyFrom writes bytes from a reader into the response body
+// it returns an interuption if the writing bytes go beyond the response body limit.
+// It won't read the reader if the body access isn't accesible.
+func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, int, error) {
+	if tx.RuleEngine == types.RuleEngineOff {
+		return nil, 0, nil
+	}
+
+	if !tx.ResponseBodyAccess {
+		return nil, 0, nil
+	}
+
+	if tx.ResponseBodyLimit == tx.requestBodyBuffer.length {
+		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
+			return tx.interruption, 0, nil
+		}
+
+		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionProcessPartial {
+			return nil, 0, nil
+		}
+	}
+
+	var (
+		writingBytes           int64
+		runProcessResponseBody = false
+	)
+	if l, ok := r.(ByteLenger); ok {
+		writingBytes = int64(l.Len())
+		if tx.responseBodyBuffer.length+writingBytes >= tx.ResponseBodyLimit {
+			if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
+				return setAndReturnBodyLimitInterruption(tx)
+			}
+
+			if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial {
+				writingBytes = tx.ResponseBodyLimit - tx.responseBodyBuffer.length
+				runProcessResponseBody = true
+			}
+		}
+	} else {
+		writingBytes = tx.ResponseBodyLimit - tx.responseBodyBuffer.length
+	}
+
+	w, err := io.CopyN(tx.responseBodyBuffer, r, writingBytes)
+	if err != nil && err != io.EOF {
+		return nil, int(w), err
+	}
+
+	if tx.responseBodyBuffer.length == tx.ResponseBodyLimit {
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionReject {
+			return setAndReturnBodyLimitInterruption(tx)
+		}
+
+		if tx.WAF.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial {
+			runProcessResponseBody = true
+		}
+	}
+
+	err = nil
+	if runProcessResponseBody {
+		_, err = tx.ProcessResponseBody()
+	}
+	return tx.interruption, int(w), err
 }
 
 // ProcessResponseBody Perform the response body (if any)
@@ -1066,19 +1181,15 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 		return tx.interruption, nil
 	}
 	tx.WAF.Logger.Debug("[%s] Attempting to process response body", tx.id)
-	reader, err := tx.ResponseBodyBuffer.Reader()
-	if err != nil {
-		return tx.interruption, err
-	}
-	reader = io.LimitReader(reader, tx.WAF.ResponseBodyLimit)
-	buf := new(strings.Builder)
-	length, err := io.Copy(buf, reader)
+	reader, err := tx.responseBodyBuffer.Reader()
 	if err != nil {
 		return tx.interruption, err
 	}
 
-	if tx.ResponseBodyBuffer.Size() >= tx.WAF.ResponseBodyLimit {
-		tx.variables.outboundDataError.Set("1")
+	buf := new(strings.Builder)
+	length, err := io.Copy(buf, reader)
+	if err != nil {
+		return tx.interruption, err
 	}
 
 	tx.variables.responseContentLength.Set(strconv.FormatInt(length, 10))
@@ -1266,7 +1377,7 @@ func (tx *Transaction) Close() error {
 	if err := tx.requestBodyBuffer.Reset(); err != nil {
 		errs = append(errs, err)
 	}
-	if err := tx.ResponseBodyBuffer.Reset(); err != nil {
+	if err := tx.responseBodyBuffer.Reset(); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -434,7 +434,7 @@ func TestResponseBody(t *testing.T) {
 	tx.ResponseBodyAccess = true
 	tx.RuleEngine = types.RuleEngineOn
 	tx.AddResponseHeader("content-type", "text/plain")
-	if _, err := tx.ResponseBodyBuffer.Write([]byte("test123")); err != nil {
+	if it, _, err := tx.WriteResponseBody([]byte("test123")); it != nil || err != nil {
 		t.Error("Failed to write response body buffer")
 	}
 	if _, err := tx.ProcessResponseBody(); err != nil {

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -671,26 +671,26 @@ func TestTransactionSyncPool(t *testing.T) {
 // directly calling Write, otherwise error "Limit reached while writing" is raised and the body is not
 // partially written like this test expects.
 
-// func TestTxPhase4Magic(t *testing.T) {
-// 	waf := NewWAF()
-// 	waf.ResponseBodyAccess = true
-// 	waf.ResponseBodyLimit = 3
-// 	waf.ResponseBodyLimitAction = types.BodyLimitActionProcessPartial
-// 	tx := waf.NewTransaction()
-// 	tx.AddResponseHeader("content-type", "text/html")
-// 	if _, err := tx.ResponseBodyBuffer.Write([]byte("more bytes")); err != nil {
-// 		t.Error(err)
-// 	}
-// 	if _, err := tx.ProcessResponseBody(); err != nil {
-// 		t.Error(err)
-// 	}
-// 	if tx.variables.outboundDataError.String() != "1" {
-// 		t.Error("failed to set outbound data error")
-// 	}
-// 	if tx.variables.responseBody.String() != "mor" {
-// 		t.Error("failed to set response body")
-// 	}
-// }
+func TestTxPhase4Magic(t *testing.T) {
+	waf := NewWAF()
+	waf.ResponseBodyAccess = true
+	waf.ResponseBodyLimit = 3
+	waf.ResponseBodyLimitAction = types.BodyLimitActionProcessPartial
+	tx := waf.NewTransaction()
+	tx.AddResponseHeader("content-type", "text/html")
+	if it, _, err := tx.WriteResponseBody([]byte("more bytes")); it != nil || err != nil {
+		t.Error(err)
+	}
+	if _, err := tx.ProcessResponseBody(); err != nil {
+		t.Error(err)
+	}
+	if tx.variables.outboundDataError.String() != "1" {
+		t.Error("failed to set outbound data error")
+	}
+	if tx.variables.responseBody.String() != "mor" {
+		t.Error("failed to set response body")
+	}
+}
 
 func TestVariablesMatch(t *testing.T) {
 	waf := NewWAF()

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -429,22 +429,212 @@ func TestAuditLog(t *testing.T) {
 	}
 }
 
-func TestResponseBody(t *testing.T) {
-	tx := makeTransaction(t)
-	tx.ResponseBodyAccess = true
-	tx.RuleEngine = types.RuleEngineOn
-	tx.AddResponseHeader("content-type", "text/plain")
-	if it, _, err := tx.WriteResponseBody([]byte("test123")); it != nil || err != nil {
-		t.Error("Failed to write response body buffer")
+var responseBodyWriters = map[string]func(tx *Transaction, body string) (*types.Interruption, int, error){
+	"WriteResponsequestBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.WriteResponseBody([]byte(body))
+	},
+	"ReadResponseBodyFromKnownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.ReadResponseBodyFrom(strings.NewReader(body))
+	},
+	"ReadResponseBodyFromUnknownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.ReadResponseBodyFrom(struct{ io.Reader }{
+			strings.NewReader(body),
+		})
+	},
+}
+
+func TestWriteResponseBody(t *testing.T) {
+	const (
+		urlencodedBody    = "some=result&second=data"
+		urlencodedBodyLen = len(urlencodedBody)
+	)
+
+	testCases := []struct {
+		name                    string
+		responseBodyLimit       int
+		responseBodyLimitAction types.BodyLimitAction
+		shouldInterrupt         bool
+	}{
+		{
+			name:                    "LimitNotReached",
+			responseBodyLimit:       urlencodedBodyLen + 2,
+			responseBodyLimitAction: types.BodyLimitAction(-1),
+		},
+		{
+			name:                    "LimitReachedAndRejects",
+			responseBodyLimit:       urlencodedBodyLen - 3,
+			responseBodyLimitAction: types.BodyLimitActionReject,
+			shouldInterrupt:         true,
+		},
+		{
+			name:                    "LimitReachedAndPartialProcessing",
+			responseBodyLimit:       urlencodedBodyLen - 3,
+			responseBodyLimitAction: types.BodyLimitActionProcessPartial,
+		},
 	}
-	if _, err := tx.ProcessResponseBody(); err != nil {
-		t.Error("Failed to process response body")
+
+	urlencodedBodyLenThird := urlencodedBodyLen / 3
+	bodyChunks := map[string][]string{
+		"BodyInOneShot":     {urlencodedBody},
+		"BodyInThreeChunks": {urlencodedBody[0:urlencodedBodyLenThird], urlencodedBody[urlencodedBodyLenThird : 2*urlencodedBodyLenThird], urlencodedBody[2*urlencodedBodyLenThird:]},
 	}
-	if tx.variables.responseBody.String() != "test123" {
-		t.Error("failed to set response body")
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for name, writeResponseBody := range responseBodyWriters {
+				t.Run(name, func(t *testing.T) {
+					for name, chunks := range bodyChunks {
+						t.Run(name, func(t *testing.T) {
+							waf := NewWAF()
+							waf.RuleEngine = types.RuleEngineOn
+							waf.ResponseBodyAccess = true
+							waf.ResponseBodyLimit = int64(testCase.responseBodyLimit)
+							waf.ResponseBodyLimitAction = testCase.responseBodyLimitAction
+
+							tx := waf.NewTransaction()
+							tx.AddResponseHeader("content-type", "text/plain")
+
+							it := tx.ProcessResponseHeaders(200, "HTTP/1")
+							if it != nil {
+								t.Fatal("Unexpected interruption on headers")
+							}
+
+							var err error
+
+							for _, c := range chunks {
+								if it, _, err = writeResponseBody(tx, c); err != nil {
+									t.Errorf("Failed to write body buffer: %s", err.Error())
+								}
+							}
+
+							if testCase.shouldInterrupt {
+								if it == nil {
+									t.Fatal("Expected interruption, got nil")
+								}
+							} else {
+								it, err := tx.ProcessResponseBody()
+								if err != nil {
+									t.Fatal(err)
+								}
+
+								if it != nil {
+									t.Fatalf("Unexpected interruption")
+								}
+								// checking if the body has been populated up to the first POST arg
+								index := strings.Index(urlencodedBody, "&")
+								if tx.variables.responseBody.String()[:index] != urlencodedBody[:index] {
+									t.Error("failed to set response body")
+								}
+							}
+
+							_ = tx.Close()
+						})
+					}
+
+				})
+			}
+
+		})
 	}
-	if err := tx.Close(); err != nil {
-		t.Error(err)
+}
+
+func TestWriteResponseBodyOnLimitReached(t *testing.T) {
+	testCases := map[string]struct {
+		responseBodyLimitAction types.BodyLimitAction
+		preexistingInterruption *types.Interruption
+	}{
+		"reject": {
+			responseBodyLimitAction: types.BodyLimitActionReject,
+			preexistingInterruption: &types.Interruption{
+				RuleID: 123,
+			},
+		},
+		"partial processing": {
+			responseBodyLimitAction: types.BodyLimitActionProcessPartial,
+		},
+	}
+
+	for tName, tCase := range testCases {
+		waf := NewWAF()
+		waf.RuleEngine = types.RuleEngineOn
+		waf.ResponseBodyAccess = true
+		waf.ResponseBodyLimit = 2
+		waf.ResponseBodyLimitAction = tCase.responseBodyLimitAction
+
+		t.Run(tName, func(t *testing.T) {
+			for wName, writer := range responseBodyWriters {
+				t.Run(wName, func(t *testing.T) {
+					tx := waf.NewTransaction()
+					_, err := tx.responseBodyBuffer.Write([]byte("ab"))
+					if err != nil {
+						t.Fatalf("unexpected error when writing to body buffer directly: %s", err.Error())
+					}
+					tx.interruption = tCase.preexistingInterruption
+
+					it, n, err := writer(tx, "c")
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+
+					if it != tCase.preexistingInterruption {
+						t.Fatalf("unexpected interruption")
+					}
+
+					if n != 0 {
+						t.Fatalf("unexpected number of bytes written")
+					}
+
+					_ = tx.Close()
+				})
+			}
+		})
+	}
+}
+
+func TestWriteResponseBodyIsNopWhenBodyIsNotAccesible(t *testing.T) {
+	testCases := []struct {
+		ruleEngine         types.RuleEngineStatus
+		responseBodyAccess bool
+	}{
+		{
+			ruleEngine: types.RuleEngineOff,
+		},
+		{
+			ruleEngine:         types.RuleEngineOn,
+			responseBodyAccess: false,
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(fmt.Sprintf(
+			"ruleEngine = %s and responseBodyAccess = %t",
+			tCase.ruleEngine.String(),
+			tCase.responseBodyAccess,
+		), func(t *testing.T) {
+			waf := NewWAF()
+			waf.RuleEngine = tCase.ruleEngine
+			waf.ResponseBodyAccess = tCase.responseBodyAccess
+
+			for wName, writer := range responseBodyWriters {
+				t.Run(wName, func(t *testing.T) {
+					tx := waf.NewTransaction()
+					it, n, err := writer(tx, "abc")
+					if err != nil {
+						t.Fatalf("unexpected error: %s", err.Error())
+					}
+
+					if it != nil {
+						t.Fatalf("unexpected interruption")
+					}
+
+					if n != 0 {
+						t.Fatalf("unexpected number of bytes written")
+					}
+
+					_ = tx.Close()
+				})
+			}
+		})
 	}
 }
 
@@ -665,11 +855,6 @@ func TestTransactionSyncPool(t *testing.T) {
 		}
 	}
 }
-
-// TODO: enable again after implemeting tx.ReadResponseBodyFrom
-// Adding Limit check inside body_buffer, we have to rely on tx.ReadResponseBodyFrom instead of
-// directly calling Write, otherwise error "Limit reached while writing" is raised and the body is not
-// partially written like this test expects.
 
 func TestTxPhase4Magic(t *testing.T) {
 	waf := NewWAF()

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -176,7 +176,7 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 			MemoryLimit: w.RequestBodyInMemoryLimit,
 			Limit:       w.ResponseBodyLimit,
 		})
-		tx.ResponseBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
+		tx.responseBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath: w.TmpDir,
 			// the response body is just buffered in memory. Therefore, Limit and MemoryLimit are equal.
 			MemoryLimit: w.ResponseBodyLimit,

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -317,9 +317,10 @@ func TestTxIssue147(t *testing.T) {
 	// we need a content-type header
 	tx.AddResponseHeader("Content-Type", "text/html")
 	if tx.IsResponseBodyProcessable() {
-		if _, err := tx.ResponseBodyBuffer.Write([]byte("#!/usr/bin/python")); err != nil {
+		if it, _, err := tx.WriteResponseBody([]byte("#!/usr/bin/python")); it != nil || err != nil {
 			t.Error(err)
 		}
+
 		it, err := tx.ProcessResponseBody()
 		if err != nil {
 			t.Error(err)

--- a/rules/transaction.go
+++ b/rules/transaction.go
@@ -26,9 +26,12 @@ type TransactionState interface {
 	// Interrupt interrupts the transaction.
 	Interrupt(interruption *types.Interruption)
 
+	// TODO: elaborate while addressing ContentInjection actions
 	// ResponseBodyWriter allows writing to the response body.
 	// TODO(anuraaga): Should this be combined with interruption? Any action writing anything to response can be dangerous.
-	ResponseBodyWriter() io.Writer
+	// ResponseBodyWriter() io.Writer
+	WriteResponseBody(b []byte) (*types.Interruption, int, error)
+	ReadResponseBodyFrom(io.Reader) (*types.Interruption, int, error)
 
 	// ContentInjection returns whether content injection is enabled for this transaction.
 	ContentInjection() bool // TODO(anuraaga): Should be resolved at Init time when WAF is truly immutable.

--- a/testing/engine.go
+++ b/testing/engine.go
@@ -151,7 +151,7 @@ func (t *Test) SetResponseBody(body interface{}) error {
 	if lbody == 0 {
 		return nil
 	}
-	if _, err := t.transaction.ResponseBodyWriter().Write([]byte(data)); err != nil {
+	if it, _, err := t.transaction.WriteResponseBody([]byte(data)); it != nil || err != nil {
 		return err
 	}
 	return nil

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -72,7 +72,7 @@ type Transaction interface {
 	// This will set ARGS_(GET|POST), ARGS, ARGS_NAMES, ARGS_COMBINED_SIZE and
 	// ARGS_(GET|POST)_NAMES
 	// With this method it is possible to feed Coraza with a GET or POST argument
-	// providing granual control over the arguments.
+	// providing granular control over the arguments.
 	AddArgument(orig ArgumentType, key string, value string)
 
 	// ProcessRequestBody Performs the request body (if any)
@@ -113,12 +113,8 @@ type Transaction interface {
 	// note: Remember to check for a possible intervention.
 	ProcessResponseHeaders(code int, proto string) *Interruption
 
-	// ResponseBodyWriter returns a io.Writer for writing the response body to.
-	// Contents will be buffered until the transaction is closed.
-	ResponseBodyWriter() io.Writer
-
 	// ResponseBodyReader returns a reader for content that has been written by
-	// ResponseBodyWriter. This can be useful for buffering the response body
+	// response body buffer. This can be useful for buffering the response body
 	// within the Transaction while also passing it further in an HTTP framework.
 	ResponseBodyReader() (io.Reader, error)
 
@@ -130,6 +126,22 @@ type Transaction interface {
 	//
 	// note Remember to check for a possible intervention.
 	ProcessResponseBody() (*Interruption, error)
+
+	// WriteResponseBody attempts to write data into the body up to the buffer limit and
+	// returns an interruption if the body is bigger than the limit and the action is to
+	// reject. This is specially convenient to resolve an interruption before copying
+	// the body into the response body buffer.
+	//
+	// It returns the corresponding interruption, the number of bytes written an error if any.
+	WriteResponseBody(b []byte) (*Interruption, int, error)
+
+	// ReadRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// returns an interruption if the body is bigger than the limit and the action is to
+	// reject. This is specially convenient to resolve an interruption before copying
+	// the body into the response body buffer.
+	//
+	// It returns the corresponding interruption, the number of bytes written an error if any.
+	ReadResponseBodyFrom(io.Reader) (*Interruption, int, error)
 
 	// ProcessLogging Logging all information relative to this transaction.
 	// An error log

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -78,7 +78,7 @@ type Transaction interface {
 	// ProcessRequestBody Performs the analysis of the request body (if any)
 	//
 	// This method perform the analysis on the request body. It is optional to
-	// call that function. If this API consumer already know that there isn't a
+	// call that function. If this API consumer already knows that there isn't a
 	// body for inspect it is recommended to skip this step.
 	//
 	// Remember to check for a possible intervention.
@@ -121,7 +121,7 @@ type Transaction interface {
 	// ProcessResponseBody Perform the analysis of the response body (if any)
 	//
 	// This method perform the analysis on the response body. It is optional to
-	// call that method. If this API consumer already know that there isn't a
+	// call that method. If this API consumer already knows that there isn't a
 	// body for inspect it is recommended to skip this step.
 	//
 	// note Remember to check for a possible intervention.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -135,7 +135,7 @@ type Transaction interface {
 	// It returns the corresponding interruption, the number of bytes written an error if any.
 	WriteResponseBody(b []byte) (*Interruption, int, error)
 
-	// ReadRequestBodyFrom attempts to write data into the body up to the buffer limit and
+	// ReadResponseBodyFrom attempts to write data into the body up to the buffer limit and
 	// returns an interruption if the body is bigger than the limit and the action is to
 	// reject. This is specially convenient to resolve an interruption before copying
 	// the body into the response body buffer.

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -75,7 +75,7 @@ type Transaction interface {
 	// providing granular control over the arguments.
 	AddArgument(orig ArgumentType, key string, value string)
 
-	// ProcessRequestBody Performs the request body (if any)
+	// ProcessRequestBody Performs the analysis of the request body (if any)
 	//
 	// This method perform the analysis on the request body. It is optional to
 	// call that function. If this API consumer already know that there isn't a
@@ -118,9 +118,9 @@ type Transaction interface {
 	// within the Transaction while also passing it further in an HTTP framework.
 	ResponseBodyReader() (io.Reader, error)
 
-	// ProcessResponseBody Perform the request body (if any)
+	// ProcessResponseBody Perform the analysis of the response body (if any)
 	//
-	// This method perform the analysis on the request body. It is optional to
+	// This method perform the analysis on the response body. It is optional to
 	// call that method. If this API consumer already know that there isn't a
 	// body for inspect it is recommended to skip this step.
 	//

--- a/types/waf.go
+++ b/types/waf.go
@@ -97,17 +97,16 @@ func (re RuleEngineStatus) String() string {
 	return "unknown"
 }
 
-// BodyLimitAction represents the action
-// to take when the request body size exceeds
-// the configured limit.
+// BodyLimitAction represents the action to take when
+// the body size exceeds the configured limit.
 type BodyLimitAction int
 
 const (
-	// BodyLimitActionProcessPartial will process the request body
-	// up to the limit and then reject the request
+	// BodyLimitActionProcessPartial will process the body
+	// up to the limit and then ignores the remaining body bytes
 	BodyLimitActionProcessPartial BodyLimitAction = 0
-	// BodyLimitActionReject will reject the request in case
-	// the request body size exceeds the configured limit
+	// BodyLimitActionReject will reject the connection in case
+	// the body size exceeds the configured limit
 	BodyLimitActionReject BodyLimitAction = 1
 )
 


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/pull/560, implemented corresponding functions for the response body. 

actions related to ContentInjection require extra care. See: https://github.com/corazawaf/coraza/pull/589