### PR TITLE
chore: avoids initializing the audit log on every directive.

### DIFF
--- a/auditlog/concurrent_writer.go
+++ b/auditlog/concurrent_writer.go
@@ -17,38 +17,42 @@ import (
 )
 
 type concurrentWriter struct {
-	mux           *sync.RWMutex
-	auditlogger   *log.Logger
-	auditDir      string
-	auditDirMode  fs.FileMode
-	auditFileMode fs.FileMode
-	formatter     Formatter
-	closer        func() error
+	mux         *sync.RWMutex
+	log         *log.Logger
+	logDir      string
+	logDirMode  fs.FileMode
+	logFileMode fs.FileMode
+	formatter   Formatter
+	io.Closer
 }
 
 func (cl *concurrentWriter) Init(c Config) error {
-	cl.auditFileMode = c.FileMode
-	cl.auditDir = c.Dir
-	cl.auditDirMode = c.DirMode
+	if c.File == "" {
+		cl.Closer = noopCloser{}
+		return nil
+	}
+
+	cl.logFileMode = c.FileMode
+	cl.logDir = c.Dir
+	cl.logDirMode = c.DirMode
 	cl.formatter = c.Formatter
 	cl.mux = &sync.RWMutex{}
 
-	w := io.Discard
-	if c.File != "" {
-		f, err := os.OpenFile(c.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, cl.auditFileMode)
-		if err != nil {
-			return err
-		}
-		w = f
-		cl.closer = f.Close
-	} else {
-		cl.closer = func() error { return nil }
+	f, err := os.OpenFile(c.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, cl.logFileMode)
+	if err != nil {
+		return err
 	}
-	cl.auditlogger = log.New(w, "", 0)
+	cl.Closer = f
+
+	cl.log = log.New(f, "", 0)
 	return nil
 }
 
 func (cl concurrentWriter) Write(al *Log) error {
+	if cl.formatter == nil {
+		return nil
+	}
+
 	// 192.168.3.130 192.168.3.1 - - [22/Aug/2009:13:24:20 +0100] "GET / HTTP/1.1" 200 56 "-" "-" SojdH8AAQEAAAugAQAAAAAA "-" /20090822/20090822-1324/20090822-132420-SojdH8AAQEAAAugAQAAAAAA 0 1248
 	t := time.Unix(0, al.Transaction.UnixTimestamp)
 
@@ -56,38 +60,34 @@ func (cl concurrentWriter) Write(al *Log) error {
 	ymdhm := ymd + t.Format("-1504")
 	filename := ymdhm + t.Format("05") + "-" + al.Transaction.ID
 
-	logdir := path.Join(cl.auditDir, ymd, ymdhm)
-	if err := os.MkdirAll(logdir, cl.auditDirMode); err != nil {
+	logdir := path.Join(cl.logDir, ymd, ymdhm)
+	if err := os.MkdirAll(logdir, cl.logDirMode); err != nil {
 		return err
 	}
 
-	jsdata, err := cl.formatter(al)
+	formattedAL, err := cl.formatter(al)
 	if err != nil {
 		return err
 	}
 
 	filepath := path.Join(logdir, filename)
-	if err = os.WriteFile(filepath, jsdata, cl.auditFileMode); err != nil {
+	if err = os.WriteFile(filepath, formattedAL, cl.logFileMode); err != nil {
 		return err
 	}
 
 	cl.mux.Lock()
 	defer cl.mux.Unlock()
 
-	cl.auditlogger.Printf("%s %s - - [%s]", al.Transaction.ClientIP, al.Transaction.HostIP, al.Transaction.Timestamp)
+	cl.log.Printf("%s %s - - [%s]", al.Transaction.ClientIP, al.Transaction.HostIP, al.Transaction.Timestamp)
 	if al.Transaction.Request != nil {
-		cl.auditlogger.Printf(` "%s %s %s"`, al.Transaction.Request.Method, al.Transaction.Request.URI, al.Transaction.Request.HTTPVersion)
+		cl.log.Printf(` "%s %s %s"`, al.Transaction.Request.Method, al.Transaction.Request.URI, al.Transaction.Request.HTTPVersion)
 	}
 	if al.Transaction.Response != nil {
-		cl.auditlogger.Printf(` %d`, al.Transaction.Response.Status)
+		cl.log.Printf(` %d`, al.Transaction.Response.Status)
 	}
-	cl.auditlogger.Printf("%s - %s\n", al.Transaction.ID, filepath)
+	cl.log.Printf("%s - %s\n", al.Transaction.ID, filepath)
 
 	return nil
-}
-
-func (cl *concurrentWriter) Close() error {
-	return cl.closer()
 }
 
 var _ Writer = (*concurrentWriter)(nil)

--- a/auditlog/logger.go
+++ b/auditlog/logger.go
@@ -32,7 +32,7 @@ func NewConfig() Config {
 	return Config{
 		File:      "",
 		FileMode:  0644,
-		Dir:       "./",
+		Dir:       "",
 		DirMode:   0755,
 		Formatter: nativeFormatter,
 	}

--- a/auditlog/logger.go
+++ b/auditlog/logger.go
@@ -32,7 +32,7 @@ func NewConfig() Config {
 	return Config{
 		File:      "",
 		FileMode:  0644,
-		Dir:       "",
+		Dir:       "./",
 		DirMode:   0755,
 		Formatter: nativeFormatter,
 	}

--- a/auditlog/noop_closer.go
+++ b/auditlog/noop_closer.go
@@ -1,0 +1,5 @@
+package auditlog
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }

--- a/config.go
+++ b/config.go
@@ -208,12 +208,12 @@ func (c *wafConfig) WithResponseBodyMimeTypes(mimeTypes []string) WAFConfig {
 type auditLogConfig struct {
 	relevantOnly bool
 	parts        types.AuditLogParts
-	logger       auditlog.Writer
+	writer       auditlog.Writer
 }
 
 func (c *auditLogConfig) LogRelevantOnly() AuditLogConfig {
 	ret := c.clone()
-	c.relevantOnly = true
+	ret.relevantOnly = true
 	return ret
 }
 
@@ -225,7 +225,7 @@ func (c *auditLogConfig) WithParts(parts types.AuditLogParts) AuditLogConfig {
 
 func (c *auditLogConfig) WithLogger(logger auditlog.Writer) AuditLogConfig {
 	ret := c.clone()
-	ret.logger = logger
+	ret.writer = logger
 	return ret
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -122,22 +122,19 @@ func TestConfigLogger(t *testing.T) {
 		LogRelevantOnly().
 		WithLogger(logger).
 		WithParts([]types.AuditLogPart("abcdedf"))
+
 	cfg := NewWAFConfig().WithAuditLog(logCfg)
 	waf, err := NewWAF(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	w := waf.(wafWrapper)
-	// TODO(jptosso): this is not working, but there is a comment in the code
-	/*
-		if w.waf.AuditEngine != types.AuditEngineRelevantOnly {
-			t.Errorf("expected audit engine to be relevant only")
-		}
-	*/
-	if w.waf.AuditLogWriter == nil {
-		t.Errorf("expected audit log writer to be set")
-	}
+
 	if w.waf.AuditLogParts == nil {
 		t.Errorf("expected audit log parts to be set")
+	}
+
+	if w.waf.AuditEngine != types.AuditEngineRelevantOnly {
+		t.Errorf("expected audit engine to be relevant only")
 	}
 }

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1246,13 +1246,11 @@ func (tx *Transaction) ProcessLogging() {
 	tx.debugLogger.Debug().
 		Msg("Transaction marked for audit logging")
 
-	if writer := tx.WAF.AuditLogWriter; writer != nil {
-		// We don't log if there is an empty audit logger
-		if err := writer.Write(tx.AuditLog()); err != nil {
-			tx.debugLogger.Error().
-				Err(err).
-				Msg("Failed to write audit log")
-		}
+	// We don't log if there is an empty audit logger
+	if err := tx.WAF.AuditLogWriter().Write(tx.AuditLog()); err != nil {
+		tx.debugLogger.Error().
+			Err(err).
+			Msg("Failed to write audit log")
 	}
 }
 

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -302,10 +302,13 @@ func (w *WAF) SetDebugLogLevel(lvl debuglog.Level) error {
 	return nil
 }
 
+// SetAuditLogWriter sets the audit log writer
 func (w *WAF) SetAuditLogWriter(alw auditlog.Writer) {
 	w.auditLogWriter = alw
 }
 
+// AuditLogWriter returns the audit log writer. If the writer is not initialized,
+// it will be initialized
 func (w *WAF) AuditLogWriter() auditlog.Writer {
 	if !w.auditLogWriterInitialized {
 		if err := w.auditLogWriter.Init(w.AuditLogWriterConfig); err != nil {
@@ -316,6 +319,9 @@ func (w *WAF) AuditLogWriter() auditlog.Writer {
 	return w.auditLogWriter
 }
 
+// InitAuditLogWriter initializes the audit log writer. If the writer is already
+// initialized, it will return an error as initializing the audit log writer twice
+// seems to be a bug.
 func (w *WAF) InitAuditLogWriter() error {
 	if w.auditLogWriterInitialized {
 		return errors.New("audit log writer already initialized")

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -120,6 +120,10 @@ type WAF struct {
 
 	ErrorLogCb func(rule types.MatchedRule)
 
+	// AuditLogConfig is configuration of audit logging, populated by multiple directives and consumed by
+	// SecAuditLog.
+	AuditLogConfig auditlog.Config
+
 	// AuditLogWriter is used to write audit logs
 	AuditLogWriter auditlog.Writer
 }
@@ -270,6 +274,7 @@ func NewWAF() *WAF {
 		ResponseBodyAccess: false,
 		ResponseBodyLimit:  _1gb,
 		AuditLogWriter:     logWriter,
+		AuditLogConfig:     auditlog.NewConfig(),
 		Logger:             logger,
 	}
 

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -579,7 +579,7 @@ func directiveSecAuditLog(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.WAF.AuditLogConfig.File = options.Opts
+	options.WAF.AuditLogWriterConfig.File = options.Opts
 
 	return nil
 }
@@ -593,7 +593,7 @@ func directiveSecAuditLogType(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.WAF.AuditLogWriter = writer
+	options.WAF.SetAuditLogWriter(writer)
 
 	return nil
 }
@@ -611,7 +611,7 @@ func directiveSecAuditLogFormat(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.WAF.AuditLogConfig.Formatter = formatter
+	options.WAF.AuditLogWriterConfig.Formatter = formatter
 
 	return nil
 }
@@ -621,7 +621,7 @@ func directiveSecAuditLogDir(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.WAF.AuditLogConfig.Dir = options.Opts
+	options.WAF.AuditLogWriterConfig.Dir = options.Opts
 
 	return nil
 }
@@ -647,7 +647,7 @@ func directiveSecAuditLogDirMode(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.WAF.AuditLogConfig.DirMode = fs.FileMode(auditLogDirMode)
+	options.WAF.AuditLogWriterConfig.DirMode = fs.FileMode(auditLogDirMode)
 
 	return nil
 }
@@ -671,7 +671,7 @@ func directiveSecAuditLogFileMode(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.WAF.AuditLogConfig.FileMode = fs.FileMode(auditLogFileMode)
+	options.WAF.AuditLogWriterConfig.FileMode = fs.FileMode(auditLogFileMode)
 
 	return nil
 }

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -29,10 +29,6 @@ type DirectiveOptions struct {
 	Path     []string
 	Datasets map[string][]string
 
-	// AuditLog is configuration of audit logging, populated by multiple directives and consumed by
-	// SecAuditLog.
-	AuditLog auditlog.Config
-
 	// Parser is configuration of the parser, populated by multiple directives and consumed by
 	// directives that parse.
 	Parser ParserConfig
@@ -583,10 +579,8 @@ func directiveSecAuditLog(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.AuditLog.File = options.Opts
-	if err := options.WAF.AuditLogWriter.Init(options.AuditLog); err != nil {
-		return err
-	}
+	options.WAF.AuditLogConfig.File = options.Opts
+
 	return nil
 }
 
@@ -599,10 +593,8 @@ func directiveSecAuditLogType(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := writer.Init(options.AuditLog); err != nil {
-		return err
-	}
 	options.WAF.AuditLogWriter = writer
+
 	return nil
 }
 
@@ -619,11 +611,8 @@ func directiveSecAuditLogFormat(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.AuditLog.Formatter = formatter
+	options.WAF.AuditLogConfig.Formatter = formatter
 
-	if err := options.WAF.AuditLogWriter.Init(options.AuditLog); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -632,10 +621,8 @@ func directiveSecAuditLogDir(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	options.AuditLog.Dir = options.Opts
-	if err := options.WAF.AuditLogWriter.Init(options.AuditLog); err != nil {
-		return err
-	}
+	options.WAF.AuditLogConfig.Dir = options.Opts
+
 	return nil
 }
 
@@ -660,10 +647,8 @@ func directiveSecAuditLogDirMode(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.AuditLog.DirMode = fs.FileMode(auditLogDirMode)
-	if err := options.WAF.AuditLogWriter.Init(options.AuditLog); err != nil {
-		return err
-	}
+	options.WAF.AuditLogConfig.DirMode = fs.FileMode(auditLogDirMode)
+
 	return nil
 }
 
@@ -686,10 +671,8 @@ func directiveSecAuditLogFileMode(options *DirectiveOptions) error {
 	if err != nil {
 		return err
 	}
-	options.AuditLog.FileMode = fs.FileMode(auditLogFileMode)
-	if err := options.WAF.AuditLogWriter.Init(options.AuditLog); err != nil {
-		return err
-	}
+	options.WAF.AuditLogConfig.FileMode = fs.FileMode(auditLogFileMode)
+
 	return nil
 }
 

--- a/internal/seclang/directives_log_test.go
+++ b/internal/seclang/directives_log_test.go
@@ -37,18 +37,9 @@ func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := waf.AuditLogWriter.Init(waf.AuditLogConfig); err != nil {
-		t.Fatal(err)
-	}
-
 	id := utils.RandomString(10)
 
-	if waf.AuditLogWriter == nil {
-		t.Fatal("Missing audit log writer")
-		return
-	}
-
-	if err := waf.AuditLogWriter.Write(&auditlog.Log{
+	if err := waf.AuditLogWriter().Write(&auditlog.Log{
 		Parts: types.AuditLogParts("ABCDEFGHIJKZ"),
 		Transaction: auditlog.Transaction{
 			ID: id,

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/auditlog"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/internal/environment"
 	"github.com/corazawaf/coraza/v3/internal/io"
@@ -206,7 +205,6 @@ func NewParser(waf *corazawaf.WAF) *Parser {
 		options: &DirectiveOptions{
 			WAF:      waf,
 			Datasets: make(map[string][]string),
-			AuditLog: auditlog.NewConfig(),
 		},
 		root: io.OSFS{},
 	}

--- a/testing/auditlog_test.go
+++ b/testing/auditlog_test.go
@@ -43,10 +43,6 @@ func TestAuditLogMessages(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	if err := waf.AuditLogWriter.Init(waf.AuditLogConfig); err != nil {
-		t.Fatal(err)
-	}
-
 	tx := waf.NewTransaction()
 	tx.AddGetRequestArgument("test", "test")
 	tx.ProcessRequestHeaders()
@@ -131,10 +127,6 @@ func TestAuditLogRelevantOnlyOk(t *testing.T) {
 		SecAuditLogRelevantStatus ".*"
 		SecRule ARGS "@unconditionalMatch" "id:1,phase:1,log,msg:'unconditional match'"
 	`); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := waf.AuditLogWriter.Init(waf.AuditLogConfig); err != nil {
 		t.Fatal(err)
 	}
 

--- a/waf.go
+++ b/waf.go
@@ -58,7 +58,6 @@ func NewWAF(config WAFConfig) (WAF, error) {
 	}
 
 	if a := c.auditLog; a != nil {
-		// TODO(anuraaga): Can't override AuditEngineOn from rules to off this way.
 		if a.relevantOnly {
 			waf.AuditEngine = types.AuditEngineRelevantOnly
 		} else {
@@ -67,12 +66,13 @@ func NewWAF(config WAFConfig) (WAF, error) {
 
 		waf.AuditLogParts = a.parts
 
-		if a.logger != nil {
-			waf.AuditLogWriter = a.logger
-			if err := waf.AuditLogWriter.Init(waf.AuditLogConfig); err != nil {
-				return nil, fmt.Errorf("invalid WAF config from audit log: %w", err)
-			}
+		if a.writer != nil {
+			waf.SetAuditLogWriter(a.writer)
 		}
+	}
+
+	if err := waf.InitAuditLogWriter(); err != nil {
+		return nil, fmt.Errorf("invalid WAF config from audit log: %w", err)
 	}
 
 	if c.requestBodyAccess {

--- a/waf.go
+++ b/waf.go
@@ -69,6 +69,9 @@ func NewWAF(config WAFConfig) (WAF, error) {
 
 		if a.logger != nil {
 			waf.AuditLogWriter = a.logger
+			if err := waf.AuditLogWriter.Init(waf.AuditLogConfig); err != nil {
+				return nil, fmt.Errorf("invalid WAF config from audit log: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Audit log is more tricky than debuglog as there are many variables in play: StorageDir, dirMode, fileMode, file. Hence we can do the immutable pattern because that would be overkill.

Closes #698