### PR TITLE
Small cleanups to actions parsing

### DIFF
--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -412,10 +412,10 @@ const unset = -1
 // Action arguments are allowed to wrap values between colons(”)
 func parseActions(actions string) ([]ruleAction, error) {
 	iskey := true
-	var ckey strings.Builder
-	var cval strings.Builder
-	ckey.Reset()
-	cval.Reset()
+	var key strings.Builder
+	var val strings.Builder
+	key.Reset()
+	val.Reset()
 
 	quoted := false
 	var res []ruleAction
@@ -429,12 +429,12 @@ actionLoop:
 			// skip whitespaces in key
 			continue actionLoop
 		case !quoted && c == ',':
-			res, disruptiveActionIndex, err = appendRuleAction(res, ckey.String(), cval.String(), disruptiveActionIndex)
+			res, disruptiveActionIndex, err = appendRuleAction(res, key.String(), val.String(), disruptiveActionIndex)
 			if err != nil {
 				return nil, err
 			}
-			ckey.Reset()
-			cval.Reset()
+			key.Reset()
+			val.Reset()
 			iskey = true
 		case iskey && c == ':':
 			iskey = false
@@ -450,13 +450,13 @@ actionLoop:
 				// skip unquoted whitespaces
 				continue actionLoop
 			}
-			cval.WriteByte(c)
+			val.WriteByte(c)
 		case iskey:
-			ckey.WriteByte(c)
+			key.WriteByte(c)
 		}
 		if i+1 == len(actions) {
 			// last action, returned disruptiveActionIndex is not needed
-			res, _, err = appendRuleAction(res, ckey.String(), cval.String(), disruptiveActionIndex)
+			res, _, err = appendRuleAction(res, key.String(), val.String(), disruptiveActionIndex)
 			if err != nil {
 				return nil, err
 			}
@@ -465,8 +465,8 @@ actionLoop:
 	return res, nil
 }
 
-func appendRuleAction(res []ruleAction, ckey string, cval string, disruptiveActionIndex int) ([]ruleAction, int, error) {
-	f, err := actionsmod.Get(ckey)
+func appendRuleAction(res []ruleAction, key string, val string, disruptiveActionIndex int) ([]ruleAction, int, error) {
+	f, err := actionsmod.Get(key)
 	if err != nil {
 		return res, unset, err
 	}
@@ -475,8 +475,8 @@ func appendRuleAction(res []ruleAction, ckey string, cval string, disruptiveActi
 		// actions present, or inherited, only the last one will take effect).
 		// Therefore, if we encounter another disruptive action, we replace the previous one.
 		res[disruptiveActionIndex] = ruleAction{
-			Key:   ckey,
-			Value: cval,
+			Key:   key,
+			Value: val,
 			F:     f,
 			Atype: f.Type(),
 		}
@@ -485,8 +485,8 @@ func appendRuleAction(res []ruleAction, ckey string, cval string, disruptiveActi
 			disruptiveActionIndex = len(res)
 		}
 		res = append(res, ruleAction{
-			Key:   ckey,
-			Value: cval,
+			Key:   key,
+			Value: val,
 			F:     f,
 			Atype: f.Type(),
 		})


### PR DESCRIPTION
We don't do any unicode handling in the parse so we can loop on bytes without utf8 decoding.

Also don't call `Builder.String()` multiple times to simplify the code (no affect on allocations as that method doesn't allocate, just cleaner IMO)

After
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/seclang
BenchmarkParseActions
BenchmarkParseActions-10    	 1255496	       932.3 ns/op
PASS
```

Before
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/seclang
BenchmarkParseActions
BenchmarkParseActions-10    	 1042354	      1104 ns/op
PASS
```