### PR TITLE
chore: updates directives doc about SecDebugLogLevel

### DIFF
--- a/coraza.conf-recommended
+++ b/coraza.conf-recommended
@@ -205,12 +205,12 @@ SecDataDir /tmp/
 
 # Default debug log path
 # Debug levels:
-# 0: no logging (least verbose)
-# 1: error
-# 2: warn
-# 3: info
-# 4-5: debug
-# 6-9: trace (most verbose)
+# 0:   No logging (least verbose)
+# 1:   Error
+# 2:   Warn
+# 3:   Info
+# 4-8: Debug
+# 9:   Trace (most verbose)
 # Most logging has not been implemented because it will be replaced with
 # advanced rule profiling options
 #SecDebugLog /opt/coraza/var/log/debug.log

--- a/examples/http-server/testdata/request-body-limits-processpartial.conf
+++ b/examples/http-server/testdata/request-body-limits-processpartial.conf
@@ -1,4 +1,4 @@
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecDebugLog /dev/stdout
 SecRequestBodyAccess On
 SecRequestBodyInMemoryLimit 5

--- a/examples/http-server/testdata/response-body-limits-reject.conf
+++ b/examples/http-server/testdata/response-body-limits-reject.conf
@@ -1,4 +1,4 @@
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecDebugLog /dev/stdout
 SecResponseBodyAccess On
 SecResponseBodyMimeType text/plain

--- a/examples/http-server/testdata/response-body.conf
+++ b/examples/http-server/testdata/response-body.conf
@@ -1,4 +1,4 @@
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecDebugLog /dev/stdout
 SecResponseBodyAccess On
 SecResponseBodyMimeType text/plain

--- a/examples/http-server/testdata/response-headers.conf
+++ b/examples/http-server/testdata/response-headers.conf
@@ -1,3 +1,3 @@
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecDebugLog /dev/stdout
 SecRule RESPONSE_HEADERS:Foo "@pm bar" "id:199,phase:3,deny,t:lowercase,deny, status:403,msg:'Invalid response header',log,auditlog"

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -305,7 +305,7 @@ func TestHttpServer(t *testing.T) {
 			conf := coraza.NewWAFConfig().
 				WithDirectives(`
 	# This is a comment
-	SecDebugLogLevel 5
+	SecDebugLogLevel 9
 	SecRequestBodyAccess On
 	SecResponseBodyAccess On
 	SecResponseBodyMimeType text/plain

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -759,8 +759,8 @@ func directiveSecDebugLog(options *DirectiveOptions) error {
 // - 1:   Error
 // - 2:   Warn
 // - 3:   Info
-// - 4-5: Debug
-// - 6-9: Trace (most verbose)
+// - 4-8: Debug
+// - 9:   Trace (most verbose)
 //
 // Levels outside the 0-9 range will default to level 3 (Info)
 func directiveSecDebugLogLevel(options *DirectiveOptions) error {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -747,22 +747,22 @@ func directiveSecDebugLog(options *DirectiveOptions) error {
 }
 
 // Description: Configures the verboseness of the debug log data.
-// Default: 2
+// Default: 3
 // Syntax: SecDebugLogLevel [LOG_LEVEL]
 // ---
 // Depending on the implementation, errors ranging from 1 to 2 might be directly
-// logged to the connector error log. For example, level 2 (error) logs will be
+// logged to the connector error log. For example, level 1 (error) logs will be
 // written to caddy server error logs.
 // The possible values for the debug log level are:
 //
-// - 0: Fatal
-// - 1: Panic
-// - 2: Error
-// - 3: Warning
-// - 4: details of how transactions are handled
-// - 5: log everything, including very detailed debugging information
+// - 0:   No logging (least verbose)
+// - 1:   Error
+// - 2:   Warn
+// - 3:   Info
+// - 4-5: Debug
+// - 6-9: Trace (most verbose)
 //
-// All levels over 5 will be considered as 5.
+// Levels outside the 0-9 range will default to level 3 (Info)
 func directiveSecDebugLogLevel(options *DirectiveOptions) error {
 	lvl, err := strconv.Atoi(options.Opts)
 	if err != nil {

--- a/internal/seclang/directives_log_test.go
+++ b/internal/seclang/directives_log_test.go
@@ -80,7 +80,7 @@ func TestDebugDirectives(t *testing.T) {
 	}
 	if err := directiveSecDebugLogLevel(&DirectiveOptions{
 		WAF:  waf,
-		Opts: "5",
+		Opts: "3",
 	}); err != nil {
 		t.Error(err)
 	}

--- a/testing/engine/ctl.go
+++ b/testing/engine/ctl.go
@@ -48,7 +48,7 @@ var _ = profile.RegisterProfile(profile.Profile{
 		},
 	},
 	Rules: `
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecRequestBodyAccess On
 SecAction "id:1, phase:1, ctl:ruleRemoveByTag=test, \
 	ctl:ruleRemoveById=444, \

--- a/testing/engine/match.go
+++ b/testing/engine/match.go
@@ -50,7 +50,7 @@ var _ = profile.RegisterProfile(profile.Profile{
 		},
 	},
 	Rules: `
-SecDebugLogLevel 5
+SecDebugLogLevel 9
 SecRule SERVER_ADDR "! ^127" "id:1, phase:1, log"
 
 SecRule SERVER_PORT "!" "id:2, phase:1, log"


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/pull/519:
- updates `SecDebugLogLevel` doc
- updates a few `SecDebugLogLevel` values across tests
- fixes conf-recommended file