### PR TITLE
feat: adds WithRecommendedDirectives to easily load recommended configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@ package coraza
 import (
 	"io/fs"
 
+	_ "embed"
+
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/loggers"
 	"github.com/corazawaf/coraza/v3/types"
@@ -17,6 +19,9 @@ import (
 type WAFConfig interface {
 	// WithRules adds rules to the WAF.
 	WithRules(rules ...*corazawaf.Rule) WAFConfig
+
+	// WithRecommendedDirectives adds the directives from the coraza.conf-recommended file
+	WithRecommendedDirectives() WAFConfig
 
 	// WithDirectives parses the directives from the given string and adds them to the WAF.
 	WithDirectives(directives string) WAFConfig
@@ -131,6 +136,13 @@ func (c *wafConfig) WithRules(rules ...*corazawaf.Rule) WAFConfig {
 		ret.rules = append(ret.rules, wafRule{rule: r})
 	}
 	return ret
+}
+
+//go:embed coraza.conf-recommended
+var recommendedConf string
+
+func (c *wafConfig) WithRecommendedDirectives() WAFConfig {
+	return c.WithDirectives(recommendedConf)
 }
 
 func (c *wafConfig) WithDirectivesFromFile(path string) WAFConfig {

--- a/config_test.go
+++ b/config_test.go
@@ -5,7 +5,23 @@ package coraza
 
 import (
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/types"
 )
+
+func TestRecommendedDirectives(t *testing.T) {
+	c := NewWAFConfig().
+		WithRecommendedDirectives()
+
+	waf, err := NewWAF(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := types.RuleEngineDetectionOnly, waf.(wafWrapper).waf.RuleEngine; want != have {
+		t.Errorf("unexpected rule engine, want %d, have %d", want, have)
+	}
+}
 
 func TestConfigRulesImmutable(t *testing.T) {
 	// Add enough directives so there is enough slice capacity to reuse the array for next append.


### PR DESCRIPTION
Right now, getting started with coraza forces users to at least include the library and copy the recommended conf file not on build time but mainly on runtime (wherever the binary is going to run). This is specially inconvenient as it is a big barrier for newbies because they have to check in the recommended settings and copy them at some point in the runtime.

This PR adds the shortcut to load the recommended conf right away.