### PR TITLE
breaking: removes INBOUND_ERROR_DATA in favour of INBOUND_DATA_ERROR.

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -614,8 +614,6 @@ func minPhase(v variables.RuleVariable) types.RulePhase {
 		return types.PhaseUnknown
 	case variables.StatusLine:
 		return types.PhaseResponseHeaders
-	case variables.InboundErrorData:
-		return types.PhaseRequestBody
 	case variables.Duration:
 		// If used in matching, would need to be defined for multiple inferredPhases to make sense
 		return types.PhaseUnknown

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -200,8 +200,6 @@ func (tx *Transaction) Collection(idx variables.RuleVariable) collection.Collect
 		return tx.variables.highestSeverity
 	case variables.StatusLine:
 		return tx.variables.statusLine
-	case variables.InboundErrorData:
-		return tx.variables.inboundErrorData
 	case variables.Duration:
 		return tx.variables.duration
 	case variables.ResponseHeadersNames:
@@ -790,11 +788,11 @@ func (tx *Transaction) WriteRequestBody(b []byte) (*types.Interruption, int, err
 	if tx.requestBodyBuffer.length >= (math.MaxInt64 - writingBytes) {
 		// Overflow, failing. MaxInt64 is not a realistic payload size. Furthermore, it has been tested that
 		// bytes.Buffer does not work with this kind of sizes. See comments in BodyBuffer Write(data []byte)
-		return nil, 0, errors.New("Overflow reached while writing request body")
+		return nil, 0, errors.New("overflow reached while writing request body")
 	}
 
 	if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
-		tx.variables.inboundErrorData.Set("1")
+		tx.variables.inboundDataError.Set("1")
 		if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 			// We interrupt this transaction in case RequestBodyLimitAction is Reject
 			return setAndReturnBodyLimitInterruption(tx)
@@ -860,7 +858,7 @@ func (tx *Transaction) ReadRequestBodyFrom(r io.Reader) (*types.Interruption, in
 			return nil, 0, errors.New("overflow reached while writing request body")
 		}
 		if tx.requestBodyBuffer.length+writingBytes >= tx.RequestBodyLimit {
-			tx.variables.inboundErrorData.Set("1")
+			tx.variables.inboundDataError.Set("1")
 			if tx.WAF.RequestBodyLimitAction == types.BodyLimitActionReject {
 				return setAndReturnBodyLimitInterruption(tx)
 			}
@@ -1476,7 +1474,6 @@ type TransactionVariables struct {
 	geo                      *collections.Map
 	highestSeverity          *collections.Single
 	inboundDataError         *collections.Single
-	inboundErrorData         *collections.Single
 	matchedVar               *collections.Single
 	matchedVarName           *collections.Single
 	matchedVars              *collections.NamedCollection
@@ -1574,7 +1571,6 @@ func NewTransactionVariables() *TransactionVariables {
 	v.serverPort = collections.NewSingle(variables.ServerPort)
 	v.highestSeverity = collections.NewSingle(variables.HighestSeverity)
 	v.statusLine = collections.NewSingle(variables.StatusLine)
-	v.inboundErrorData = collections.NewSingle(variables.InboundErrorData)
 	v.duration = collections.NewSingle(variables.Duration)
 	v.resBodyError = collections.NewSingle(variables.ResBodyError)
 	v.resBodyErrorMsg = collections.NewSingle(variables.ResBodyErrorMsg)
@@ -1786,10 +1782,6 @@ func (v *TransactionVariables) StatusLine() collection.Single {
 	return v.statusLine
 }
 
-func (v *TransactionVariables) InboundErrorData() collection.Single {
-	return v.inboundErrorData
-}
-
 func (v *TransactionVariables) Env() collection.Map {
 	return v.env
 }
@@ -1997,9 +1989,6 @@ func (v *TransactionVariables) All(f func(v variables.RuleVariable, col collecti
 		return
 	}
 	if !f(variables.InboundDataError, v.inboundDataError) {
-		return
-	}
-	if !f(variables.InboundErrorData, v.inboundErrorData) {
 		return
 	}
 	if !f(variables.MatchedVar, v.matchedVar) {

--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -28,7 +28,8 @@ const (
 	FilesCombinedSize
 	// FullRequestLength is the length of the full request
 	FullRequestLength
-	// InboundDataError represents errors for inbound data
+	// InboundDataError will be set to 1 when the request body size
+	// is above the setting configured by SecRequesteBodyLimit
 	InboundDataError
 	// MatchedVar is the value of the matched variable
 	MatchedVar
@@ -107,9 +108,6 @@ const (
 	// StatusLine is the status line of the response, including the request method
 	// and HTTP version information
 	StatusLine
-	// InboundErrorData will be set to 1 when the request body size
-	// is above the setting configured by SecRequesteBodyLimit
-	InboundErrorData
 	// Duration contains the time in miliseconds from
 	// the beginning of the transaction until this point
 	Duration

--- a/internal/variables/variablesmap.gen.go
+++ b/internal/variables/variablesmap.gen.go
@@ -90,8 +90,6 @@ func (v RuleVariable) Name() string {
 		return "HIGHEST_SEVERITY"
 	case StatusLine:
 		return "STATUS_LINE"
-	case InboundErrorData:
-		return "INBOUND_ERROR_DATA"
 	case Duration:
 		return "DURATION"
 	case ResponseHeadersNames:
@@ -253,7 +251,6 @@ var rulemapRev = map[string]RuleVariable{
 	"SERVER_PORT":                      ServerPort,
 	"HIGHEST_SEVERITY":                 HighestSeverity,
 	"STATUS_LINE":                      StatusLine,
-	"INBOUND_ERROR_DATA":               InboundErrorData,
 	"DURATION":                         Duration,
 	"RESPONSE_HEADERS_NAMES":           ResponseHeadersNames,
 	"REQUEST_HEADERS_NAMES":            RequestHeadersNames,

--- a/rules/transaction.go
+++ b/rules/transaction.go
@@ -94,7 +94,6 @@ type TransactionVariables interface {
 	ServerPort() collection.Single
 	HighestSeverity() collection.Single
 	StatusLine() collection.Single
-	InboundErrorData() collection.Single
 	Env() collection.Map
 	TX() collection.Map
 	Rule() collection.Map

--- a/types/variables/variables.go
+++ b/types/variables/variables.go
@@ -28,7 +28,8 @@ const (
 	FilesCombinedSize = variables.FilesCombinedSize
 	// FullRequestLength is the length of the full request
 	FullRequestLength = variables.FullRequestLength
-	// InboundDataError represents errors for inbound data
+	// InboundDataError will be set to 1 when the request body size
+	// is above the setting configured by SecRequesteBodyLimit
 	InboundDataError = variables.InboundDataError
 	// MatchedVar is the value of the matched variable
 	MatchedVar = variables.MatchedVar
@@ -109,9 +110,6 @@ const (
 	// StatusLine is the status line of the response, including the request method
 	// and HTTP version information
 	StatusLine = variables.StatusLine
-	// InboundErrorData will be set to 1 when the request body size
-	// is above the setting configured by SecRequesteBodyLimit
-	InboundErrorData = variables.InboundErrorData
 	// Duration contains the time in miliseconds from
 	// the beginning of the transaction until this point
 	Duration = variables.Duration


### PR DESCRIPTION
Currently we had the two variables but only one of them was used, given that modsecurity also has INBOUND_DATA_ERROR (see https://github.com/SpiderLabs/ModSecurity/blob/5f632a5ed5cf79fde9dee3ae518631951cee8762/Makefile.am\#L218) it appears that INBOUND_ERROR_DATA was a typo.

Closes #564.
