### PR TITLE
Move debug formatting to collections and remove Map.Data

### DIFF
--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -23,8 +23,6 @@ jobs:
         go-version: [1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    container:
-      image: tinygo/tinygo:0.26.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -34,6 +32,11 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
+
+      - name: setup tinygo
+        uses: acifani/setup-tinygo@v1
+        with:
+          tinygo-version: 0.26.0
 
       - name: Cache TinyGo build
         uses: actions/cache@v3

--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -20,8 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # TODO(anuraaga): Add 1.19.x after TinyGo adds support for it.
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     container:

--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     container:
-      image: tinygo/tinygo:0.24.0
+      image: tinygo/tinygo:0.26.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/bodyprocessors/json.go
+++ b/bodyprocessors/json.go
@@ -25,11 +25,7 @@ func (js *jsonBodyProcessor) ProcessRequest(reader io.Reader, v rules.Transactio
 	argsGetCol := v.ArgsGet()
 	for key, value := range data {
 		// TODO: This hack prevent GET variables from overriding POST variables
-		for k := range argsGetCol.Data() {
-			if k == key {
-				argsGetCol.Remove(k)
-			}
-		}
+		argsGetCol.Remove(key)
 		col.SetIndex(key, 0, value)
 	}
 	return nil

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -69,7 +69,4 @@ type Map interface {
 
 	// Remove deletes the key from the CollectionMap
 	Remove(key string)
-
-	// Data returns all the data in the CollectionMap
-	Data() map[string][]string
 }

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -22,7 +22,7 @@ type Map struct {
 
 var _ collection.Map = &Map{}
 
-func NewMap(variable variables.RuleVariable) collection.Map {
+func NewMap(variable variables.RuleVariable) *Map {
 	return &Map{
 		name:     variable.Name(),
 		variable: variable,
@@ -144,15 +144,23 @@ func (c *Map) Reset() {
 	}
 }
 
-func (c *Map) Data() map[string][]string {
-	result := map[string][]string{}
+func (c *Map) String() string {
+	res := strings.Builder{}
+	res.WriteString(c.name)
+	res.WriteString(":\n")
 	for k, v := range c.data {
-		result[k] = make([]string, 0, len(v))
-		for _, a := range v {
-			result[k] = append(result[k], a.value)
+		res.WriteString("    ")
+		res.WriteString(k)
+		res.WriteString(": ")
+		for i, vv := range v {
+			if i > 0 {
+				res.WriteString(",")
+			}
+			res.WriteString(vv.value)
 		}
+		res.WriteByte('\n')
 	}
-	return result
+	return res.String()
 }
 
 // keyValue stores the case preserved original key and value

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -46,6 +46,13 @@ func TestMap(t *testing.T) {
 `
 
 	if have := fmt.Sprint(c); have != wantStr {
-		t.Errorf("String() = %q, want %q", have, wantStr)
+		// Map order is not guaranteed, not pretty but checking twice is the simplest for now.
+		wantStr = `ARGS_POST:
+    key2: value2,value3
+    key: value
+`
+		if have := fmt.Sprint(c); have != wantStr {
+			t.Errorf("String() = %q, want %q", have, wantStr)
+		}
 	}
 }

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -51,7 +51,7 @@ func TestMap(t *testing.T) {
     key2: value2,value3
     key: value
 `
-		if have := fmt.Sprint(c); have != wantStr {
+		if have != wantStr {
 			t.Errorf("String() = %q, want %q", have, wantStr)
 		}
 	}

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -14,6 +14,7 @@
 package collections
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -35,5 +36,16 @@ func TestMap(t *testing.T) {
 	}
 	if l := len(c.FindRegex(regexp.MustCompile("k.*"))); l != 2 {
 		t.Errorf("Error should find regex, got %d", l)
+	}
+
+	c.Add("key2", "value3")
+
+	wantStr := `ARGS_POST:
+    key: value
+    key2: value2,value3
+`
+
+	if have := fmt.Sprint(c); have != wantStr {
+		t.Errorf("String() = %q, want %q", have, wantStr)
 	}
 }

--- a/internal/collections/named.go
+++ b/internal/collections/named.go
@@ -4,7 +4,9 @@
 package collections
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
@@ -14,7 +16,7 @@ import (
 
 // NamedCollection is a Collection that also keeps track of unique names.
 type NamedCollection struct {
-	collection.Map
+	*Map
 	names []string
 }
 
@@ -57,6 +59,18 @@ func (c *NamedCollection) Remove(key string) {
 	}
 }
 
+// Data is an internal method used for serializing to JSON
+func (c *NamedCollection) Data() map[string][]string {
+	result := map[string][]string{}
+	for k, v := range c.data {
+		result[k] = make([]string, 0, len(v))
+		for _, a := range v {
+			result[k] = append(result[k], a.value)
+		}
+	}
+	return result
+}
+
 // Name returns the name for the current CollectionMap
 func (c *NamedCollection) Name() string {
 	return c.Map.Name()
@@ -67,16 +81,16 @@ func (c *NamedCollection) Reset() {
 	c.names = nil
 }
 
-func (c *NamedCollection) Data() map[string][]string {
-	return c.Map.Data()
-}
-
 func (c *NamedCollection) Names(rv variables.RuleVariable) collection.Collection {
 	return &NamedCollectionNames{
 		name:       rv.Name(),
 		variable:   rv,
 		collection: c,
 	}
+}
+
+func (c *NamedCollection) String() string {
+	return fmt.Sprint(c.Map)
 }
 
 func (c *NamedCollection) addName(key string) {
@@ -119,4 +133,17 @@ func (c *NamedCollectionNames) Name() string {
 }
 
 func (c *NamedCollectionNames) Reset() {
+}
+
+func (c *NamedCollectionNames) String() string {
+	res := strings.Builder{}
+	res.WriteString(c.name)
+	res.WriteString(": ")
+	for i, k := range c.collection.names {
+		if i > 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(k)
+	}
+	return res.String()
 }

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -34,7 +34,14 @@ func TestNamedCollection(t *testing.T) {
     key2: value2
 `
 	if have := fmt.Sprint(c); have != wantStr {
-		t.Errorf("String() = %q, want %q", have, wantStr)
+		// Map order is not guaranteed, not pretty but checking twice is the simplest for now.
+		wantStr = `ARGS_POST:
+    key2: value2
+    key: value
+`
+		if have := fmt.Sprint(c); have != wantStr {
+			t.Errorf("String() = %q, want %q", have, wantStr)
+		}
 	}
 
 	// Now test names

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -4,6 +4,7 @@
 package collections
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -28,6 +29,13 @@ func TestNamedCollection(t *testing.T) {
 	if l := len(c.FindRegex(regexp.MustCompile("k.*"))); l != 2 {
 		t.Errorf("Error should find regex, got %d", l)
 	}
+	wantStr := `ARGS_POST:
+    key: value
+    key2: value2
+`
+	if have := fmt.Sprint(c); have != wantStr {
+		t.Errorf("String() = %q, want %q", have, wantStr)
+	}
 
 	// Now test names
 
@@ -37,12 +45,24 @@ func TestNamedCollection(t *testing.T) {
 	}
 
 	assertValuesMatch(t, names.FindAll(), "key", "key2")
+	if want, have := "ARGS_POST_NAMES: key,key2", fmt.Sprint(names); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
 	c.Add("key", "value2")
 	assertValuesMatch(t, names.FindAll(), "key", "key2")
+	if want, have := "ARGS_POST_NAMES: key,key2", fmt.Sprint(names); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
 	// While selection operators will treat this as case-insensitive, names should have all names
 	// as-is.
 	c.Add("Key", "value3")
 	assertValuesMatch(t, names.FindAll(), "key", "key2", "Key")
+	if want, have := "ARGS_POST_NAMES: key,key2,Key", fmt.Sprint(names); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
 	c.Remove("key2")
 	assertValuesMatch(t, names.FindAll(), "key", "Key")
+	if want, have := "ARGS_POST_NAMES: key,Key", fmt.Sprint(names); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
 }

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -39,7 +39,7 @@ func TestNamedCollection(t *testing.T) {
     key2: value2
     key: value
 `
-		if have := fmt.Sprint(c); have != wantStr {
+		if have != wantStr {
 			t.Errorf("String() = %q, want %q", have, wantStr)
 		}
 	}

--- a/internal/collections/single.go
+++ b/internal/collections/single.go
@@ -4,6 +4,8 @@
 package collections
 
 import (
+	"fmt"
+
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
 	"github.com/corazawaf/coraza/v3/types"
@@ -50,4 +52,8 @@ func (c *Single) Name() string {
 
 func (c *Single) Reset() {
 	c.data = ""
+}
+
+func (c *Single) String() string {
+	return fmt.Sprintf("%s: %s", c.name, c.data)
 }

--- a/internal/collections/single_test.go
+++ b/internal/collections/single_test.go
@@ -20,11 +20,19 @@ func TestSingle(t *testing.T) {
 		t.Errorf("want %s, have %s", want, have)
 	}
 
+	if want, have := "ARGS_PATH: ", c.String(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
+
 	assertValuesMatch(t, c.FindAll())
 
 	c.Set("bear")
 
 	if want, have := "bear", c.Get(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
+
+	if want, have := "ARGS_PATH: bear", c.String(); want != have {
 		t.Errorf("want %s, have %s", want, have)
 	}
 

--- a/internal/collections/sized.go
+++ b/internal/collections/sized.go
@@ -4,6 +4,7 @@
 package collections
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 
@@ -62,14 +63,18 @@ func (c *SizeCollection) Reset() {
 	// do nothing
 }
 
+func (c *SizeCollection) String() string {
+	return fmt.Sprintf("%s: %d", c.name, c.size())
+}
+
 // Size returns the size of all the collections values
 func (c *SizeCollection) size() int {
 	i := 0
 	for _, d := range c.data {
 		// we iterate over d
-		for _, data := range d.Data() {
+		for _, data := range d.data {
 			for _, v := range data {
-				i += len(v)
+				i += len(v.value)
 			}
 		}
 	}

--- a/internal/collections/sized_test.go
+++ b/internal/collections/sized_test.go
@@ -15,10 +15,22 @@ func TestSizedCollection(t *testing.T) {
 	proxy := NewSizeCollection(variables.ArgsCombinedSize, c1, c2)
 
 	assertValuesMatch(t, proxy.FindAll(), "0")
+	if want, have := "ARGS_COMBINED_SIZE: 0", proxy.String(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
 	c1.Set("key1", []string{"value1", "value2"})
 	assertValuesMatch(t, proxy.FindAll(), "12")
+	if want, have := "ARGS_COMBINED_SIZE: 12", proxy.String(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
 	c1.Set("key2", []string{"value2"})
 	assertValuesMatch(t, proxy.FindAll(), "18")
+	if want, have := "ARGS_COMBINED_SIZE: 18", proxy.String(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
 	c2.Set("key3", []string{"value3"})
 	assertValuesMatch(t, proxy.FindAll(), "24")
+	if want, have := "ARGS_COMBINED_SIZE: 24", proxy.String(); want != have {
+		t.Errorf("want %s, have %s", want, have)
+	}
 }

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1106,7 +1106,7 @@ func validateMacroExpansion(tests map[string]string, tx *Transaction, t *testing
 		res := m.Expand(tx)
 		if res != v {
 			if testing.Verbose() {
-				fmt.Println(tx.Debug())
+				fmt.Println(tx)
 				fmt.Println("===STACK===\n", string(debug.Stack())+"\n===STACK===")
 			}
 			t.Error("Failed set transaction for " + k + ", expected " + v + ", got " + res)

--- a/testing/engine_test.go
+++ b/testing/engine_test.go
@@ -34,7 +34,7 @@ func TestDebug(t *testing.T) {
 	if err := test.RunPhases(); err != nil {
 		t.Error(err)
 	}
-	debug := fmt.Sprintf("%s", test.transaction)
+	debug := fmt.Sprint(test.transaction)
 	expected := []string{
 		"REQUEST_URI: /test",
 		"REQUEST_METHOD: OPTIONS",


### PR DESCRIPTION
Currently there is a confusing `Data()` method on `Map` which looks very similar to `FindAll`. It's a bit more optimized for string formatting, but not by much.

This moves the string formatting to the collections themselves - it seems easier to reason about, more flexible, and more performant. Some other uses of Data are removed or made internal.