### PR TITLE
chore: removes support for SecTmpDir.

### DIFF
--- a/coraza.conf-recommended
+++ b/coraza.conf-recommended
@@ -168,14 +168,6 @@ SecResponseBodyLimitAction ProcessPartial
 
 # -- Filesystem configuration ------------------------------------------------
 
-# The location where Coraza stores temporary files (for example, when
-# it needs to handle a file upload that is larger than the configured limit).
-# 
-# This default setting is chosen due to all systems have /tmp available however, 
-# this is less than ideal. It is recommended that you specify a location that's private.
-#
-SecTmpDir /tmp/
-
 # The location where Coraza will keep its persistent data.  This default setting 
 # is chosen due to all systems have /tmp available however, it
 # too should be updated to a place that other users can't access.

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -278,15 +278,6 @@ func directiveSecWebAppID(options *DirectiveOptions) error {
 	return nil
 }
 
-func directiveSecTmpDir(options *DirectiveOptions) error {
-	if len(options.Opts) == 0 {
-		return errEmptyOptions
-	}
-
-	options.WAF.TmpDir = options.Opts
-	return nil
-}
-
 func directiveSecServerSignature(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
 		return errEmptyOptions

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -141,10 +141,6 @@ func TestDirectives(t *testing.T) {
 			{"", expectErrorOnDirective},
 			{"/tmp", func(w *corazawaf.WAF) bool { return w.UploadDir == "/tmp" }},
 		},
-		"SecTmpDir": {
-			{"", expectErrorOnDirective},
-			{"/tmp", func(w *corazawaf.WAF) bool { return w.TmpDir == "/tmp" }},
-		},
 		"SecSensorId": {
 			{"", expectErrorOnDirective},
 			{"test", func(w *corazawaf.WAF) bool { return w.SensorID == "test" }},

--- a/internal/seclang/directivesmap.gen.go
+++ b/internal/seclang/directivesmap.gen.go
@@ -15,7 +15,6 @@ var (
 	_ directive = directiveSecRequestBodyAccess
 	_ directive = directiveSecRuleEngine
 	_ directive = directiveSecWebAppID
-	_ directive = directiveSecTmpDir
 	_ directive = directiveSecServerSignature
 	_ directive = directiveSecRuleRemoveByTag
 	_ directive = directiveSecRuleRemoveByMsg
@@ -75,7 +74,6 @@ var directivesMap = map[string]directive{
 	"secrequestbodyaccess":           directiveSecRequestBodyAccess,
 	"secruleengine":                  directiveSecRuleEngine,
 	"secwebappid":                    directiveSecWebAppID,
-	"sectmpdir":                      directiveSecTmpDir,
 	"secserversignature":             directiveSecServerSignature,
 	"secruleremovebytag":             directiveSecRuleRemoveByTag,
 	"secruleremovebymsg":             directiveSecRuleRemoveByMsg,
@@ -132,5 +130,6 @@ var directivesMap = map[string]directive{
 	"secruleupdateactionbyid":  directiveUnsupported,
 	"secrulescript":            directiveUnsupported,
 	"secruleperftime":          directiveUnsupported,
-	"Secunicodemap":            directiveUnsupported,
+	"secunicodemap":            directiveUnsupported,
+	"sectmpdir":                directiveUnsupported,
 }

--- a/internal/seclang/generator/directivesmap.go.tmpl
+++ b/internal/seclang/generator/directivesmap.go.tmpl
@@ -21,5 +21,6 @@ var directivesMap = map[string]directive{
 	"secruleupdateactionbyid":  directiveUnsupported,
 	"secrulescript":            directiveUnsupported,
 	"secruleperftime":          directiveUnsupported,
-	"Secunicodemap":            directiveUnsupported,
+	"secunicodemap":            directiveUnsupported,
+	"sectmpdir":                directiveUnsupported,
 }


### PR DESCRIPTION
We drop support for this, aligning with modsec 3 as described in https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#sectmpdir

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: