### PR TITLE
Some cleanups to debuglog API

### DIFF
--- a/actions/ctl.go
+++ b/actions/ctl.go
@@ -295,7 +295,7 @@ func (a *ctlFn) Evaluate(_ rules.RuleMetadata, txS rules.TransactionState) {
 			return
 		}
 
-		tx.SetDebugLogLevel(debuglog.LogLevel(lvl))
+		tx.SetDebugLogLevel(debuglog.Level(lvl))
 	}
 }
 

--- a/actions/ctl_test.go
+++ b/actions/ctl_test.go
@@ -318,7 +318,7 @@ func TestCtl(t *testing.T) {
 			defer logsBuf.Reset()
 
 			logger := debuglog.Default().
-				WithLevel(debuglog.LogLevelWarn).
+				WithLevel(debuglog.LevelWarn).
 				WithOutput(logsBuf)
 
 			waf := corazawaf.NewWAF()

--- a/debuglog/default.go
+++ b/debuglog/default.go
@@ -12,7 +12,7 @@ import (
 )
 
 type defaultEvent struct {
-	level   LogLevel
+	level   Level
 	printer Printer
 	fields  []byte
 }
@@ -90,7 +90,7 @@ func (defaultEvent) IsEnabled() bool {
 type defaultLogger struct {
 	printer       Printer
 	factory       PrinterFactory
-	level         LogLevel
+	level         Level
 	defaultFields []byte
 }
 
@@ -103,7 +103,7 @@ func (l defaultLogger) WithOutput(w io.Writer) Logger {
 	}
 }
 
-func (l defaultLogger) WithLevel(lvl LogLevel) Logger {
+func (l defaultLogger) WithLevel(lvl Level) Logger {
 	return defaultLogger{
 		printer:       l.printer,
 		factory:       l.factory,
@@ -126,43 +126,43 @@ func (l defaultLogger) With(fs ...ContextField) Logger {
 }
 
 func (l defaultLogger) Trace() Event {
-	if l.level < LogLevelTrace {
-		return NopEvent{}
+	if l.level < LevelTrace {
+		return noopEvent{}
 	}
 
-	return &defaultEvent{printer: l.printer, level: LogLevelTrace, fields: l.defaultFields}
+	return &defaultEvent{printer: l.printer, level: LevelTrace, fields: l.defaultFields}
 }
 
 func (l defaultLogger) Debug() Event {
-	if l.level < LogLevelDebug {
-		return NopEvent{}
+	if l.level < LevelDebug {
+		return noopEvent{}
 	}
 
-	return &defaultEvent{printer: l.printer, level: LogLevelDebug, fields: l.defaultFields}
+	return &defaultEvent{printer: l.printer, level: LevelDebug, fields: l.defaultFields}
 }
 
 func (l defaultLogger) Info() Event {
-	if l.level < LogLevelInfo {
-		return NopEvent{}
+	if l.level < LevelInfo {
+		return noopEvent{}
 	}
 
-	return &defaultEvent{printer: l.printer, level: LogLevelInfo, fields: l.defaultFields}
+	return &defaultEvent{printer: l.printer, level: LevelInfo, fields: l.defaultFields}
 }
 
 func (l defaultLogger) Warn() Event {
-	if l.level < LogLevelWarn {
-		return NopEvent{}
+	if l.level < LevelWarn {
+		return noopEvent{}
 	}
 
-	return &defaultEvent{printer: l.printer, level: LogLevelWarn, fields: l.defaultFields}
+	return &defaultEvent{printer: l.printer, level: LevelWarn, fields: l.defaultFields}
 }
 
 func (l defaultLogger) Error() Event {
-	if l.level < LogLevelError {
-		return NopEvent{}
+	if l.level < LevelError {
+		return noopEvent{}
 	}
 
-	return &defaultEvent{printer: l.printer, level: LogLevelError, fields: l.defaultFields}
+	return &defaultEvent{printer: l.printer, level: LevelError, fields: l.defaultFields}
 }
 
 // Default returns a default logger that writes to stderr.
@@ -170,13 +170,13 @@ func Default() Logger {
 	return DefaultWithPrinterFactory(defaultPrinterFactory)
 }
 
-type Printer func(lvl LogLevel, message, fields string)
+type Printer func(lvl Level, message, fields string)
 
 type PrinterFactory func(w io.Writer) Printer
 
 var defaultPrinterFactory = func(w io.Writer) Printer {
 	l := log.New(w, "", log.LstdFlags)
-	return func(lvl LogLevel, message, fields string) {
+	return func(lvl Level, message, fields string) {
 		l.Printf("[%s] %s %s", lvl.String(), message, fields)
 	}
 }
@@ -187,6 +187,6 @@ func DefaultWithPrinterFactory(f PrinterFactory) Logger {
 	return defaultLogger{
 		printer: f(os.Stderr),
 		factory: f,
-		level:   LogLevelInfo,
+		level:   LevelInfo,
 	}
 }

--- a/debuglog/default_test.go
+++ b/debuglog/default_test.go
@@ -43,11 +43,11 @@ func TestLoggerLogLevels(t *testing.T) {
 			buf := bytes.Buffer{}
 			Default().WithOutput(&buf)
 			for settedLevel := 0; settedLevel <= 9; settedLevel++ {
-				l := Default().WithOutput(io.Discard).WithLevel(LogLevel(settedLevel))
+				l := Default().WithOutput(io.Discard).WithLevel(Level(settedLevel))
 				event := tCase.logFunction(l)()
 				if settedLevel >= tCase.expectedLowestPrintedLevel {
-					if _, ok := event.(NopEvent); ok {
-						t.Fatalf("Missing expected log. Level: %s, Function: %s", LogLevel(settedLevel).String(), name)
+					if _, ok := event.(noopEvent); ok {
+						t.Fatalf("Missing expected log. Level: %s, Function: %s", Level(settedLevel).String(), name)
 					}
 
 					if !event.IsEnabled() {
@@ -55,7 +55,7 @@ func TestLoggerLogLevels(t *testing.T) {
 					}
 				}
 				if settedLevel < tCase.expectedLowestPrintedLevel {
-					if _, ok := event.(NopEvent); !ok {
+					if _, ok := event.(noopEvent); !ok {
 						t.Fatalf("Unexpected log. Level: %d, Function: %s", settedLevel, name)
 					}
 				}
@@ -66,7 +66,7 @@ func TestLoggerLogLevels(t *testing.T) {
 
 func TestMsg(t *testing.T) {
 	t.Run("empty error", func(t *testing.T) {
-		l := Default().WithOutput(io.Discard).WithLevel(LogLevelInfo)
+		l := Default().WithOutput(io.Discard).WithLevel(LevelInfo)
 		fields := l.Info().Err(nil).(*defaultEvent).fields
 		if want, have := 0, len(fields); want != have {
 			t.Fatalf("unexpected number of fields, want %d, have %d", want, have)
@@ -75,7 +75,7 @@ func TestMsg(t *testing.T) {
 
 	t.Run("empty message", func(t *testing.T) {
 		buf := bytes.Buffer{}
-		l := Default().WithOutput(&buf).WithLevel(LogLevelInfo)
+		l := Default().WithOutput(&buf).WithLevel(LevelInfo)
 		l.Info().Msg("")
 		if want, have := 0, buf.Len(); want != have {
 			t.Fatalf("unexpected message length, want %d, have %d", want, have)
@@ -84,7 +84,7 @@ func TestMsg(t *testing.T) {
 
 	t.Run("message", func(t *testing.T) {
 		buf := bytes.Buffer{}
-		l := Default().WithOutput(&buf).WithLevel(LogLevelInfo)
+		l := Default().WithOutput(&buf).WithLevel(LevelInfo)
 		l.Info().
 			Bool("a", true).
 			Int("b", -1).
@@ -106,7 +106,7 @@ func TestMsg(t *testing.T) {
 
 func TestLogMessagePrefixes(t *testing.T) {
 	buf := bytes.Buffer{}
-	l := Default().WithOutput(&buf).WithLevel(LogLevelTrace)
+	l := Default().WithOutput(&buf).WithLevel(LevelTrace)
 	testCases := map[string]struct {
 		logPrintEvent Event
 	}{
@@ -129,7 +129,7 @@ func TestLogMessagePrefixes(t *testing.T) {
 
 func TestWithLogger(t *testing.T) {
 	buf := bytes.Buffer{}
-	l := Default().WithOutput(&buf).WithLevel(LogLevelInfo)
+	l := Default().WithOutput(&buf).WithLevel(LevelInfo)
 	l2 := l.
 		With(
 			Bool("a", true),
@@ -167,7 +167,7 @@ func TestWithLogger(t *testing.T) {
 
 func TestWithLoggerAccumulative(t *testing.T) {
 	buf := bytes.Buffer{}
-	l := Default().WithOutput(&buf).WithLevel(LogLevelInfo)
+	l := Default().WithOutput(&buf).WithLevel(LevelInfo)
 	l2 := l.With(Bool("a", true))
 	l3 := l2.With(Int("b", -1))
 	l3.Info().

--- a/debuglog/level.go
+++ b/debuglog/level.go
@@ -3,48 +3,48 @@
 
 package debuglog
 
-// LogLevel is the type of log level
-type LogLevel int8
+// Level is the type of log level
+type Level int8
 
 const (
-	// LogLevelUnknown is a default value for unknown log level
-	LogLevelUnknown LogLevel = iota - 1
-	// LogLevelNoLog is the lowest level of logging, no logs are generated
-	LogLevelNoLog
-	// LogLevelError is the level of logging only for errors
-	LogLevelError
-	// LogLevelWarn is the level of logging for warnings
-	LogLevelWarn
-	// LogLevelInfo is the lowest of logging for informational messages
-	LogLevelInfo
-	// LogLevelDebug is the level of logging for debug messages
-	LogLevelDebug
+	// LevelUnknown is a default value for unknown log level
+	LevelUnknown Level = iota - 1
+	// LevelNoLog is the lowest level of logging, no logs are generated
+	LevelNoLog
+	// LevelError is the level of logging only for errors
+	LevelError
+	// LevelWarn is the level of logging for warnings
+	LevelWarn
+	// LevelInfo is the lowest of logging for informational messages
+	LevelInfo
+	// LevelDebug is the level of logging for debug messages
+	LevelDebug
 	// ModSecurity compatibility, levels 4-8 will be Debug level
 	_ = iota + 2
-	// LogLevelTrace is the highest level of logging
-	LogLevelTrace
+	// LevelTrace is the highest level of logging
+	LevelTrace
 )
 
 // String returns the string representation of the log level
-func (level LogLevel) String() string {
+func (level Level) String() string {
 	switch {
-	case level == LogLevelNoLog:
+	case level == LevelNoLog:
 		return "NOLOG"
-	case level == LogLevelError:
+	case level == LevelError:
 		return "ERROR"
-	case level == LogLevelWarn:
+	case level == LevelWarn:
 		return "WARN"
-	case level == LogLevelInfo:
+	case level == LevelInfo:
 		return "INFO"
-	case level >= LogLevelDebug && level < LogLevelTrace:
+	case level >= LevelDebug && level < LevelTrace:
 		return "DEBUG"
-	case level == LogLevelTrace:
+	case level == LevelTrace:
 		return "TRACE"
 	}
 	return "UNKNOWN"
 }
 
 // Valid returns true if the log level is valid
-func (level LogLevel) Valid() bool {
-	return level >= LogLevelNoLog && level <= LogLevelTrace
+func (level Level) Valid() bool {
+	return level >= LevelNoLog && level <= LevelTrace
 }

--- a/debuglog/level_test.go
+++ b/debuglog/level_test.go
@@ -10,17 +10,17 @@ import (
 
 func TestLevelString(t *testing.T) {
 	var tests = []struct {
-		level LogLevel
+		level Level
 		want  string
 	}{
-		{LogLevelNoLog, "NOLOG"},
-		{LogLevelError, "ERROR"},
-		{LogLevelWarn, "WARN"},
-		{LogLevelInfo, "INFO"},
-		{LogLevelDebug, "DEBUG"},
-		{LogLevelTrace, "TRACE"},
-		{LogLevelUnknown, "UNKNOWN"},
-		{LogLevel(11), "UNKNOWN"},
+		{LevelNoLog, "NOLOG"},
+		{LevelError, "ERROR"},
+		{LevelWarn, "WARN"},
+		{LevelInfo, "INFO"},
+		{LevelDebug, "DEBUG"},
+		{LevelTrace, "TRACE"},
+		{LevelUnknown, "UNKNOWN"},
+		{Level(11), "UNKNOWN"},
 	}
 
 	for _, test := range tests {
@@ -34,17 +34,17 @@ func TestLevelString(t *testing.T) {
 
 func TestLevelValid(t *testing.T) {
 	var tests = []struct {
-		level   LogLevel
+		level   Level
 		isValid bool
 	}{
-		{LogLevelUnknown, false},
-		{LogLevelNoLog, true},
-		{LogLevelError, true},
-		{LogLevelWarn, true},
-		{LogLevelInfo, true},
-		{LogLevelDebug, true},
-		{LogLevelTrace, true},
-		{LogLevel(11), false},
+		{LevelUnknown, false},
+		{LevelNoLog, true},
+		{LevelError, true},
+		{LevelWarn, true},
+		{LevelInfo, true},
+		{LevelDebug, true},
+		{LevelTrace, true},
+		{Level(11), false},
 	}
 
 	for _, test := range tests {

--- a/debuglog/logger.go
+++ b/debuglog/logger.go
@@ -73,7 +73,7 @@ type Logger interface {
 	WithOutput(w io.Writer) Logger
 
 	// Level creates a child logger with the minimum accepted level set to level.
-	WithLevel(lvl LogLevel) Logger
+	WithLevel(lvl Level) Logger
 
 	// WithOutput duplicates the current logger and adds context fields to it.
 	With(...ContextField) Logger

--- a/debuglog/nop.go
+++ b/debuglog/nop.go
@@ -7,21 +7,22 @@ import (
 	"fmt"
 )
 
-type NopEvent struct{}
+type noopEvent struct{}
 
-func (NopEvent) Msg(string)                            {}
-func (e NopEvent) Str(string, string) Event            { return e }
-func (e NopEvent) Err(error) Event                     { return e }
-func (e NopEvent) Bool(string, bool) Event             { return e }
-func (e NopEvent) Int(string, int) Event               { return e }
-func (e NopEvent) Uint(string, uint) Event             { return e }
-func (e NopEvent) Stringer(string, fmt.Stringer) Event { return e }
-func (e NopEvent) IsEnabled() bool                     { return false }
+func (noopEvent) Msg(string)                            {}
+func (e noopEvent) Str(string, string) Event            { return e }
+func (e noopEvent) Err(error) Event                     { return e }
+func (e noopEvent) Bool(string, bool) Event             { return e }
+func (e noopEvent) Int(string, int) Event               { return e }
+func (e noopEvent) Uint(string, uint) Event             { return e }
+func (e noopEvent) Stringer(string, fmt.Stringer) Event { return e }
+func (e noopEvent) IsEnabled() bool                     { return false }
 
-func Nop() Logger {
+// Noop returns a Logger which does no logging.
+func Noop() Logger {
 	return defaultLogger{
-		printer: func(LogLevel, string, string) {},
+		printer: func(Level, string, string) {},
 		factory: defaultPrinterFactory,
-		level:   LogLevelNoLog,
+		level:   LevelNoLog,
 	}
 }

--- a/debuglog/nop_test.go
+++ b/debuglog/nop_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestNop(t *testing.T) {
-	l := Nop().(defaultLogger)
-	if want, have := l.level, LogLevelNoLog; want != have {
+	l := Noop().(defaultLogger)
+	if want, have := l.level, LevelNoLog; want != have {
 		t.Fatalf("unexpected log level when nop")
 	}
 

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -295,7 +295,7 @@ func TestHttpServer(t *testing.T) {
 
 	logger := debuglog.Default().
 		WithOutput(testLogOutput{t}).
-		WithLevel(debuglog.LogLevelInfo)
+		WithLevel(debuglog.LevelInfo)
 
 	// Perform tests
 	for name, tCase := range tests {
@@ -357,7 +357,7 @@ func TestHttpServerWithRuleEngineOff(t *testing.T) {
 	}
 	logger := debuglog.Default().
 		WithOutput(testLogOutput{t}).
-		WithLevel(debuglog.LogLevelInfo)
+		WithLevel(debuglog.LevelInfo)
 
 	// Perform tests
 	for name, tCase := range tests {

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -286,7 +286,7 @@ func (tx *Transaction) DebugLogger() debuglog.Logger {
 	return tx.debugLogger
 }
 
-func (tx *Transaction) SetDebugLogLevel(lvl debuglog.LogLevel) {
+func (tx *Transaction) SetDebugLogLevel(lvl debuglog.Level) {
 	tx.debugLogger = tx.debugLogger.WithLevel(lvl)
 }
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -782,7 +782,7 @@ func TestProcessBodiesSkippedIfHeadersPhasesNotReached(t *testing.T) {
 	logBuffer := &bytes.Buffer{}
 	waf := NewWAF()
 	waf.SetDebugLogOutput(logBuffer)
-	_ = waf.SetDebugLogLevel(debuglog.LogLevelDebug)
+	_ = waf.SetDebugLogLevel(debuglog.LevelDebug)
 	tx := waf.NewTransaction()
 	tx.RuleEngine = types.RuleEngineOn
 	tx.RequestBodyAccess = true
@@ -1008,7 +1008,7 @@ func TestTxSetServerName(t *testing.T) {
 
 	waf := NewWAF()
 	waf.SetDebugLogOutput(logBuffer)
-	_ = waf.SetDebugLogLevel(debuglog.LogLevelWarn)
+	_ = waf.SetDebugLogLevel(debuglog.LevelWarn)
 
 	tx := waf.NewTransaction()
 	tx.lastPhase = types.PhaseRequestHeaders
@@ -1220,7 +1220,7 @@ func TestProcessorsIdempotencyWithAlreadyRaisedInterruption(t *testing.T) {
 
 	waf := NewWAF()
 	waf.SetDebugLogOutput(logBuffer)
-	_ = waf.SetDebugLogLevel(debuglog.LogLevelError)
+	_ = waf.SetDebugLogLevel(debuglog.LevelError)
 
 	expectedInterruption := &types.Interruption{
 		RuleID: 123,

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -251,7 +251,7 @@ const _1gb = 1073741824
 
 // NewWAF creates a new WAF instance with default variables
 func NewWAF() *WAF {
-	logger := debuglog.Nop()
+	logger := debuglog.Noop()
 
 	logWriter, err := auditlog.GetLogWriter("serial")
 	if err != nil {
@@ -286,7 +286,7 @@ func (w *WAF) SetDebugLogOutput(wr io.Writer) {
 }
 
 // SetDebugLogLevel changes the debug level of the WAF instance
-func (w *WAF) SetDebugLogLevel(lvl debuglog.LogLevel) error {
+func (w *WAF) SetDebugLogLevel(lvl debuglog.Level) error {
 	if !lvl.Valid() {
 		return errors.New("invalid log level")
 	}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -909,7 +909,7 @@ func directiveSecDebugLogLevel(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	return options.WAF.SetDebugLogLevel(debuglog.LogLevel(lvl))
+	return options.WAF.SetDebugLogLevel(debuglog.Level(lvl))
 }
 
 func directiveSecRuleUpdateTargetByID(options *DirectiveOptions) error {

--- a/testing/coraza_test.go
+++ b/testing/coraza_test.go
@@ -61,7 +61,7 @@ func TestEngine(t *testing.T) {
 func testList(t *testing.T, p *profile.Profile) ([]*Test, error) {
 	t.Helper()
 	logger := debuglog.Default().
-		WithLevel(debuglog.LogLevelDebug).
+		WithLevel(debuglog.LevelDebug).
 		WithOutput(testLogOutput{t})
 	var tests []*Test
 	for _, test := range p.Tests {


### PR DESCRIPTION
- Remove `Log` prefix from some types because `log` is part of the package name
- Nop -> Noop to read like English instead of asm instruction
- Made `noopEvent` private