### PR TITLE
fix: fixes the parser to avoid invalid rules.

### DIFF
--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -49,7 +49,12 @@ func directiveInclude(_ *DirectiveOptions) error {
 
 var _ directive = directiveInclude
 
+var errEmptyOptions = errors.New("expected options")
+
 func directiveSecComponentSignature(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
 	options.WAF.ComponentNames = append(options.WAF.ComponentNames, options.Opts)
 	return nil
 }
@@ -87,6 +92,10 @@ func directiveSecComponentSignature(options *DirectiveOptions) error {
 //
 // ```
 func directiveSecMarker(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	rule := corazawaf.NewRule()
 	rule.Raw_ = fmt.Sprintf("SecMarker %s", options.Opts)
 	rule.SecMark_ = options.Opts
@@ -95,7 +104,7 @@ func directiveSecMarker(options *DirectiveOptions) error {
 	rule.Line_ = options.Config.Get("parser_last_line", 0).(int)
 	rule.File_ = options.Config.Get("parser_config_file", "").(string)
 	if err := options.WAF.Rules.Add(rule); err != nil {
-		return newCompileRuleError(err, options.Opts)
+		return err
 	}
 	options.WAF.Logger.Debug("added secmark rule")
 	return nil
@@ -112,6 +121,10 @@ func directiveSecMarker(options *DirectiveOptions) error {
 // SecAction "nolog,phase:1,initcol:RESOURCE=%{REQUEST_FILENAME}"
 // ```
 func directiveSecAction(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	rule, err := ParseRule(RuleOptions{
 		WithOperator: false,
 		WAF:          options.WAF,
@@ -120,10 +133,10 @@ func directiveSecAction(options *DirectiveOptions) error {
 		Data:         options.Opts,
 	})
 	if err != nil {
-		return newCompileRuleError(err, options.Opts)
+		return err
 	}
 	if err := options.WAF.Rules.Add(rule); err != nil {
-		return newCompileRuleError(err, options.Opts)
+		return err
 	}
 	options.WAF.Logger.Debug("Added SecAction: %s", options.Opts)
 	return nil
@@ -145,6 +158,10 @@ func directiveSecAction(options *DirectiveOptions) error {
 // SecRule ARGS "@rx attack" "phase:1,log,deny,id:1"
 // ```
 func directiveSecRule(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	ignoreErrors := options.Config.Get("ignore_rule_compilation_errors", false).(bool)
 	rule, err := ParseRule(RuleOptions{
 		WithOperator: true,
@@ -154,7 +171,7 @@ func directiveSecRule(options *DirectiveOptions) error {
 		Data:         options.Opts,
 	})
 	if err != nil && !ignoreErrors {
-		return newCompileRuleError(err, options.Opts)
+		return err
 	} else if err != nil && ignoreErrors {
 		options.WAF.Logger.Debug("Ignoring rule compilation error for rule %s: %s", options.Opts, err.Error())
 		return nil
@@ -179,9 +196,13 @@ func directiveSecRule(options *DirectiveOptions) error {
 // configured with `SecResponseBodyMimeType`).
 // - Off: do not buffer response bodies.
 func directiveSecResponseBodyAccess(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	b, err := parseBoolean(strings.ToLower(options.Opts))
 	if err != nil {
-		return newDirectiveError(err, "SecResponseBodyAccess")
+		return err
 	}
 	options.WAF.ResponseBodyAccess = b
 	return nil
@@ -194,6 +215,10 @@ func directiveSecResponseBodyAccess(options *DirectiveOptions) error {
 // Anything over the limit will be rejected with status code 413 (Request Entity Too Large).
 // There is a hard limit of 1 GB.
 func directiveSecRequestBodyLimit(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	limit, err := strconv.ParseInt(options.Opts, 10, 64)
 	if err != nil {
 		return err
@@ -212,9 +237,13 @@ func directiveSecRequestBodyLimit(options *DirectiveOptions) error {
 // - On: buffer request bodies
 // - Off: do not buffer request bodies
 func directiveSecRequestBodyAccess(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	b, err := parseBoolean(strings.ToLower(options.Opts))
 	if err != nil {
-		return newDirectiveError(err, "SecRequestBodyAccess")
+		return err
 	}
 	options.WAF.RequestBodyAccess = b
 	return nil
@@ -240,21 +269,37 @@ func directiveUnsupported(options *DirectiveOptions) error {
 }
 
 func directiveSecWebAppID(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.WebAppID = options.Opts
 	return nil
 }
 
 func directiveSecTmpDir(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.TmpDir = options.Opts
 	return nil
 }
 
 func directiveSecServerSignature(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.ServerSignature = options.Opts
 	return nil
 }
 
 func directiveSecRuleRemoveByTag(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	for _, r := range options.WAF.Rules.FindByTag(options.Opts) {
 		options.WAF.Rules.DeleteByID(r.ID_)
 	}
@@ -262,6 +307,10 @@ func directiveSecRuleRemoveByTag(options *DirectiveOptions) error {
 }
 
 func directiveSecRuleRemoveByMsg(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	for _, r := range options.WAF.Rules.FindByMsg(options.Opts) {
 		options.WAF.Rules.DeleteByID(r.ID_)
 	}
@@ -280,6 +329,10 @@ func directiveSecResponseBodyMimeTypesClear(options *DirectiveOptions) error {
 }
 
 func directiveSecResponseBodyMimeType(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.ResponseBodyMimeTypes = strings.Split(options.Opts, " ")
 	return nil
 }
@@ -321,6 +374,10 @@ func directiveSecResponseBodyLimitAction(options *DirectiveOptions) error {
 // This setting will not affect the responses with MIME types that are not selected for
 // buffering. There is a hard limit of 1 GB.
 func directiveSecResponseBodyLimit(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	limit, err := strconv.ParseInt(options.Opts, 10, 64)
 	if err != nil {
 		return err
@@ -355,6 +412,10 @@ func directiveSecRequestBodyLimitAction(options *DirectiveOptions) error {
 // When a `multipart/form-data` request is being processed, once the in-memory limit is reached,
 // the request body will start to be streamed into a temporary file on disk.
 func directiveSecRequestBodyInMemoryLimit(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	limit, err := strconv.ParseInt(options.Opts, 10, 64)
 	if err != nil {
 		return err
@@ -364,6 +425,10 @@ func directiveSecRequestBodyInMemoryLimit(options *DirectiveOptions) error {
 }
 
 func directiveSecRemoteRulesFailAction(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.AbortOnRemoteRulesFail = strings.ToLower(options.Opts) == "abort"
 	return nil
 }
@@ -377,6 +442,10 @@ func directiveSecConnWriteStateLimit(options *DirectiveOptions) error {
 }
 
 func directiveSecSensorID(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.SensorID = options.Opts
 	return nil
 }
@@ -439,6 +508,10 @@ func directiveSecHashEngine(options *DirectiveOptions) error {
 // Important: Every `SecDefaultAction` directive must specify a disruptive action and a processing
 // phase and cannot contain metadata actions.
 func directiveSecDefaultAction(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	da, _ := options.Config.Get("rule_default_actions", []string{}).([]string)
 	da = append(da, options.Opts)
 	options.Config.Set("rule_default_actions", da)
@@ -485,7 +558,7 @@ func directiveSecCollectionTimeout(options *DirectiveOptions) error {
 // or for the directory.
 func directiveSecAuditLog(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLog /some/absolute/path.log")
+		return errEmptyOptions
 	}
 
 	options.Config.Set("auditlog_file", options.Opts)
@@ -497,8 +570,9 @@ func directiveSecAuditLog(options *DirectiveOptions) error {
 
 func directiveSecAuditLogType(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLogType [concurrent/https/serial/...]")
+		return errEmptyOptions
 	}
+
 	writer, err := loggers.GetLogWriter(options.Opts)
 	if err != nil {
 		return err
@@ -516,8 +590,9 @@ func directiveSecAuditLogType(options *DirectiveOptions) error {
 // Default: Native
 func directiveSecAuditLogFormat(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLogFormat [json/native/...]")
+		return errEmptyOptions
 	}
+
 	formatter, err := loggers.GetLogFormatter(options.Opts)
 	if err != nil {
 		return err
@@ -532,8 +607,9 @@ func directiveSecAuditLogFormat(options *DirectiveOptions) error {
 
 func directiveSecAuditLogDir(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLogDir /some/absolute/path")
+		return errEmptyOptions
 	}
+
 	options.Config.Set("auditlog_dir", options.Opts)
 	if err := options.WAF.AuditLogWriter.Init(options.Config); err != nil {
 		return err
@@ -555,8 +631,9 @@ func directiveSecAuditLogDir(options *DirectiveOptions) error {
 // ```
 func directiveSecAuditLogDirMode(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLogDirMode [0777/0700/...]")
+		return errEmptyOptions
 	}
+
 	auditLogDirMode, err := strconv.ParseInt(options.Opts, 8, 32)
 	if err != nil {
 		return err
@@ -580,8 +657,9 @@ func directiveSecAuditLogDirMode(options *DirectiveOptions) error {
 // ```
 func directiveSecAuditLogFileMode(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
-		return errors.New("syntax error: SecAuditLogFileMode [0777/0700/...]")
+		return errEmptyOptions
 	}
+
 	auditLogFileMode, err := strconv.ParseInt(options.Opts, 8, 32)
 	if err != nil {
 		return err
@@ -615,6 +693,10 @@ func directiveSecAuditLogFileMode(options *DirectiveOptions) error {
 // and send rule matches to the audit log regardless of status. You must specify noauditlog in the
 // rules manually or set it in `SecDefaultAction`.
 func directiveSecAuditLogRelevantStatus(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	var err error
 	options.WAF.AuditLogRelevantStatus, err = regexp.Compile(options.Opts)
 	return err
@@ -659,6 +741,10 @@ func directiveSecAuditLogRelevantStatus(options *DirectiveOptions) error {
 // matched. The rules are fully qualified and will thus show inherited actions and default operators.
 // - Z: Final boundary, signifies the end of the entry (mandatory).
 func directiveSecAuditLogParts(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.AuditLogParts = types.AuditLogParts(options.Opts)
 	return nil
 }
@@ -690,13 +776,20 @@ func directiveSecAuditLogParts(options *DirectiveOptions) error {
 // SecAuditLogRelevantStatus ^(?:5|4(?!04))
 // ```
 func directiveSecAuditEngine(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	au, err := types.ParseAuditEngineStatus(options.Opts)
 	options.WAF.AuditEngine = au
 	return err
 }
 
 func directiveSecDataDir(options *DirectiveOptions) error {
-	// TODO validations
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	options.WAF.DataDir = options.Opts
 	return nil
 }
@@ -704,13 +797,17 @@ func directiveSecDataDir(options *DirectiveOptions) error {
 func directiveSecUploadKeepFiles(options *DirectiveOptions) error {
 	b, err := parseBoolean(options.Opts)
 	if err != nil {
-		return newDirectiveError(err, "SecUploadKeepFiles")
+		return err
 	}
 	options.WAF.UploadKeepFiles = b
 	return nil
 }
 
 func directiveSecUploadFileMode(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	fm, err := strconv.ParseInt(options.Opts, 8, 32)
 	if err != nil {
 		return err
@@ -720,12 +817,20 @@ func directiveSecUploadFileMode(options *DirectiveOptions) error {
 }
 
 func directiveSecUploadFileLimit(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	var err error
 	options.WAF.UploadFileLimit, err = strconv.Atoi(options.Opts)
 	return err
 }
 
 func directiveSecUploadDir(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	// TODO validations
 	options.WAF.UploadDir = options.Opts
 	return nil
@@ -746,6 +851,10 @@ func directiveSecUploadDir(options *DirectiveOptions) error {
 // should be able to reduce it down to 128 KB or lower. Anything over the limit will be
 // rejected with status code 413 (Request Entity Too Large). There is a hard limit of 1 GB.
 func directiveSecRequestBodyNoFilesLimit(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	var err error
 	options.WAF.RequestBodyNoFilesLimit, err = strconv.ParseInt(options.Opts, 10, 64)
 	return err
@@ -757,6 +866,10 @@ func directiveSecRequestBodyNoFilesLimit(options *DirectiveOptions) error {
 // Logs will be written to this file. Make sure the process user has write access to the
 // directory.
 func directiveSecDebugLog(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	return options.WAF.SetDebugLogPath(options.Opts)
 }
 
@@ -806,7 +919,7 @@ func directiveSecRuleUpdateTargetByID(options *DirectiveOptions) error {
 func directiveSecIgnoreRuleCompilationErrors(options *DirectiveOptions) error {
 	b, err := parseBoolean(options.Opts)
 	if err != nil {
-		return newDirectiveError(err, "SecIgnoreRuleCompilationErrors")
+		return err
 	}
 	if b {
 		options.WAF.Logger.Warn(`Coraza is running in Compatibility Mode (SecIgnoreRuleCompilationErrors On)
@@ -817,6 +930,10 @@ func directiveSecIgnoreRuleCompilationErrors(options *DirectiveOptions) error {
 }
 
 func directiveSecDataset(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+
 	name, d, ok := strings.Cut(options.Opts, " ")
 	if !ok {
 		return errors.New("syntax error: SecDataset name `\n...\n`")
@@ -835,14 +952,6 @@ func directiveSecDataset(options *DirectiveOptions) error {
 	}
 	options.Datasets[name] = arr
 	return nil
-}
-
-func newCompileRuleError(err error, opts string) error {
-	return fmt.Errorf("failed to compile rule (%s): %s", err, opts)
-}
-
-func newDirectiveError(err error, directive string) error {
-	return fmt.Errorf("syntax error for directive %s: %s", directive, err)
 }
 
 func parseBoolean(data string) (bool, error) {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -436,7 +436,14 @@ func directiveSecRemoteRulesFailAction(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.WAF.AbortOnRemoteRulesFail = strings.ToLower(options.Opts) == "abort"
+	switch strings.ToLower(options.Opts) {
+	case "abort":
+		options.WAF.AbortOnRemoteRulesFail = true
+	case "warn":
+		options.WAF.AbortOnRemoteRulesFail = false
+	default:
+		return errors.New("unknown option")
+	}
 	return nil
 }
 

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/loggers"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -291,7 +292,7 @@ func directiveSecServerSignature(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.WAF.ServerSignature = options.Opts
+	options.WAF.ServerSignature = utils.MaybeRemoveQuotes(options.Opts)
 	return nil
 }
 
@@ -318,12 +319,18 @@ func directiveSecRuleRemoveByMsg(options *DirectiveOptions) error {
 }
 
 func directiveSecRuleRemoveByID(options *DirectiveOptions) error {
-	id, _ := strconv.Atoi(options.Opts)
+	id, err := strconv.Atoi(options.Opts)
+	if err != nil {
+		return err
+	}
 	options.WAF.Rules.DeleteByID(id)
 	return nil
 }
 
 func directiveSecResponseBodyMimeTypesClear(options *DirectiveOptions) error {
+	if len(options.Opts) > 0 {
+		return errors.New("unexpected options")
+	}
 	options.WAF.ResponseBodyMimeTypes = nil
 	return nil
 }

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -109,6 +109,15 @@ func TestDirectives(t *testing.T) {
 		check func(*corazawaf.WAF) bool
 	}
 	directiveCases := map[string][]directiveCase{
+		"SecComponentSignature": {
+			{"", expectErrorOnDirective},
+			{"name", func(w *corazawaf.WAF) bool { return len(w.ComponentNames) == 1 }},
+		},
+		"SecMarker": {
+			{"", expectErrorOnDirective},
+			{"999", func(w *corazawaf.WAF) bool { return w.Rules.Count() == 1 }},
+			{"MY_TEXT", func(w *corazawaf.WAF) bool { return w.Rules.Count() == 1 }},
+		},
 		"SecWebAppId": {
 			{"", expectErrorOnDirective},
 			{"test123", func(w *corazawaf.WAF) bool { return w.WebAppID == "test123" }},
@@ -192,11 +201,34 @@ func TestDirectives(t *testing.T) {
 			{"Reject", func(w *corazawaf.WAF) bool { return w.RequestBodyLimitAction == types.BodyLimitActionReject }},
 			{"ProcessPartial", func(w *corazawaf.WAF) bool { return w.RequestBodyLimitAction == types.BodyLimitActionProcessPartial }},
 		},
+		"SecRequestBodyAccess": {
+			{"", expectErrorOnDirective},
+			{"What?", expectErrorOnDirective},
+			{"On", func(w *corazawaf.WAF) bool { return w.RequestBodyAccess }},
+			{"Off", func(w *corazawaf.WAF) bool { return !w.RequestBodyAccess }},
+		},
 		"SecResponseBodyLimitAction": {
 			{"", expectErrorOnDirective},
 			{"What?", expectErrorOnDirective},
 			{"Reject", func(w *corazawaf.WAF) bool { return w.ResponseBodyLimitAction == types.BodyLimitActionReject }},
 			{"ProcessPartial", func(w *corazawaf.WAF) bool { return w.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial }},
+		},
+		"SecResponseBodyAccess": {
+			{"", expectErrorOnDirective},
+			{"What?", expectErrorOnDirective},
+			{"On", func(w *corazawaf.WAF) bool { return w.ResponseBodyAccess }},
+			{"Off", func(w *corazawaf.WAF) bool { return !w.ResponseBodyAccess }},
+		},
+		"SecRemoteRulesFailAction": {
+			{"", expectErrorOnDirective},
+			{"What?", expectErrorOnDirective},
+			{"Abort", func(w *corazawaf.WAF) bool { return w.AbortOnRemoteRulesFail }},
+		},
+		"SecDefaultAction": {
+			{"", expectErrorOnDirective},
+		},
+		"SecAuditLog": {
+			{"", expectErrorOnDirective},
 		},
 	}
 

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -34,110 +34,6 @@ func Test_NonImplementedDirective(t *testing.T) {
 	}
 }
 
-func Test_directive(t *testing.T) {
-	w := corazawaf.NewWAF()
-	p := NewParser(w)
-	if err := p.FromString("SecWebAppId test123"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.WebAppID != "test123" {
-		t.Error("failed to set SecWebAppId")
-	}
-	if err := p.FromString("SecUploadKeepFiles On"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if !w.UploadKeepFiles {
-		t.Error("failed to set SecUploadKeepFiles")
-	}
-	if err := p.FromString("SecUploadFileMode 0700"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if err := p.FromString("SecUploadFileLimit 1000"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.UploadFileLimit != 1000 {
-		t.Error("failed to set SecUploadFileLimit")
-	}
-	if err := p.FromString("SecUploadDir /tmp"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.UploadDir != "/tmp" {
-		t.Error("failed to set SecUploadDir")
-	}
-	if err := p.FromString("SecTmpDir /tmp"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.TmpDir != "/tmp" {
-		t.Error("failed to set SecTmpDir")
-	}
-	if err := p.FromString("SecSensorId test"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.SensorID != "test" {
-		t.Error("failed to set SecSensorId")
-	}
-	if err := p.FromString("SecRuleEngine DetectionOnly"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if w.RuleEngine != types.RuleEngineDetectionOnly {
-		t.Errorf("failed to set SecRuleEngine, got %s and expected %s", w.RuleEngine.String(), types.RuleEngineDetectionOnly.String())
-	}
-	if err := p.FromString(`SecAction "id:1,tag:test"`); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if err := p.FromString("SecRuleRemoveByTag test"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if p.options.WAF.Rules.Count() != 0 {
-		t.Error("Failed to remove rule with SecRuleRemoveByTag")
-	}
-	if err := p.FromString(`SecAction "id:1,msg:'test'"`); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if err := p.FromString("SecRuleRemoveByMsg test"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if p.options.WAF.Rules.Count() != 0 {
-		t.Error("Failed to remove rule with SecRuleRemoveByMsg")
-	}
-	if err := p.FromString(`SecAction "id:1"`); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if err := p.FromString("SecRuleRemoveById 1"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if p.options.WAF.Rules.Count() != 0 {
-		t.Error("Failed to remove rule with SecRuleRemoveById")
-	}
-	if err := p.FromString("SecResponseBodyMimeTypesClear"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if len(p.options.WAF.ResponseBodyMimeTypes) != 0 {
-		t.Error("failed to set SecResponseBodyMimeTypesClear")
-	}
-	if err := p.FromString("SecResponseBodyMimeType text/html"); err != nil {
-		t.Error("failed to set parser from string")
-	}
-	if p.options.WAF.ResponseBodyMimeTypes[0] != "text/html" {
-		t.Error("failed to set SecResponseBodyMimeType")
-	}
-	if err := p.FromString(`SecServerSignature "Microsoft-IIS/6.0"`); err != nil {
-		t.Error("failed to set directive: SecServerSignature")
-	}
-	if err := p.FromString(`SecRequestBodyInMemoryLimit 131072`); err != nil {
-		t.Error("failed to set directive: SecRequestBodyInMemoryLimit")
-	}
-	if err := p.FromString(`SecRemoteRulesFailAction Abort`); err != nil {
-		t.Error("failed to set directive: SecRemoteRulesFailAction")
-	}
-	if err := p.FromString(`SecRequestBodyLimitAction Reject`); err != nil {
-		t.Error("failed to set directive: SecRequestBodyLimitAction")
-	}
-	if err := p.FromString(`SecResponseBodyLimitAction ProcessPartial`); err != nil {
-		t.Error("failed to set directive: SecResponseBodyLimitAction")
-	}
-}
-
 func TestSecRuleUpdateTargetBy(t *testing.T) {
 	waf := corazawaf.NewWAF()
 	rule, err := ParseRule(RuleOptions{
@@ -213,17 +109,94 @@ func TestDirectives(t *testing.T) {
 		check func(*corazawaf.WAF) bool
 	}
 	directiveCases := map[string][]directiveCase{
+		"SecWebAppId": {
+			{"", expectErrorOnDirective},
+			{"test123", func(w *corazawaf.WAF) bool { return w.WebAppID == "test123" }},
+		},
+		"SecUploadKeepFiles": {
+			{"", expectErrorOnDirective},
+			{"Ox", expectErrorOnDirective},
+			{"On", func(w *corazawaf.WAF) bool { return w.UploadKeepFiles }},
+			{"Off", func(w *corazawaf.WAF) bool { return !w.UploadKeepFiles }},
+		},
+		"SecUploadFileMode": {
+			{"", expectErrorOnDirective},
+			{"888", expectErrorOnDirective},
+			{"700", func(w *corazawaf.WAF) bool { return w.UploadFileMode == 0700 }},
+		},
+		"SecUploadFileLimit": {
+			{"", expectErrorOnDirective},
+			{"1000", func(w *corazawaf.WAF) bool { return w.UploadFileLimit == 1000 }},
+		},
+		"SecUploadDir": {
+			{"", expectErrorOnDirective},
+			{"/tmp", func(w *corazawaf.WAF) bool { return w.UploadDir == "/tmp" }},
+		},
+		"SecTmpDir": {
+			{"", expectErrorOnDirective},
+			{"/tmp", func(w *corazawaf.WAF) bool { return w.TmpDir == "/tmp" }},
+		},
+		"SecSensorId": {
+			{"", expectErrorOnDirective},
+			{"test", func(w *corazawaf.WAF) bool { return w.SensorID == "test" }},
+		},
+		"SecRuleEngine": {
+			{"What?", expectErrorOnDirective},
+			{"DetectionOnly", func(w *corazawaf.WAF) bool { return w.RuleEngine == types.RuleEngineDetectionOnly }},
+			{"On", func(w *corazawaf.WAF) bool { return w.RuleEngine == types.RuleEngineOn }},
+			{"Off", func(w *corazawaf.WAF) bool { return w.RuleEngine == types.RuleEngineOff }},
+		},
+		"SecAction": {
+			{"", expectErrorOnDirective},
+			{`"id:1,tag:test"`, func(w *corazawaf.WAF) bool { return w.Rules.Count() == 1 }},
+		},
+		"SecRuleRemoveByTag": {
+			{"", expectErrorOnDirective},
+		},
+		"SecRuleRemoveByMsg": {
+			{"", expectErrorOnDirective},
+		},
+		"SecRuleRemoveById": {
+			{"", expectErrorOnDirective},
+		},
+		"SecResponseBodyMimeTypesClear": {
+			{"", func(w *corazawaf.WAF) bool { return len(w.ResponseBodyMimeTypes) == 0 }},
+			{"x", expectErrorOnDirective},
+		},
+		"SecResponseBodyMimeType": {
+			{"", expectErrorOnDirective},
+			{"text/html", func(w *corazawaf.WAF) bool { return w.ResponseBodyMimeTypes[0] == "text/html" }},
+		},
+		"SecServerSignature": {
+			{"", expectErrorOnDirective},
+			{`"Microsoft-IIS/6.0"`, func(w *corazawaf.WAF) bool { return w.ServerSignature == "Microsoft-IIS/6.0" }},
+		},
 		"SecRequestBodyLimit": {
+			{"", expectErrorOnDirective},
 			{"x", expectErrorOnDirective},
 			{"123", func(w *corazawaf.WAF) bool { return w.RequestBodyLimit == 123 }},
 		},
 		"SecResponseBodyLimit": {
+			{"", expectErrorOnDirective},
 			{"y", expectErrorOnDirective},
 			{"123", func(w *corazawaf.WAF) bool { return w.ResponseBodyLimit == 123 }},
 		},
 		"SecRequestBodyInMemoryLimit": {
+			{"", expectErrorOnDirective},
 			{"z", expectErrorOnDirective},
 			{"123", func(w *corazawaf.WAF) bool { return *(w.RequestBodyInMemoryLimit()) == 123 }},
+		},
+		"SecRequestBodyLimitAction": {
+			{"", expectErrorOnDirective},
+			{"What?", expectErrorOnDirective},
+			{"Reject", func(w *corazawaf.WAF) bool { return w.RequestBodyLimitAction == types.BodyLimitActionReject }},
+			{"ProcessPartial", func(w *corazawaf.WAF) bool { return w.RequestBodyLimitAction == types.BodyLimitActionProcessPartial }},
+		},
+		"SecResponseBodyLimitAction": {
+			{"", expectErrorOnDirective},
+			{"What?", expectErrorOnDirective},
+			{"Reject", func(w *corazawaf.WAF) bool { return w.ResponseBodyLimitAction == types.BodyLimitActionReject }},
+			{"ProcessPartial", func(w *corazawaf.WAF) bool { return w.ResponseBodyLimitAction == types.BodyLimitActionProcessPartial }},
 		},
 	}
 

--- a/internal/seclang/parser_test.go
+++ b/internal/seclang/parser_test.go
@@ -22,7 +22,7 @@ func TestInterruption(t *testing.T) {
 	waf := coraza.NewWAF()
 	p := NewParser(waf)
 	if err := p.FromString(`SecAction "id:1,deny,log,phase:1"`); err != nil {
-		t.Error("Could not create from string")
+		t.Errorf("Could not create from string: %s", err.Error())
 	}
 	tx := waf.NewTransaction()
 	if tx.ProcessRequestHeaders() == nil {
@@ -36,6 +36,20 @@ func TestDirectivesCaseInsensitive(t *testing.T) {
 	err := p.FromString("seCwEbAppid 15")
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestInvalidDirective(t *testing.T) {
+	waf := coraza.NewWAF()
+	p := NewParser(waf)
+	err := p.FromString("Unknown Rule")
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	err = p.FromString("SecEngineRule")
+	if err == nil {
+		t.Error("expected error")
 	}
 }
 

--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -4,6 +4,7 @@
 package seclang
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -87,8 +88,9 @@ func TestSecRuleInlineVariableNegation(t *testing.T) {
 	err = p.FromString(`
 		SecRule REQUEST_URI|!REQUEST_COOKIES: "abc" "id:9,phase:2"
 	`)
-	if !strings.Contains(err.Error(), "failed to compile rule") {
-		t.Errorf("Error should be failed to compile rule, got %s", err)
+	expectedErr := "failed to compile the directive"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("unexpected error, want %q, got %q", expectedErr, err.Error())
 	}
 }
 
@@ -108,8 +110,9 @@ func TestSecRuleUpdateTargetVariableNegation(t *testing.T) {
 		SecRule REQUEST_URI|REQUEST_COOKIES "abc" "id:8,phase:2"
 		SecRuleUpdateTargetById 8 "!REQUEST_HEADERS:"
 	`)
-	if err.Error() != "unknown variable" {
-		t.Errorf("Error should be unknown variable, got %s", err.Error())
+	expectedErr := errors.New("unknown variable")
+	if errors.Unwrap(err).Error() != expectedErr.Error() {
+		t.Fatalf("unexpexted error, want %q, have %q", expectedErr, errors.Unwrap(err).Error())
 	}
 
 	// Try to update undefined rule
@@ -117,9 +120,9 @@ func TestSecRuleUpdateTargetVariableNegation(t *testing.T) {
 		SecRule REQUEST_URI|REQUEST_COOKIES "abc" "id:9,phase:2"
 		SecRuleUpdateTargetById 99 "!REQUEST_HEADERS:xyz"
 	`)
-	if err.Error() != "cannot create a variable exception for an undefined rule" {
-		t.Error("Error should be cannot create a variable exception for an undefined rule, got ",
-			err)
+	expectedErr = errors.New("cannot create a variable exception for an undefined rule")
+	if errors.Unwrap(err).Error() != expectedErr.Error() {
+		t.Fatalf("unexpected error, want %q, have %q", expectedErr, errors.Unwrap(err).Error())
 	}
 }
 

--- a/types/waf.go
+++ b/types/waf.go
@@ -80,7 +80,7 @@ func ParseRuleEngineStatus(re string) (RuleEngineStatus, error) {
 	case "off":
 		return RuleEngineOff, nil
 	}
-	return -1, fmt.Errorf("invalid rule engine status: %s", re)
+	return -1, fmt.Errorf("invalid rule engine status: %q", re)
 }
 
 // String returns the string representation of the
@@ -88,11 +88,11 @@ func ParseRuleEngineStatus(re string) (RuleEngineStatus, error) {
 func (re RuleEngineStatus) String() string {
 	switch re {
 	case RuleEngineOn:
-		return "on"
+		return "On"
 	case RuleEngineDetectionOnly:
 		return "DetectionOnly"
 	case RuleEngineOff:
-		return "off"
+		return "Off"
 	}
 	return "unknown"
 }


### PR DESCRIPTION
Currently if the directive is invalid (e.g. a valid directive without options) the parser would not fail. This PR changes that so that the directives will fail if malformed.

**Important:** Until now we are operating under the assumption **the only direction** which does not require options is `directiveSecResponseBodyMimeTypesClear` (to be confirmed by @airween @dune73 @fzipi)

Funny note: this has been found by trying to resurrect the playground