### PR TITLE
Backfills in memory limit

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,11 +72,7 @@ type WAFConfig interface {
 
 // NewWAFConfig creates a new WAFConfig with the default settings.
 func NewWAFConfig() WAFConfig {
-	return &wafConfig{
-		requestBodyLimit:         corazawaf.UnsetLimit,
-		requestBodyInMemoryLimit: corazawaf.UnsetLimit,
-		responseBodyLimit:        corazawaf.UnsetLimit,
-	}
+	return &wafConfig{}
 }
 
 // AuditLogConfig controls audit logging.
@@ -109,10 +105,10 @@ type wafConfig struct {
 	rules                    []wafRule
 	auditLog                 *auditLogConfig
 	requestBodyAccess        bool
-	requestBodyLimit         int
-	requestBodyInMemoryLimit int
+	requestBodyLimit         *int
+	requestBodyInMemoryLimit *int
 	responseBodyAccess       bool
-	responseBodyLimit        int
+	responseBodyLimit        *int
 	responseBodyMimeTypes    []string
 	debugLogger              loggers.DebugLogger
 	errorCallback            func(rule types.MatchedRule)
@@ -189,19 +185,19 @@ func (c *wafConfig) clone() *wafConfig {
 
 func (c *wafConfig) WithRequestBodyLimit(limit int) WAFConfig {
 	ret := c.clone()
-	ret.requestBodyLimit = limit
+	ret.requestBodyLimit = &limit
 	return ret
 }
 
 func (c *wafConfig) WithRequestBodyInMemoryLimit(limit int) WAFConfig {
 	ret := c.clone()
-	ret.requestBodyInMemoryLimit = limit
+	ret.requestBodyInMemoryLimit = &limit
 	return ret
 }
 
 func (c *wafConfig) WithResponseBodyLimit(limit int) WAFConfig {
 	ret := c.clone()
-	ret.responseBodyLimit = limit
+	ret.responseBodyLimit = &limit
 	return ret
 }
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -546,7 +546,7 @@ func TestHandlerAPI(t *testing.T) {
 		},
 	}
 
-	waf, err := coraza.NewWAF(coraza.NewWAFConfig().WithRequestBodyLimit(3).WithRequestBodyInMemoryLimit(3))
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig().WithRequestBodyLimit(3))
 	if err != nil {
 		t.Fatalf("unexpected error while creating the WAF: %s", err.Error())
 	}

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -30,8 +30,8 @@ import (
 
 func TestProcessRequest(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://www.coraza.io/test", strings.NewReader("test=456"))
-	waf := corazawaf.NewWAF()
-	tx := waf.NewTransaction()
+	waf, _ := coraza.NewWAF(coraza.NewWAFConfig())
+	tx := waf.NewTransaction().(*corazawaf.Transaction)
 	if _, err := processRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
@@ -45,9 +45,9 @@ func TestProcessRequest(t *testing.T) {
 
 func TestProcessRequestEngineOff(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://www.coraza.io/test", strings.NewReader("test=456"))
-	waf := corazawaf.NewWAF()
-	waf.RuleEngine = types.RuleEngineOff
-	tx := waf.NewTransaction()
+	// TODO(jcchavezs): Shall we make RuleEngine a first class method in WAF config?
+	waf, _ := coraza.NewWAF(coraza.NewWAFConfig().WithDirectives("SecRuleEngine OFF"))
+	tx := waf.NewTransaction().(*corazawaf.Transaction)
 	if _, err := processRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
@@ -60,11 +60,9 @@ func TestProcessRequestEngineOff(t *testing.T) {
 }
 
 func TestProcessRequestMultipart(t *testing.T) {
-	waf := corazawaf.NewWAF()
-	waf.RequestBodyAccess = true
+	waf, _ := coraza.NewWAF(coraza.NewWAFConfig().WithRequestBodyAccess())
 
 	tx := waf.NewTransaction()
-	tx.RequestBodyAccess = true
 
 	req := createMultipartRequest(t)
 
@@ -127,17 +125,20 @@ func createMultipartRequest(t *testing.T) *http.Request {
 // from issue https://github.com/corazawaf/coraza/issues/159 @zpeasystart
 func TestDirectiveSecAuditLog(t *testing.T) {
 	waf := corazawaf.NewWAF()
-	p := seclang.NewParser(waf)
-	if err := p.FromString(`
+	waf.RequestBodyAccess = true
+	if err := seclang.NewParser(waf).FromString(`
 	SecRule REQUEST_FILENAME "@unconditionalMatch" "id:100, phase:2, t:none, log, setvar:'tx.count=+1',chain"
 	SecRule ARGS:username "@unconditionalMatch" "t:none, setvar:'tx.count=+2',chain"
 	SecRule ARGS:password "@unconditionalMatch" "t:none, setvar:'tx.count=+3'"
 		`); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+	if err := waf.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
 	tx := waf.NewTransaction()
 	defer tx.Close()
-	tx.RequestBodyAccess = true
 	tx.ForceRequestBodyVariable = true
 	// request
 	rdata := []string{

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -491,7 +491,7 @@ func TestWriteResponseBody(t *testing.T) {
 							waf.ResponseBodyLimit = int64(testCase.responseBodyLimit)
 							waf.ResponseBodyLimitAction = testCase.responseBodyLimitAction
 
-							if err := waf.ValidateAndBackfill(); err != nil {
+							if err := waf.Validate(); err != nil {
 								t.Fatalf("failed to validate the WAF: %s", err.Error())
 							}
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -491,7 +491,7 @@ func TestWriteResponseBody(t *testing.T) {
 							waf.ResponseBodyLimit = int64(testCase.responseBodyLimit)
 							waf.ResponseBodyLimitAction = testCase.responseBodyLimitAction
 
-							if err := waf.Validate(); err != nil {
+							if err := waf.ValidateAndBackfill(); err != nil {
 								t.Fatalf("failed to validate the WAF: %s", err.Error())
 							}
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -199,7 +199,6 @@ func TestWriteRequestBody(t *testing.T) {
 							waf.RuleEngine = types.RuleEngineOn
 							waf.RequestBodyAccess = true
 							waf.RequestBodyLimit = int64(testCase.requestBodyLimit)
-							waf.RequestBodyInMemoryLimit = int64(testCase.requestBodyLimit)
 							waf.RequestBodyLimitAction = testCase.requestBodyLimitAction
 
 							tx := waf.NewTransaction()
@@ -270,7 +269,6 @@ func TestWriteRequestBodyOnLimitReached(t *testing.T) {
 		waf.RuleEngine = types.RuleEngineOn
 		waf.RequestBodyAccess = true
 		waf.RequestBodyLimit = 2
-		waf.RequestBodyInMemoryLimit = 2
 		waf.RequestBodyLimitAction = tCase.requestBodyLimitAction
 
 		t.Run(tName, func(t *testing.T) {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -279,6 +279,13 @@ func NewWAF() *WAF {
 		TmpDir:             os.TempDir(),
 	}
 
+	// Here we link the request body in memory limit with the request body limit,
+	// hence it changes accordingly unless the user sets the memory limit to differ.
+	// This allows the WAF object to be valid despite wether the request body in memory
+	// limit is set or not and only perform the comparisons when the value is set by the
+	// user. For example, the test could require the requestBodyLimit to be 3 and no need
+	// to worry about the requestBodyInMemoryLimit but the WAF sill be invalid and the
+	// validation will fail.
 	waf.requestBodyInMemoryLimit = &(waf.RequestBodyLimit)
 
 	if err := waf.SetDebugLogPath(""); err != nil {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -310,6 +310,10 @@ func (w *WAF) SetRequestBodyInMemoryLimit(limit int64) {
 	w.requestBodyInMemoryLimit = &limit
 }
 
+func (w *WAF) RequestBodyInMemoryLimit() *int64 {
+	return w.requestBodyInMemoryLimit
+}
+
 // Validate validates the waf after all the settings have been set.
 func (w *WAF) Validate() error {
 	if w.RequestBodyLimit <= 0 {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -50,7 +50,7 @@ type WAF struct {
 	RequestBodyLimit int64
 
 	// Request body in memory limit
-	RequestBodyInMemoryLimit int64
+	requestBodyInMemoryLimit *int64
 
 	// If true, transactions will have access to the response body
 	ResponseBodyAccess bool
@@ -150,9 +150,9 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 	tx.AuditLogParts = w.AuditLogParts
 	tx.ForceRequestBodyVariable = false
 	tx.RequestBodyAccess = w.RequestBodyAccess
-	tx.RequestBodyLimit = w.RequestBodyLimit
+	tx.RequestBodyLimit = int64(w.RequestBodyLimit)
 	tx.ResponseBodyAccess = w.ResponseBodyAccess
-	tx.ResponseBodyLimit = w.ResponseBodyLimit
+	tx.ResponseBodyLimit = int64(w.ResponseBodyLimit)
 	tx.RuleEngine = w.RuleEngine
 	tx.HashEngine = false
 	tx.HashEnforcement = false
@@ -172,7 +172,7 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 	if tx.requestBodyBuffer == nil {
 		tx.requestBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath:     w.TmpDir,
-			MemoryLimit: w.RequestBodyInMemoryLimit,
+			MemoryLimit: int64(*w.requestBodyInMemoryLimit),
 			Limit:       w.ResponseBodyLimit,
 		})
 		tx.responseBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
@@ -243,13 +243,15 @@ func (w *WAF) SetDebugLogPath(path string) error {
 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		w.Logger.Error("failed to open the file: %s", err.Error())
+		w.Logger.Error("failed to open the debug log file: %s", err.Error())
 	}
 
 	w.Logger.SetOutput(f)
 
 	return nil
 }
+
+const _1gb = 1073741824
 
 // NewWAF creates a new WAF instance with default variables
 func NewWAF() *WAF {
@@ -267,15 +269,18 @@ func NewWAF() *WAF {
 		// Initializing pool for transactions
 		txPool: sync.NewPool(func() interface{} { return new(Transaction) }),
 		// These defaults are unavoidable as they are zero values for the variables
-		RuleEngine:               types.RuleEngineOn,
-		RequestBodyAccess:        false,
-		RequestBodyLimit:         _1gb,
-		RequestBodyInMemoryLimit: _1gb,
-		ResponseBodyAccess:       false,
-		ResponseBodyLimit:        _1gb,
-		AuditLogWriter:           logWriter,
-		Logger:                   logger,
+		RuleEngine:         types.RuleEngineOn,
+		RequestBodyAccess:  false,
+		RequestBodyLimit:   _1gb,
+		ResponseBodyAccess: false,
+		ResponseBodyLimit:  _1gb,
+		AuditLogWriter:     logWriter,
+		Logger:             logger,
+		TmpDir:             os.TempDir(),
 	}
+
+	waf.requestBodyInMemoryLimit = &(waf.RequestBodyLimit)
+
 	if err := waf.SetDebugLogPath(""); err != nil {
 		fmt.Println(err)
 	}
@@ -297,10 +302,9 @@ func (w *WAF) SetErrorCallback(cb func(rule types.MatchedRule)) {
 	w.ErrorLogCb = cb
 }
 
-const (
-	_1gb       = 1073741824
-	UnsetLimit = -1
-)
+func (w *WAF) SetRequestBodyInMemoryLimit(limit int64) {
+	w.requestBodyInMemoryLimit = &limit
+}
 
 func (w *WAF) Validate() error {
 	if w.RequestBodyLimit <= 0 {
@@ -311,14 +315,14 @@ func (w *WAF) Validate() error {
 		return errors.New("request body limit should be at most 1GB")
 	}
 
-	if w.RequestBodyLimit != UnsetLimit {
-		if w.RequestBodyLimit < w.RequestBodyInMemoryLimit {
+	if w.requestBodyInMemoryLimit != &w.RequestBodyLimit {
+		if *w.requestBodyInMemoryLimit <= 0 {
+			return errors.New("request body memory limit should be bigger than 0")
+		}
+
+		if w.RequestBodyLimit < *w.requestBodyInMemoryLimit {
 			return fmt.Errorf("request body limit should be at least the memory limit")
 		}
-	}
-
-	if w.RequestBodyInMemoryLimit <= 0 {
-		return errors.New("request body memory limit should be bigger than 0")
 	}
 
 	if w.ResponseBodyLimit <= 0 {

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -71,7 +71,7 @@ func TestSetDebugLogPath(t *testing.T) {
 	}
 }
 
-func TestValidateAndBackfill(t *testing.T) {
+func TestValidate(t *testing.T) {
 	testCases := map[string]struct {
 		customizer func(*WAF)
 		expectErr  bool
@@ -112,7 +112,7 @@ func TestValidateAndBackfill(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			waf := NewWAF()
 			tCase.customizer(waf)
-			err := waf.ValidateAndBackfill()
+			err := waf.Validate()
 			if tCase.expectErr {
 				if err == nil {
 					t.Fatalf("expected error: %s", err.Error())

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -71,7 +71,7 @@ func TestSetDebugLogPath(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestValidateAndBackfill(t *testing.T) {
 	testCases := map[string]struct {
 		customizer func(*WAF)
 		expectErr  bool
@@ -112,7 +112,7 @@ func TestValidate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			waf := NewWAF()
 			tCase.customizer(waf)
-			err := waf.Validate()
+			err := waf.ValidateAndBackfill()
 			if tCase.expectErr {
 				if err == nil {
 					t.Fatalf("expected error: %s", err.Error())

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -357,8 +357,9 @@ func directiveSecRequestBodyLimitAction(options *DirectiveOptions) error {
 func directiveSecRequestBodyInMemoryLimit(options *DirectiveOptions) error {
 	limit, err := strconv.ParseInt(options.Opts, 10, 64)
 	if err != nil {
-		options.WAF.SetRequestBodyInMemoryLimit(limit)
+		return err
 	}
+	options.WAF.SetRequestBodyInMemoryLimit(limit)
 	return nil
 }
 
@@ -711,8 +712,11 @@ func directiveSecUploadKeepFiles(options *DirectiveOptions) error {
 
 func directiveSecUploadFileMode(options *DirectiveOptions) error {
 	fm, err := strconv.ParseInt(options.Opts, 8, 32)
+	if err != nil {
+		return err
+	}
 	options.WAF.UploadFileMode = fs.FileMode(fm)
-	return err
+	return nil
 }
 
 func directiveSecUploadFileLimit(options *DirectiveOptions) error {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -194,9 +194,12 @@ func directiveSecResponseBodyAccess(options *DirectiveOptions) error {
 // Anything over the limit will be rejected with status code 413 (Request Entity Too Large).
 // There is a hard limit of 1 GB.
 func directiveSecRequestBodyLimit(options *DirectiveOptions) error {
-	var err error
-	options.WAF.RequestBodyLimit, err = strconv.ParseInt(options.Opts, 10, 64)
-	return err
+	limit, err := strconv.ParseInt(options.Opts, 10, 64)
+	if err != nil {
+		return err
+	}
+	options.WAF.RequestBodyLimit = limit
+	return nil
 }
 
 // Description: Configures whether request bodies will be buffered and processed by Coraza.
@@ -318,9 +321,12 @@ func directiveSecResponseBodyLimitAction(options *DirectiveOptions) error {
 // This setting will not affect the responses with MIME types that are not selected for
 // buffering. There is a hard limit of 1 GB.
 func directiveSecResponseBodyLimit(options *DirectiveOptions) error {
-	var err error
-	options.WAF.ResponseBodyLimit, err = strconv.ParseInt(options.Opts, 10, 64)
-	return err
+	limit, err := strconv.ParseInt(options.Opts, 10, 64)
+	if err != nil {
+		return err
+	}
+	options.WAF.ResponseBodyLimit = limit
+	return nil
 }
 
 // Description: Controls what happens once a request body limit, configured with
@@ -349,9 +355,11 @@ func directiveSecRequestBodyLimitAction(options *DirectiveOptions) error {
 // When a `multipart/form-data` request is being processed, once the in-memory limit is reached,
 // the request body will start to be streamed into a temporary file on disk.
 func directiveSecRequestBodyInMemoryLimit(options *DirectiveOptions) error {
-	var err error
-	options.WAF.RequestBodyInMemoryLimit, err = strconv.ParseInt(options.Opts, 10, 64)
-	return err
+	limit, err := strconv.ParseInt(options.Opts, 10, 64)
+	if err != nil {
+		options.WAF.SetRequestBodyInMemoryLimit(limit)
+	}
+	return nil
 }
 
 func directiveSecRemoteRulesFailAction(options *DirectiveOptions) error {

--- a/waf.go
+++ b/waf.go
@@ -76,20 +76,20 @@ func NewWAF(config WAFConfig) (WAF, error) {
 		waf.RequestBodyAccess = true
 	}
 
-	if c.requestBodyLimit != corazawaf.UnsetLimit {
-		waf.RequestBodyLimit = int64(c.requestBodyLimit)
+	if c.requestBodyLimit != nil {
+		waf.RequestBodyLimit = int64(*c.requestBodyLimit)
 	}
 
-	if c.requestBodyInMemoryLimit != corazawaf.UnsetLimit {
-		waf.RequestBodyInMemoryLimit = int64(c.requestBodyInMemoryLimit)
+	if c.requestBodyInMemoryLimit != nil {
+		waf.SetRequestBodyInMemoryLimit(int64(*c.requestBodyInMemoryLimit))
 	}
 
 	if c.responseBodyAccess {
 		waf.ResponseBodyAccess = true
 	}
 
-	if c.responseBodyLimit != corazawaf.UnsetLimit {
-		waf.ResponseBodyLimit = int64(c.responseBodyLimit)
+	if c.responseBodyLimit != nil {
+		waf.ResponseBodyLimit = int64(*c.responseBodyLimit)
 	}
 
 	if c.errorCallback != nil {

--- a/waf.go
+++ b/waf.go
@@ -96,7 +96,7 @@ func NewWAF(config WAFConfig) (WAF, error) {
 		waf.ErrorLogCb = c.errorCallback
 	}
 
-	if err := waf.ValidateAndBackfill(); err != nil {
+	if err := waf.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/waf.go
+++ b/waf.go
@@ -96,7 +96,7 @@ func NewWAF(config WAFConfig) (WAF, error) {
 		waf.ErrorLogCb = c.errorCallback
 	}
 
-	if err := waf.Validate(); err != nil {
+	if err := waf.ValidateAndBackfill(); err != nil {
 		return nil, err
 	}
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -42,8 +42,8 @@ func TestRequestBodyLimit(t *testing.T) {
 	for name, tCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			cfg := NewWAFConfig().(*wafConfig)
-			cfg.requestBodyLimit = tCase.limit
-			cfg.requestBodyInMemoryLimit = tCase.inMemoryLimit
+			cfg.requestBodyLimit = &tCase.limit
+			cfg.requestBodyInMemoryLimit = &tCase.inMemoryLimit
 
 			_, err := NewWAF(cfg)
 			if tCase.expectedErr == nil {
@@ -84,7 +84,7 @@ func TestResponseBodyLimit(t *testing.T) {
 	for name, tCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			cfg := NewWAFConfig().(*wafConfig)
-			cfg.responseBodyLimit = tCase.limit
+			cfg.responseBodyLimit = &tCase.limit
 
 			_, err := NewWAF(cfg)
 			if tCase.expectedErr == nil {


### PR DESCRIPTION
Currently in memory limit default value is hardcoded to 1GB which is inconvenient when we set low values for body limit e.g. in tests as we also need to set the in memory limit despite the fact it is part of the test or not.