### PR TITLE
Add typesafe auditlog config

### DIFF
--- a/auditlog/concurrent_writer.go
+++ b/auditlog/concurrent_writer.go
@@ -15,8 +15,6 @@ import (
 	"path"
 	"sync"
 	"time"
-
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 type concurrentWriter struct {
@@ -29,16 +27,16 @@ type concurrentWriter struct {
 	closer        func() error
 }
 
-func (cl *concurrentWriter) Init(c types.Config) error {
-	cl.auditFileMode = c.Get("auditlog_file_mode", fs.FileMode(0644)).(fs.FileMode)
-	cl.auditDir = c.Get("auditlog_dir", "").(string)
-	cl.auditDirMode = c.Get("auditlog_dir_mode", fs.FileMode(0755)).(fs.FileMode)
-	cl.formatter = c.Get("auditlog_formatter", nativeFormatter).(LogFormatter)
+func (cl *concurrentWriter) Init(c Config) error {
+	cl.auditFileMode = c.FileMode
+	cl.auditDir = c.Dir
+	cl.auditDirMode = c.DirMode
+	cl.formatter = c.Formatter
 	cl.mux = &sync.RWMutex{}
 
 	w := io.Discard
-	if fileName := c.Get("auditlog_file", "").(string); fileName != "" {
-		f, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, cl.auditFileMode)
+	if c.File != "" {
+		f, err := os.OpenFile(c.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, cl.auditFileMode)
 		if err != nil {
 			return err
 		}

--- a/auditlog/concurrent_writer_test.go
+++ b/auditlog/concurrent_writer_test.go
@@ -15,12 +15,10 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 func TestConcurrentWriterNoop(t *testing.T) {
-	config := types.Config{}
+	config := NewConfig()
 	writer := &concurrentWriter{}
 	if err := writer.Init(config); err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -32,13 +30,13 @@ func TestConcurrentWriterNoop(t *testing.T) {
 }
 
 func TestConcurrentWriterFailsOnInit(t *testing.T) {
-	config := types.Config{
-		"auditlog_file":      "/unexisting.log",
-		"auditlog_dir":       t.TempDir(),
-		"auditlog_file_mode": fs.FileMode(0777),
-		"auditlog_dir_mode":  fs.FileMode(0777),
-		"auditlog_formatter": jsonFormatter,
-	}
+	config := NewConfig()
+	config.File = "/unexisting.log"
+	config.Dir = t.TempDir()
+	config.FileMode = fs.FileMode(0777)
+	config.DirMode = fs.FileMode(0777)
+	config.Formatter = jsonFormatter
+
 	writer := &concurrentWriter{}
 	if err := writer.Init(config); err == nil {
 		t.Error("expected error")
@@ -51,12 +49,12 @@ func TestConcurrentWriterWrites(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create concurrent logger file")
 	}
-	config := types.Config{
-		"auditlog_file":      file.Name(),
-		"auditlog_dir":       dir,
-		"auditlog_file_mode": fs.FileMode(0777),
-		"auditlog_dir_mode":  fs.FileMode(0777),
-		"auditlog_formatter": jsonFormatter,
+	config := Config{
+		File:      file.Name(),
+		Dir:       dir,
+		FileMode:  fs.FileMode(0777),
+		DirMode:   fs.FileMode(0777),
+		Formatter: jsonFormatter,
 	}
 	ts := time.Now().UnixNano()
 	al := &Log{

--- a/auditlog/logger.go
+++ b/auditlog/logger.go
@@ -5,10 +5,38 @@ package auditlog
 
 import (
 	"fmt"
+	"io/fs"
 	"strings"
-
-	"github.com/corazawaf/coraza/v3/types"
 )
+
+// Config is the configuration of a LogWriter.
+type Config struct {
+	// File is the path to the file to write the raw audit log to.
+	File string
+
+	// FileMode is the mode to use when creating File.
+	FileMode fs.FileMode
+
+	// Dir is the path to the directory to write formatted audit logs to.
+	Dir string
+
+	// DirMode is the mode to use when creating Dir.
+	DirMode fs.FileMode
+
+	// Formatter is the formatter to use when writing formatted audit logs.
+	Formatter LogFormatter
+}
+
+// NewConfig returns a Config with default values.
+func NewConfig() Config {
+	return Config{
+		File:      "",
+		FileMode:  0644,
+		Dir:       "",
+		DirMode:   0755,
+		Formatter: nativeFormatter,
+	}
+}
 
 // LogFormatter is the interface for all log formatters
 // A LogFormatter receives an auditlog and generates "readable" audit log
@@ -19,7 +47,7 @@ type LogFormatter = func(al *Log) ([]byte, error)
 // An output stream may be a file, a socket, an http request, etc
 type LogWriter interface {
 	// Init the writer requires previous preparations
-	Init(types.Config) error
+	Init(Config) error
 	// Write the audit log
 	// Using the LogFormatter is mandatory to generate a "readable" audit log
 	// It is not sent as a bslice because some writers may require some Audit

--- a/auditlog/noop_writer.go
+++ b/auditlog/noop_writer.go
@@ -7,15 +7,11 @@
 
 package auditlog
 
-import (
-	"github.com/corazawaf/coraza/v3/types"
-)
-
 // noopWriter is used to store logs in a single file
 type noopWriter struct{}
 
-func (noopWriter) Init(types.Config) error { return nil }
-func (noopWriter) Write(*Log) error        { return nil }
-func (noopWriter) Close() error            { return nil }
+func (noopWriter) Init(Config) error { return nil }
+func (noopWriter) Write(*Log) error  { return nil }
+func (noopWriter) Close() error      { return nil }
 
 var _ LogWriter = (*noopWriter)(nil)

--- a/auditlog/serial_writer.go
+++ b/auditlog/serial_writer.go
@@ -8,11 +8,8 @@ package auditlog
 
 import (
 	"io"
-	"io/fs"
 	"log"
 	"os"
-
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 // serialWriter is used to store logs in a single file
@@ -22,14 +19,13 @@ type serialWriter struct {
 	formatter LogFormatter
 }
 
-func (sl *serialWriter) Init(c types.Config) error {
-	fileMode := c.Get("auditlog_file_mode", fs.FileMode(0644)).(fs.FileMode)
-	sl.formatter = c.Get("auditlog_formatter", nativeFormatter).(LogFormatter)
+func (sl *serialWriter) Init(c Config) error {
+	fileMode := c.FileMode
+	sl.formatter = c.Formatter
 
-	fileName := c.Get("auditlog_file", "").(string)
 	var w io.Writer
-	if fileName != "" {
-		f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, fileMode)
+	if c.File != "" {
+		f, err := os.OpenFile(c.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, fileMode)
 		if err != nil {
 			return err
 		}

--- a/auditlog/serial_writer_test.go
+++ b/auditlog/serial_writer_test.go
@@ -12,12 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/corazawaf/coraza/v3/types"
 )
 
 func TestSerialLoggerFailsOnInit(t *testing.T) {
-	config := types.Config{}
+	config := NewConfig()
 	writer := &serialWriter{}
 	if err := writer.Init(config); err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -29,13 +27,13 @@ func TestSerialLoggerFailsOnInit(t *testing.T) {
 }
 
 func TestSerialWriterFailsOnInit(t *testing.T) {
-	config := types.Config{
-		"auditlog_file":      "/unexisting.log",
-		"auditlog_dir":       t.TempDir(),
-		"auditlog_file_mode": fs.FileMode(0777),
-		"auditlog_dir_mode":  fs.FileMode(0777),
-		"auditlog_formatter": jsonFormatter,
-	}
+	config := NewConfig()
+	config.File = "/unexisting.log"
+	config.Dir = t.TempDir()
+	config.FileMode = fs.FileMode(0777)
+	config.DirMode = fs.FileMode(0777)
+	config.Formatter = jsonFormatter
+
 	writer := &serialWriter{}
 	if err := writer.Init(config); err == nil {
 		t.Error("expected error")
@@ -45,10 +43,10 @@ func TestSerialWriterFailsOnInit(t *testing.T) {
 func TestSerialWriterWrites(t *testing.T) {
 	tmp := filepath.Join(t.TempDir(), "audit.log")
 	writer := &serialWriter{}
-	config := types.Config{
-		"auditlog_file":      tmp,
-		"auditlog_formatter": jsonFormatter,
-	}
+	config := NewConfig()
+	config.File = tmp
+	config.Formatter = jsonFormatter
+
 	if err := writer.Init(config); err != nil {
 		t.Error(err)
 	}

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/corazawaf/coraza/v3/auditlog"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/internal/environment"
 	"github.com/corazawaf/coraza/v3/internal/io"
@@ -207,6 +208,7 @@ func NewParser(waf *corazawaf.WAF) *Parser {
 			WAF:      waf,
 			Config:   make(types.Config),
 			Datasets: make(map[string][]string),
+			AuditLog: auditlog.NewConfig(),
 		},
 		root: io.OSFS{},
 	}


### PR DESCRIPTION
I am looking at removing `types.Config` because it is a very implicit type and has awkwardness in using it, with allocations related to defaultValue and `interface{}`. We can use concrete types instead for all our uses as far as I can tell.

This starts by creating an auditlog config type, which needs to be public as its part of the auditlog plugin mechanism. Then it can be removed by adding an internal type for containing parser state/options which is its only other usage right now.