### PR TITLE
Propagate parsed line for raw rule storage

### DIFF
--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -25,6 +25,7 @@ import (
 // TODO(anuraaga): Propagation of config probably should be separated from a directive's options.
 type DirectiveOptions struct {
 	WAF      *corazawaf.WAF
+	Raw      string
 	Opts     string
 	Path     []string
 	Datasets map[string][]string
@@ -140,6 +141,7 @@ func directiveSecAction(options *DirectiveOptions) error {
 		WithOperator: false,
 		WAF:          options.WAF,
 		ParserConfig: options.Parser,
+		Raw:          options.Raw,
 		Directive:    "SecAction",
 		Data:         options.Opts,
 	})
@@ -180,6 +182,7 @@ func directiveSecRule(options *DirectiveOptions) error {
 		WithOperator: true,
 		WAF:          options.WAF,
 		ParserConfig: options.Parser,
+		Raw:          options.Raw,
 		Directive:    "SecRule",
 		Data:         options.Opts,
 	})

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -135,8 +135,7 @@ func (p *Parser) FromString(data string) error {
 
 func (p *Parser) evaluateLine(l string) error {
 	if l == "" || l[0] == '#' {
-		// at this point we should not receive an empty line or a commented line
-		return errors.New("invalid line")
+		panic("invalid line")
 	}
 	// first we get the directive
 	dir, opts, _ := strings.Cut(l, " ")
@@ -163,6 +162,7 @@ func (p *Parser) evaluateLine(l string) error {
 		return p.log(fmt.Sprintf("unknown directive %q", directive))
 	}
 
+	p.options.Raw = l
 	p.options.Opts = opts
 	p.options.Parser.LastLine = p.currentLine
 	p.options.Parser.ConfigFile = p.currentFile

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -172,10 +172,8 @@ func (p *RuleParser) ParseOperator(operator string) error {
 	// We clone strings to ensure a slice into larger rule definition isn't kept in
 	// memory just to store operator information.
 	opRaw, opdataRaw, _ := strings.Cut(operator, " ")
-	opRaw = strings.Clone(opRaw)
 	op := strings.TrimSpace(opRaw)
 	opdata := strings.TrimSpace(opdataRaw)
-	opdata = strings.Clone(opdata)
 
 	if op[0] == '@' {
 		// we trim @
@@ -296,6 +294,7 @@ type RuleOptions struct {
 	WithOperator bool
 	WAF          *corazawaf.WAF
 	ParserConfig ParserConfig
+	Raw          string
 	Directive    string
 	Data         string
 }
@@ -358,7 +357,7 @@ func ParseRule(options RuleOptions) (*corazawaf.Rule, error) {
 		}
 	}
 	rule := rp.Rule()
-	rule.Raw_ = fmt.Sprintf("%s %s", options.Directive, options.Data)
+	rule.Raw_ = options.Raw
 	rule.File_ = options.ParserConfig.ConfigFile
 	rule.Line_ = options.ParserConfig.LastLine
 


### PR DESCRIPTION
Raw rules are stored for audit log purposes. Currently we reconstruct the raw string, but this means that much content of the string is stored twice, in this new string, and as slices from the original parsed line that is often stored in operators such as rx or pm. If we propagate from the original line instead, the string is only present once.