### PR TITLE
fix: fixes the superflous header write.

### DIFF
--- a/examples/http-server/main_test.go
+++ b/examples/http-server/main_test.go
@@ -79,7 +79,7 @@ func TestHttpServer(t *testing.T) {
 		{
 			"positive for response body limit reject",
 			"/",
-			403,
+			413,
 			map[string]string{
 				"DIRECTIVES_FILE": "./testdata/response-body-limits-reject.conf",
 				"RESPONSE_BODY":   "response body beyond the limit",


### PR DESCRIPTION
This PR fixes

```
2023/01/30 22:44:14 http: superfluous response.WriteHeader call from github.com/corazawaf/coraza/v3/http.wrap.func1 (interceptor.go:126)
```