### PR TITLE
Replace action/operator tokenization from regex to code

### DIFF
--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -146,6 +146,27 @@ func TestDefaultActionsForPhase2(t *testing.T) {
 		t.Error("phase 1 rules shouldn't have log set by default actions")
 	}
 }
+
+func TestInvalidOperatorRuleData(t *testing.T) {
+	tests := []string{
+		`ARGS`,
+		`ARGS `,
+		`ARGS notquoted "deny"`,
+		`Args "op`,
+		`ARGS "op" notquoted`,
+		`Args "op" "`,
+		`Args "op" "deny`,
+	}
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt, func(t *testing.T) {
+			if _, _, _, err := parseActionOperator(tt); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
 func BenchmarkParseActions(b *testing.B) {
 	actionsToBeParsed := "id:980170,phase:5,pass,t:none,noauditlog,msg:'Anomaly Scores:Inbound Scores - Outbound Scores',tag:test"
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Regexes are pretty slow and use memory, forever in the case of package variables. While not terrible, it's good to avoid them where we can I think. In this case there was a combination of regex and cut being used, and an incorrect `3` instead of `2` passed to the regex making the logic even more confusing. Manually writing the code results in much more, but it seems worth it