### PR TITLE
Simplify Map API

### DIFF
--- a/actions/setvar.go
+++ b/actions/setvar.go
@@ -68,7 +68,7 @@ func (a *setvarFn) Type() rules.ActionType {
 }
 
 func (a *setvarFn) evaluateTxCollection(r rules.RuleMetadata, tx rules.TransactionState, key string, value string) {
-	col := (tx.Collection(a.collection)).(*collection.Map)
+	col := (tx.Collection(a.collection)).(collection.Map)
 	if col == nil {
 		// fmt.Println("Invalid Collection " + a.Collection) LOG error?
 		return

--- a/collection/collection_map.go
+++ b/collection/collection_map.go
@@ -11,18 +11,42 @@ import (
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
+type Map interface {
+	Get(key string) []string
+	FindRegex(key *regexp.Regexp) []types.MatchData
+	FindString(key string) []types.MatchData
+	FindAll() []types.MatchData
+	keysRx(rx *regexp.Regexp) []string
+	keys() []string
+	AddCS(key string, vKey string, vVal string)
+	Add(key string, value string)
+	AddUniqueCS(key string, vKey string, vVal string)
+	AddUnique(key string, value string)
+	SetCS(key string, vKey string, values []string)
+	Set(key string, values []string)
+	SetIndexCS(key string, index int, vKey string, value string)
+	SetIndex(key string, index int, value string)
+	Remove(key string)
+	Name() string
+	Reset()
+	Data() map[string][]string
+
+	rawData() map[string][]types.AnchoredVar
+	variable_() variables.RuleVariable
+}
+
 // Map are used to store VARIABLE data
 // for transactions, this data structured is designed
 // to store slices of data for keys
 // Important: CollectionMaps ARE NOT concurrent safe
-type Map struct {
+type caseSensitiveMap struct {
 	data     map[string][]types.AnchoredVar
 	name     string
 	variable variables.RuleVariable
 }
 
 // Get returns a slice of strings for a key
-func (c *Map) Get(key string) []string {
+func (c *caseSensitiveMap) Get(key string) []string {
 	var values []string
 	for _, a := range c.data[key] {
 		values = append(values, a.Value)
@@ -31,7 +55,7 @@ func (c *Map) Get(key string) []string {
 }
 
 // FindRegex returns a slice of MatchData for the regex
-func (c *Map) FindRegex(key *regexp.Regexp) []types.MatchData {
+func (c *caseSensitiveMap) FindRegex(key *regexp.Regexp) []types.MatchData {
 	var result []types.MatchData
 	for k, data := range c.data {
 		if key.MatchString(k) {
@@ -49,7 +73,7 @@ func (c *Map) FindRegex(key *regexp.Regexp) []types.MatchData {
 }
 
 // FindString returns a slice of MatchData for the string
-func (c *Map) FindString(key string) []types.MatchData {
+func (c *caseSensitiveMap) FindString(key string) []types.MatchData {
 	var result []types.MatchData
 	if key == "" {
 		return c.FindAll()
@@ -69,7 +93,7 @@ func (c *Map) FindString(key string) []types.MatchData {
 }
 
 // FindAll returns all the contained elements
-func (c *Map) FindAll() []types.MatchData {
+func (c *caseSensitiveMap) FindAll() []types.MatchData {
 	var result []types.MatchData
 	for _, data := range c.data {
 		for _, d := range data {
@@ -84,7 +108,7 @@ func (c *Map) FindAll() []types.MatchData {
 	return result
 }
 
-func (c *Map) keysRx(rx *regexp.Regexp) []string {
+func (c *caseSensitiveMap) keysRx(rx *regexp.Regexp) []string {
 	var keys []string
 	for k := range c.data {
 		if rx.MatchString(k) {
@@ -94,7 +118,7 @@ func (c *Map) keysRx(rx *regexp.Regexp) []string {
 	return keys
 }
 
-func (c *Map) keys() []string {
+func (c *caseSensitiveMap) keys() []string {
 	var keys []string
 	for k := range c.data {
 		keys = append(keys, k)
@@ -103,19 +127,19 @@ func (c *Map) keys() []string {
 }
 
 // AddCS a value to some key with case sensitive vKey
-func (c *Map) AddCS(key string, vKey string, vVal string) {
+func (c *caseSensitiveMap) AddCS(key string, vKey string, vVal string) {
 	aVal := types.AnchoredVar{Name: vKey, Value: vVal}
 	c.data[key] = append(c.data[key], aVal)
 }
 
 // Add a value to some key
-func (c *Map) Add(key string, value string) {
+func (c *caseSensitiveMap) Add(key string, value string) {
 	c.AddCS(key, key, value)
 }
 
 // AddUniqueCS will add a value to a key if it is not already there
 // with case sensitive vKey
-func (c *Map) AddUniqueCS(key string, vKey string, vVal string) {
+func (c *caseSensitiveMap) AddUniqueCS(key string, vKey string, vVal string) {
 	if c.data[key] == nil {
 		c.AddCS(key, vKey, vVal)
 		return
@@ -130,14 +154,14 @@ func (c *Map) AddUniqueCS(key string, vKey string, vVal string) {
 }
 
 // AddUnique will add a value to a key if it is not already there
-func (c *Map) AddUnique(key string, value string) {
+func (c *caseSensitiveMap) AddUnique(key string, value string) {
 	c.AddUniqueCS(key, key, value)
 }
 
 // SetCS will replace the key's value with this slice
 // internally converts [] string to []types.AnchoredVar
 // with case sensitive vKey
-func (c *Map) SetCS(key string, vKey string, values []string) {
+func (c *caseSensitiveMap) SetCS(key string, vKey string, values []string) {
 	c.data[key] = make([]types.AnchoredVar, 0, len(values))
 	for _, v := range values {
 		c.data[key] = append(c.data[key], types.AnchoredVar{Name: vKey, Value: v})
@@ -146,7 +170,7 @@ func (c *Map) SetCS(key string, vKey string, values []string) {
 
 // Set will replace the key's value with this slice
 // internally converts [] string to []types.AnchoredVar
-func (c *Map) Set(key string, values []string) {
+func (c *caseSensitiveMap) Set(key string, values []string) {
 	c.SetCS(key, key, values)
 }
 
@@ -154,7 +178,7 @@ func (c *Map) Set(key string, values []string) {
 // If the index is higher than the current size of the CollectionMap
 // it will be appended
 // with case sensitive vKey
-func (c *Map) SetIndexCS(key string, index int, vKey string, value string) {
+func (c *caseSensitiveMap) SetIndexCS(key string, index int, vKey string, value string) {
 	if c.data[key] == nil {
 		c.data[key] = []types.AnchoredVar{{Name: vKey, Value: value}}
 	}
@@ -169,29 +193,29 @@ func (c *Map) SetIndexCS(key string, index int, vKey string, value string) {
 // SetIndex will place the value under the index
 // If the index is higher than the current size of the CollectionMap
 // it will be appended
-func (c *Map) SetIndex(key string, index int, value string) {
+func (c *caseSensitiveMap) SetIndex(key string, index int, value string) {
 	c.SetIndexCS(key, index, key, value)
 }
 
 // Remove deletes the key from the CollectionMap
-func (c *Map) Remove(key string) {
+func (c *caseSensitiveMap) Remove(key string) {
 	delete(c.data, key)
 }
 
 // Name returns the name for the current CollectionMap
-func (c *Map) Name() string {
+func (c *caseSensitiveMap) Name() string {
 	return c.name
 }
 
 // Reset the current CollectionMap
-func (c *Map) Reset() {
+func (c *caseSensitiveMap) Reset() {
 	for k := range c.data {
 		delete(c.data, k)
 	}
 }
 
 // Data returns all the data in the CollectionMap
-func (c *Map) Data() map[string][]string {
+func (c *caseSensitiveMap) Data() map[string][]string {
 	result := map[string][]string{}
 	for k, v := range c.data {
 		result[k] = make([]string, 0, len(v))
@@ -202,11 +226,19 @@ func (c *Map) Data() map[string][]string {
 	return result
 }
 
-var _ Collection = &Map{}
+func (c *caseSensitiveMap) rawData() map[string][]types.AnchoredVar {
+	return c.data
+}
+
+func (c *caseSensitiveMap) variable_() variables.RuleVariable {
+	return c.variable
+}
+
+var _ Collection = &caseSensitiveMap{}
 
 // NewMap returns a collection of key->[]values
-func NewMap(variable variables.RuleVariable) *Map {
-	return &Map{
+func NewMap(variable variables.RuleVariable) Map {
+	return &caseSensitiveMap{
 		name:     variable.Name(),
 		variable: variable,
 		data:     map[string][]types.AnchoredVar{},

--- a/collection/collection_map_test.go
+++ b/collection/collection_map_test.go
@@ -33,7 +33,7 @@ func TestCollectionMap(t *testing.T) {
 	if len(c.FindString("a")) > 0 {
 		t.Error("Error should not find string")
 	}
-	if l := len(c.FindRegex(regexp.MustCompile("k.*"))); l != 3 {
+	if l := len(c.FindRegex(regexp.MustCompile("k.*"))); l != 2 {
 		t.Errorf("Error should find regex, got %d", l)
 	}
 }

--- a/collection/collection_map_test.go
+++ b/collection/collection_map_test.go
@@ -24,7 +24,7 @@ func TestCollectionMap(t *testing.T) {
 	c := NewMap(variables.ArgsPost)
 	c.SetIndex("key", 1, "value")
 	c.Set("key2", []string{"value2"})
-	if c.Get("key")[1] != "value" {
+	if c.Get("key")[0] != "value" {
 		t.Error("Error setting index")
 	}
 	if len(c.FindAll()) == 0 {

--- a/collection/collection_proxy.go
+++ b/collection/collection_proxy.go
@@ -15,7 +15,7 @@ import (
 // to store slices of data for keys
 // Important: CollectionProxys ARE NOT concurrent safe
 type Proxy struct {
-	data     []*Map
+	data     []Map
 	name     string
 	variable variables.RuleVariable
 }
@@ -79,7 +79,7 @@ func (c *Proxy) Reset() {
 var _ Collection = &Proxy{}
 
 // NewProxy returns a Proxy collection that merges all collections
-func NewProxy(variable variables.RuleVariable, data ...*Map) *Proxy {
+func NewProxy(variable variables.RuleVariable, data ...Map) *Proxy {
 	return &Proxy{
 		name:     variable.Name(),
 		variable: variable,

--- a/collection/collection_size_proxy.go
+++ b/collection/collection_size_proxy.go
@@ -15,7 +15,7 @@ import (
 // SizeProxy are used to connect the size
 // of many collection map values and return the sum
 type SizeProxy struct {
-	data     []*Map
+	data     []Map
 	name     string
 	variable variables.RuleVariable
 }
@@ -46,7 +46,7 @@ func (c *SizeProxy) Size() int64 {
 	i := 0
 	for _, d := range c.data {
 		// we iterate over d
-		for _, data := range d.data {
+		for _, data := range d.rawData() {
 			for _, v := range data {
 				i += len(v.Value)
 			}
@@ -69,7 +69,7 @@ var _ Collection = &SizeProxy{}
 
 // NewCollectionSizeProxy returns a collection that
 // only returns the total sum of all the collections values
-func NewCollectionSizeProxy(variable variables.RuleVariable, data ...*Map) *SizeProxy {
+func NewCollectionSizeProxy(variable variables.RuleVariable, data ...Map) *SizeProxy {
 	return &SizeProxy{
 		name:     variable.Name(),
 		variable: variable,

--- a/collection/collection_size_proxy.go
+++ b/collection/collection_size_proxy.go
@@ -45,12 +45,7 @@ func (c *SizeProxy) FindAll() []types.MatchData {
 func (c *SizeProxy) Size() int64 {
 	i := 0
 	for _, d := range c.data {
-		// we iterate over d
-		for _, data := range d.rawData() {
-			for _, v := range data {
-				i += len(v.Value)
-			}
-		}
+		i += d.size()
 	}
 	return int64(i)
 }

--- a/collection/collection_translation_proxy.go
+++ b/collection/collection_translation_proxy.go
@@ -16,7 +16,7 @@ import (
 // to store slices of data for keys
 // Important: CollectionTranslationProxys ARE NOT concurrent safe
 type TranslationProxy struct {
-	data     []*Map
+	data     []Map
 	name     string
 	variable variables.RuleVariable
 }
@@ -27,8 +27,8 @@ func (c *TranslationProxy) FindRegex(key *regexp.Regexp) []types.MatchData {
 	for _, c := range c.data {
 		for _, k := range c.keysRx(key) {
 			res = append(res, &corazarules.MatchData{
-				VariableName_: c.name,
-				Variable_:     c.variable,
+				VariableName_: c.Name(),
+				Variable_:     c.variable_(),
 				Value_:        k,
 			})
 		}
@@ -42,8 +42,8 @@ func (c *TranslationProxy) FindString(key string) []types.MatchData {
 		if len(c.Get(key)) > 0 {
 			return []types.MatchData{
 				&corazarules.MatchData{
-					VariableName_: c.name,
-					Variable_:     c.variable,
+					VariableName_: c.Name(),
+					Variable_:     c.variable_(),
 					Value_:        key,
 				},
 			}
@@ -58,8 +58,8 @@ func (c *TranslationProxy) FindAll() []types.MatchData {
 	for _, c := range c.data {
 		for _, k := range c.keys() {
 			res = append(res, &corazarules.MatchData{
-				VariableName_: c.name,
-				Variable_:     c.variable,
+				VariableName_: c.Name(),
+				Variable_:     c.variable_(),
 				Value_:        k,
 			})
 		}
@@ -100,7 +100,7 @@ var _ Collection = &TranslationProxy{}
 
 // NewTranslationProxy creates a translation proxy
 // Translation proxies are used to merge variable keys from multiple collections
-func NewTranslationProxy(variable variables.RuleVariable, data ...*Map) *TranslationProxy {
+func NewTranslationProxy(variable variables.RuleVariable, data ...Map) *TranslationProxy {
 	return &TranslationProxy{
 		name:     variable.Name(),
 		variable: variable,

--- a/collection/collection_translation_proxy_test.go
+++ b/collection/collection_translation_proxy_test.go
@@ -25,9 +25,7 @@ func TestCollectionTranslationProxy(t *testing.T) {
 	c2 := NewMap(variables.ArgsGet)
 	proxy := NewTranslationProxy(variables.ArgsNames, c1, c2)
 
-	c1.SetCS("key1", "key1", []string{"value1"})
 	c1.Set("key2", []string{"value2"})
-	c2.SetCS("key3", "Key3", []string{"value3"})
 
 	if len(proxy.FindAll()) != 3 {
 		t.Error("Error finding all")

--- a/collection/collection_translation_proxy_test.go
+++ b/collection/collection_translation_proxy_test.go
@@ -21,11 +21,13 @@ import (
 )
 
 func TestCollectionTranslationProxy(t *testing.T) {
-	c1 := NewMap(variables.ArgsPost)
-	c2 := NewMap(variables.ArgsGet)
+	c1 := NewCaseInsensitiveMap(variables.ArgsPost)
+	c2 := NewCaseInsensitiveMap(variables.ArgsGet)
 	proxy := NewTranslationProxy(variables.ArgsNames, c1, c2)
 
+	c1.Set("key1", []string{"value1"})
 	c1.Set("key2", []string{"value2"})
+	c2.Set("Key3", []string{"value3"})
 
 	if len(proxy.FindAll()) != 3 {
 		t.Error("Error finding all")

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -389,7 +389,7 @@ func (r *Rule) AddVariable(v variables.RuleVariable, key string, iscount bool) e
 		Name:       v.Name(),
 		Count:      iscount,
 		Variable:   v,
-		KeyStr:     strings.ToLower(key),
+		KeyStr:     key,
 		KeyRx:      re,
 		Exceptions: []ruleVariableException{},
 	})

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1614,9 +1614,9 @@ func NewTransactionVariables() *TransactionVariables {
 	v.requestHeadersNames = collection.NewCaseInsensitiveMap(variables.RequestHeadersNames)
 	v.userID = collection.NewSimple(variables.Userid)
 
-	v.argsGet = collection.NewCaseInsensitiveMap(variables.ArgsGet)
-	v.argsPost = collection.NewCaseInsensitiveMap(variables.ArgsPost)
-	v.argsPath = collection.NewCaseInsensitiveMap(variables.ArgsPath)
+	v.argsGet = collection.NewMap(variables.ArgsGet)
+	v.argsPost = collection.NewMap(variables.ArgsPost)
+	v.argsPath = collection.NewMap(variables.ArgsPath)
 	v.filesSizes = collection.NewMap(variables.FilesSizes)
 	v.filesTmpContent = collection.NewMap(variables.FilesTmpContent)
 	v.multipartFilename = collection.NewMap(variables.MultipartFilename)

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -666,7 +666,7 @@ func (tx *Transaction) ExtractArguments(orig types.ArgumentType, uri string) {
 // ARGS_(GET|POST)_NAMES
 func (tx *Transaction) AddArgument(argType types.ArgumentType, key string, value string) {
 	// TODO implement ARGS value limit using ArgumentsLimit
-	var vals *collection.Map
+	var vals collection.Map
 	switch argType {
 	case types.ArgumentGET:
 		vals = tx.variables.argsGet
@@ -1417,7 +1417,7 @@ func (tx *Transaction) Debug() string {
 			data[""] = []string{
 				col.String(),
 			}
-		case *collection.Map:
+		case collection.Map:
 			data = col.Data()
 		case *collection.Proxy:
 			data = col.Data()
@@ -1511,38 +1511,38 @@ type TransactionVariables struct {
 	statusLine                    *collection.Simple
 	inboundErrorData              *collection.Simple
 	// Custom
-	env      *collection.Map
-	tx       *collection.Map
-	rule     *collection.Map
+	env      collection.Map
+	tx       collection.Map
+	rule     collection.Map
 	duration *collection.Simple
 	// Proxy Variables
 	args *collection.Proxy
 	// Maps Variables
-	argsGet              *collection.Map
-	argsPost             *collection.Map
-	argsPath             *collection.Map
-	filesTmpNames        *collection.Map
-	geo                  *collection.Map
-	files                *collection.Map
-	requestCookies       *collection.Map
-	requestHeaders       *collection.Map
-	responseHeaders      *collection.Map
-	multipartName        *collection.Map
-	matchedVarsNames     *collection.Map
-	multipartFilename    *collection.Map
-	matchedVars          *collection.Map
-	filesSizes           *collection.Map
-	filesNames           *collection.Map
-	filesTmpContent      *collection.Map
-	responseHeadersNames *collection.Map
-	requestHeadersNames  *collection.Map
-	requestCookiesNames  *collection.Map
-	xml                  *collection.Map
-	requestXML           *collection.Map
-	responseXML          *collection.Map
-	multipartPartHeaders *collection.Map
+	argsGet              collection.Map
+	argsPost             collection.Map
+	argsPath             collection.Map
+	filesTmpNames        collection.Map
+	geo                  collection.Map
+	files                collection.Map
+	requestCookies       collection.Map
+	requestHeaders       collection.Map
+	responseHeaders      collection.Map
+	multipartName        collection.Map
+	matchedVarsNames     collection.Map
+	multipartFilename    collection.Map
+	matchedVars          collection.Map
+	filesSizes           collection.Map
+	filesNames           collection.Map
+	filesTmpContent      collection.Map
+	responseHeadersNames collection.Map
+	requestHeadersNames  collection.Map
+	requestCookiesNames  collection.Map
+	xml                  collection.Map
+	requestXML           collection.Map
+	responseXML          collection.Map
+	multipartPartHeaders collection.Map
 	// Persistent variables
-	ip *collection.Map
+	ip collection.Map
 	// Translation Proxy Variables
 	argsNames     *collection.TranslationProxy
 	argsGetNames  *collection.TranslationProxy
@@ -1760,7 +1760,7 @@ func (v *TransactionVariables) MultipartMissingSemicolon() *collection.Simple {
 	return v.multipartMissingSemicolon
 }
 
-func (v *TransactionVariables) MultipartPartHeaders() *collection.Map {
+func (v *TransactionVariables) MultipartPartHeaders() collection.Map {
 	return v.multipartPartHeaders
 }
 
@@ -1896,15 +1896,15 @@ func (v *TransactionVariables) InboundErrorData() *collection.Simple {
 	return v.inboundErrorData
 }
 
-func (v *TransactionVariables) Env() *collection.Map {
+func (v *TransactionVariables) Env() collection.Map {
 	return v.env
 }
 
-func (v *TransactionVariables) TX() *collection.Map {
+func (v *TransactionVariables) TX() collection.Map {
 	return v.tx
 }
 
-func (v *TransactionVariables) Rule() *collection.Map {
+func (v *TransactionVariables) Rule() collection.Map {
 	return v.rule
 }
 
@@ -1916,95 +1916,95 @@ func (v *TransactionVariables) Args() *collection.Proxy {
 	return v.args
 }
 
-func (v *TransactionVariables) ArgsGet() *collection.Map {
+func (v *TransactionVariables) ArgsGet() collection.Map {
 	return v.argsGet
 }
 
-func (v *TransactionVariables) ArgsPost() *collection.Map {
+func (v *TransactionVariables) ArgsPost() collection.Map {
 	return v.argsPost
 }
 
-func (v *TransactionVariables) ArgsPath() *collection.Map {
+func (v *TransactionVariables) ArgsPath() collection.Map {
 	return v.argsPath
 }
 
-func (v *TransactionVariables) FilesTmpNames() *collection.Map {
+func (v *TransactionVariables) FilesTmpNames() collection.Map {
 	return v.filesTmpNames
 }
 
-func (v *TransactionVariables) Geo() *collection.Map {
+func (v *TransactionVariables) Geo() collection.Map {
 	return v.geo
 }
 
-func (v *TransactionVariables) Files() *collection.Map {
+func (v *TransactionVariables) Files() collection.Map {
 	return v.files
 }
 
-func (v *TransactionVariables) RequestCookies() *collection.Map {
+func (v *TransactionVariables) RequestCookies() collection.Map {
 	return v.requestCookies
 }
 
-func (v *TransactionVariables) RequestHeaders() *collection.Map {
+func (v *TransactionVariables) RequestHeaders() collection.Map {
 	return v.requestHeaders
 }
 
-func (v *TransactionVariables) ResponseHeaders() *collection.Map {
+func (v *TransactionVariables) ResponseHeaders() collection.Map {
 	return v.responseHeaders
 }
 
-func (v *TransactionVariables) MultipartName() *collection.Map {
+func (v *TransactionVariables) MultipartName() collection.Map {
 	return v.multipartName
 }
 
-func (v *TransactionVariables) MatchedVarsNames() *collection.Map {
+func (v *TransactionVariables) MatchedVarsNames() collection.Map {
 	return v.matchedVarsNames
 }
 
-func (v *TransactionVariables) MultipartFilename() *collection.Map {
+func (v *TransactionVariables) MultipartFilename() collection.Map {
 	return v.multipartFilename
 }
 
-func (v *TransactionVariables) MatchedVars() *collection.Map {
+func (v *TransactionVariables) MatchedVars() collection.Map {
 	return v.matchedVars
 }
 
-func (v *TransactionVariables) FilesSizes() *collection.Map {
+func (v *TransactionVariables) FilesSizes() collection.Map {
 	return v.filesSizes
 }
 
-func (v *TransactionVariables) FilesNames() *collection.Map {
+func (v *TransactionVariables) FilesNames() collection.Map {
 	return v.filesNames
 }
 
-func (v *TransactionVariables) FilesTmpContent() *collection.Map {
+func (v *TransactionVariables) FilesTmpContent() collection.Map {
 	return v.filesTmpContent
 }
 
-func (v *TransactionVariables) ResponseHeadersNames() *collection.Map {
+func (v *TransactionVariables) ResponseHeadersNames() collection.Map {
 	return v.responseHeadersNames
 }
 
-func (v *TransactionVariables) RequestHeadersNames() *collection.Map {
+func (v *TransactionVariables) RequestHeadersNames() collection.Map {
 	return v.requestHeadersNames
 }
 
-func (v *TransactionVariables) RequestCookiesNames() *collection.Map {
+func (v *TransactionVariables) RequestCookiesNames() collection.Map {
 	return v.requestCookiesNames
 }
 
-func (v *TransactionVariables) XML() *collection.Map {
+func (v *TransactionVariables) XML() collection.Map {
 	return v.xml
 }
 
-func (v *TransactionVariables) RequestXML() *collection.Map {
+func (v *TransactionVariables) RequestXML() collection.Map {
 	return v.requestXML
 }
 
-func (v *TransactionVariables) ResponseXML() *collection.Map {
+func (v *TransactionVariables) ResponseXML() collection.Map {
 	return v.responseXML
 }
 
-func (v *TransactionVariables) IP() *collection.Map {
+func (v *TransactionVariables) IP() collection.Map {
 	return v.ip
 }
 

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -361,7 +361,7 @@ func TestIssue176(t *testing.T) {
 		t.Error("error test for github issue #176")
 	}
 
-	// 	Test for argument case-sensitive
+	// 	Test for argument case-sensitives
 	//	err = parser.FromString(`
 	//		SecRule ARGS:Test1 "123" "id:3,phase:1,log,deny"
 	//	`)
@@ -582,7 +582,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if it == nil {
+	if it != nil {
 		t.Errorf("failed to test arguments value match: Upper case argument name, %+v\n", tx.MatchedRules())
 	}
 
@@ -592,7 +592,7 @@ func TestArgumentsCaseSensitive(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if it == nil {
+	if it != nil {
 		t.Errorf("failed to test arguments value match: Lower case argument name, %+v\n", tx.MatchedRules())
 	}
 

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -63,7 +63,7 @@ func expandToken(tx rules.TransactionState, token macroToken) string {
 		return token.text
 	}
 	switch col := tx.Collection(*token.variable).(type) {
-	case *collection.Map:
+	case collection.Map:
 		if c := col.Get(token.key); len(c) > 0 {
 			return c[0]
 		}

--- a/rules/transaction.go
+++ b/rules/transaction.go
@@ -64,7 +64,7 @@ type TransactionVariables interface {
 	MultipartDataAfter() *collection.Simple
 	MultipartDataBefore() *collection.Simple
 	MultipartFileLimitExceeded() *collection.Simple
-	MultipartPartHeaders() *collection.Map
+	MultipartPartHeaders() collection.Map
 	MultipartHeaderFolding() *collection.Simple
 	MultipartInvalidHeaderFolding() *collection.Simple
 	MultipartInvalidPart() *collection.Simple
@@ -105,37 +105,37 @@ type TransactionVariables interface {
 	StatusLine() *collection.Simple
 	InboundErrorData() *collection.Simple
 	// Custom
-	Env() *collection.Map
-	TX() *collection.Map
-	Rule() *collection.Map
+	Env() collection.Map
+	TX() collection.Map
+	Rule() collection.Map
 	Duration() *collection.Simple
 	// Proxy Variables
 	Args() *collection.Proxy
 	// Maps Variables
-	ArgsGet() *collection.Map
-	ArgsPost() *collection.Map
-	ArgsPath() *collection.Map
-	FilesTmpNames() *collection.Map
-	Geo() *collection.Map
-	Files() *collection.Map
-	RequestCookies() *collection.Map
-	RequestHeaders() *collection.Map
-	ResponseHeaders() *collection.Map
-	MultipartName() *collection.Map
-	MatchedVarsNames() *collection.Map
-	MultipartFilename() *collection.Map
-	MatchedVars() *collection.Map
-	FilesSizes() *collection.Map
-	FilesNames() *collection.Map
-	FilesTmpContent() *collection.Map
-	ResponseHeadersNames() *collection.Map
-	RequestHeadersNames() *collection.Map
-	RequestCookiesNames() *collection.Map
-	XML() *collection.Map
-	RequestXML() *collection.Map
-	ResponseXML() *collection.Map
+	ArgsGet() collection.Map
+	ArgsPost() collection.Map
+	ArgsPath() collection.Map
+	FilesTmpNames() collection.Map
+	Geo() collection.Map
+	Files() collection.Map
+	RequestCookies() collection.Map
+	RequestHeaders() collection.Map
+	ResponseHeaders() collection.Map
+	MultipartName() collection.Map
+	MatchedVarsNames() collection.Map
+	MultipartFilename() collection.Map
+	MatchedVars() collection.Map
+	FilesSizes() collection.Map
+	FilesNames() collection.Map
+	FilesTmpContent() collection.Map
+	ResponseHeadersNames() collection.Map
+	RequestHeadersNames() collection.Map
+	RequestCookiesNames() collection.Map
+	XML() collection.Map
+	RequestXML() collection.Map
+	ResponseXML() collection.Map
 	// Persistent variables
-	IP() *collection.Map
+	IP() collection.Map
 	// Translation Proxy Variables
 	ArgsNames() *collection.TranslationProxy
 	ArgsGetNames() *collection.TranslationProxy


### PR DESCRIPTION
This is WIP because the implementation needs to be tied to decisions on #599 #598, I added some tweaks from there but will wait for decision before finishing. But want to send it out to check the general approach.

Currently, the map API is quite confusing mostly because case-sensitive handling is up to the caller, not the map. Indeed, the most confusing part is how `AddCS` adds a value for case-insensitive matching!

Instead, we can move the case sensitivity handling to separate map implementations and make it an interface. This removes `CS` flavors of insertion methods. It also makes things more consistent, presumably it should not be possible for a user to add elements in both sensitive and insensitive ways to the same variable.

I have also removed the `Unique` versions, instead letting the caller check the length of `Get`. I think adding a `Has` type of method would also be good, both allow not having 2x the insertion methods for a rare use case while being intuitive.