### PR TITLE
Small cleanups to parser

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -25,9 +25,6 @@ type ruleActionParams struct {
 	// The name of the action, used for logging
 	Name string
 
-	// Parameters used by the action
-	Param string
-
 	// The action to be executed
 	Function rules.Action
 }
@@ -59,9 +56,6 @@ type ruleVariableException struct {
 // to get values from the transaction's variables
 // It supports xml, regex, exceptions and many more features
 type ruleVariableParams struct {
-	// We store the name for performance
-	Name string
-
 	// If true, the count of results will be returned
 	Count bool
 
@@ -81,9 +75,6 @@ type ruleVariableParams struct {
 }
 
 type ruleTransformationParams struct {
-	// The transformation to be used, used for logging
-	Name string
-
 	// The transformation function to be used
 	Function rules.Transformation
 }
@@ -396,7 +387,6 @@ func (r *Rule) AddVariable(v variables.RuleVariable, key string, iscount bool) e
 	}
 
 	r.variables = append(r.variables, ruleVariableParams{
-		Name:       v.Name(),
 		Count:      iscount,
 		Variable:   v,
 		KeyStr:     strings.ToLower(key),
@@ -459,7 +449,7 @@ func (r *Rule) AddTransformation(name string, t rules.Transformation) error {
 	if t == nil || name == "" {
 		return fmt.Errorf("invalid transformation %q not found", name)
 	}
-	r.transformations = append(r.transformations, ruleTransformationParams{name, t})
+	r.transformations = append(r.transformations, ruleTransformationParams{Function: t})
 	r.transformationsID = transformationID(r.transformationsID, name)
 	return nil
 }

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -821,7 +821,6 @@ func TestProcessBodiesSkippedIfHeadersPhasesNotReached(t *testing.T) {
 func TestTxVariables(t *testing.T) {
 	tx := makeTransaction(t)
 	rv := ruleVariableParams{
-		Name:     "REQUEST_HEADERS",
 		Variable: variables.RequestHeaders,
 		KeyStr:   "ho.*",
 		KeyRx:    regexp.MustCompile("ho.*"),
@@ -858,7 +857,6 @@ func TestTxVariables(t *testing.T) {
 func TestTxVariablesExceptions(t *testing.T) {
 	tx := makeTransaction(t)
 	rv := ruleVariableParams{
-		Name:     "REQUEST_HEADERS",
 		Variable: variables.RequestHeaders,
 		KeyStr:   "ho.*",
 		KeyRx:    regexp.MustCompile("ho.*"),
@@ -1045,7 +1043,6 @@ func TestTxAddArgument(t *testing.T) {
 func TestTxGetField(t *testing.T) {
 	tx := makeTransaction(t)
 	rvp := ruleVariableParams{
-		Name:     "args",
 		Variable: variables.Args,
 	}
 	if f := tx.GetField(rvp); len(f) != 3 {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -922,7 +922,7 @@ func directiveSecRuleUpdateTargetByID(options *DirectiveOptions) error {
 		return err
 	}
 	rule := options.WAF.Rules.FindByID(id)
-	rp := &RuleParser{
+	rp := RuleParser{
 		rule:           rule,
 		options:        RuleOptions{},
 		defaultActions: map[types.RulePhase][]ruleAction{},

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -315,7 +315,7 @@ func ParseRule(options RuleOptions) (*corazawaf.Rule, error) {
 	}
 
 	var err error
-	rp := &RuleParser{
+	rp := RuleParser{
 		options:        options,
 		rule:           corazawaf.NewRule(),
 		defaultActions: map[types.RulePhase][]ruleAction{},
@@ -383,7 +383,7 @@ func ParseRule(options RuleOptions) (*corazawaf.Rule, error) {
 		lastChain.Chain = rule
 		return nil, nil
 	}
-	return rp.rule, nil
+	return rule, nil
 }
 
 func getLastRuleExpectingChain(w *corazawaf.WAF) *corazawaf.Rule {

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -172,6 +172,8 @@ func (p *RuleParser) ParseOperator(operator string) error {
 		operator = "!@rx " + operator[1:]
 	}
 
+	// We clone strings to ensure a slice into larger rule definition isn't kept in
+	// memory just to store operator information.
 	opRaw, opdataRaw, _ := strings.Cut(operator, " ")
 	opRaw = strings.Clone(opRaw)
 	op := strings.TrimSpace(opRaw)

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -173,8 +173,10 @@ func (p *RuleParser) ParseOperator(operator string) error {
 	}
 
 	opRaw, opdataRaw, _ := strings.Cut(operator, " ")
+	opRaw = strings.Clone(opRaw)
 	op := strings.TrimSpace(opRaw)
 	opdata := strings.TrimSpace(opdataRaw)
+	opdata = strings.Clone(opdata)
 
 	if op[0] == '@' {
 		// we trim @


### PR DESCRIPTION
I am investigating at-rest memory usage of coraza-proxy-wasm and digging through parsing / setup code as part of it. Nothing in this PR is particularly impactful yet but will send some cleanup PRs / microoptimizations as I find any.