### PR TITLE
Remove MatchData.IsNil

### DIFF
--- a/internal/corazarules/rule_match.go
+++ b/internal/corazarules/rule_match.go
@@ -47,11 +47,6 @@ func (m *MatchData) Data() string {
 	return m.Data_
 }
 
-// IsNil is used to check whether the MatchData is empty
-func (m MatchData) IsNil() bool {
-	return m == MatchData{}
-}
-
 // MatchedRule contains a list of macro expanded messages,
 // matched variables and a pointer to the rule
 type MatchedRule struct {

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -345,7 +345,7 @@ func (r *Rule) matchVariable(tx *Transaction, m *corazarules.MatchData) {
 	if rid == 0 {
 		rid = r.ParentID_
 	}
-	if !m.IsNil() {
+	if m.Variable() != variables.Unknown {
 		tx.WAF.Logger.Debug("[%s] [%d] Matching rule %d %s:%s", tx.id, rid, r.ID_, m.Variable().Name(), m.Key())
 	}
 	// we must match the vars before running the chains

--- a/types/rule_match.go
+++ b/types/rule_match.go
@@ -18,8 +18,6 @@ type MatchData interface {
 	Message() string
 	// Data is the expanded logdata of the macro
 	Data() string
-	// IsNil is used to check whether the MatchData is empty
-	IsNil() bool
 }
 
 // MatchedRule contains a list of macro expanded messages,


### PR DESCRIPTION
We only have one spot that checks for this and can just inline the check. If for some reason a user runs into it they would be able to do similar, there isn't any pointer involved so we don't lose safety vs nil dereference by removing the function.

I tried to remove use of empty match completely without completely rewriting but ran into issues with chains. I think the handling really just needs to be significantly rewritten for SecMark / SecAction, filed #676 for it.

In the meantime, we should remove from the public API.

Fixes #636