### PR TITLE
Cleanup and optimize rulegroup

### DIFF
--- a/actions/ctl.go
+++ b/actions/ctl.go
@@ -355,7 +355,7 @@ func parseCtl(data string) (ctlFunctionType, string, variables.RuleVariable, str
 	return act, value, collection, strings.TrimSpace(colkey), nil
 }
 
-func rangeToInts(rules []*corazawaf.Rule, input string) ([]int, error) {
+func rangeToInts(rules []corazawaf.Rule, input string) ([]int, error) {
 	if len(input) == 0 {
 		return nil, errors.New("empty input")
 	}

--- a/actions/ctl_test.go
+++ b/actions/ctl_test.go
@@ -424,7 +424,7 @@ func TestParseCtl(t *testing.T) {
 
 }
 func TestCtlParseRange(t *testing.T) {
-	rules := []*corazawaf.Rule{
+	rules := []corazawaf.Rule{
 		{
 			RuleMetadata: corazarules.RuleMetadata{
 				ID_: 5,

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -18,7 +18,7 @@ import (
 // It is not concurrent safe, so it's not recommended to use it
 // after compilation
 type RuleGroup struct {
-	rules []*Rule
+	rules []Rule
 }
 
 // Add a rule to the collection
@@ -45,20 +45,20 @@ func (rg *RuleGroup) Add(rule *Rule) error {
 		}
 	}
 
-	rg.rules = append(rg.rules, rule)
+	rg.rules = append(rg.rules, *rule)
 	return nil
 }
 
 // GetRules returns the slice of rules,
-func (rg *RuleGroup) GetRules() []*Rule {
+func (rg *RuleGroup) GetRules() []Rule {
 	return rg.rules
 }
 
 // FindByID return a Rule with the requested Id
 func (rg *RuleGroup) FindByID(id int) *Rule {
-	for _, r := range rg.rules {
+	for i, r := range rg.rules {
 		if r.ID_ == id {
-			return r
+			return &rg.rules[i]
 		}
 	}
 	return nil
@@ -76,7 +76,7 @@ func (rg *RuleGroup) DeleteByID(id int) {
 
 // DeleteByMsg deletes rules with the given message.
 func (rg *RuleGroup) DeleteByMsg(msg string) {
-	var kept []*Rule
+	var kept []Rule
 	for _, r := range rg.rules {
 		if r.Msg.String() != msg {
 			kept = append(kept, r)
@@ -87,7 +87,7 @@ func (rg *RuleGroup) DeleteByMsg(msg string) {
 
 // DeleteByTag deletes rules with the given tag.
 func (rg *RuleGroup) DeleteByTag(tag string) {
-	var kept []*Rule
+	var kept []Rule
 	for _, r := range rg.rules {
 		if !strings.InSlice(tag, r.Tags_) {
 			kept = append(kept, r)
@@ -118,7 +118,8 @@ func (rg *RuleGroup) Eval(phase types.RulePhase, tx *Transaction) bool {
 		delete(transformationCache, k)
 	}
 RulesLoop:
-	for _, r := range tx.WAF.Rules.GetRules() {
+	for i := range rg.rules {
+		r := &rg.rules[i]
 		// if there is already an interruption and the phase isn't logging
 		// we break the loop
 		if tx.interruption != nil && phase != types.PhaseLogging {

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -29,7 +29,7 @@ func (rg *RuleGroup) Add(rule *Rule) error {
 		return nil
 	}
 
-	if rg.FindByID(rule.ID_) != nil && rule.ID_ != 0 {
+	if rule.ID_ != 0 && rg.FindByID(rule.ID_) != nil {
 		return fmt.Errorf("there is a another rule with id %d", rule.ID_)
 	}
 
@@ -67,44 +67,38 @@ func (rg *RuleGroup) FindByID(id int) *Rule {
 // DeleteByID removes a rule by it's Id
 func (rg *RuleGroup) DeleteByID(id int) {
 	for i, r := range rg.rules {
-		if r != nil && r.ID_ == id {
-			copy(rg.rules[i:], rg.rules[i+1:])
-			rg.rules[len(rg.rules)-1] = nil
-			rg.rules = rg.rules[:len(rg.rules)-1]
+		if r.ID_ == id {
+			rg.rules = append(rg.rules[:i], rg.rules[i+1:]...)
+			return
 		}
 	}
 }
 
-// FindByMsg returns a slice of rules that matches the msg
-func (rg *RuleGroup) FindByMsg(msg string) []*Rule {
-	var rules []*Rule
+// DeleteByMsg deletes rules with the given message.
+func (rg *RuleGroup) DeleteByMsg(msg string) {
+	var kept []*Rule
 	for _, r := range rg.rules {
-		if r.Msg.String() == msg {
-			rules = append(rules, r)
+		if r.Msg.String() != msg {
+			kept = append(kept, r)
 		}
 	}
-	return rules
+	rg.rules = kept
 }
 
-// FindByTag returns a slice of rules that matches the tag
-func (rg *RuleGroup) FindByTag(tag string) []*Rule {
-	var rules []*Rule
+// DeleteByTag deletes rules with the given tag.
+func (rg *RuleGroup) DeleteByTag(tag string) {
+	var kept []*Rule
 	for _, r := range rg.rules {
-		if strings.InSlice(tag, r.Tags_) {
-			rules = append(rules, r)
+		if !strings.InSlice(tag, r.Tags_) {
+			kept = append(kept, r)
 		}
 	}
-	return rules
+	rg.rules = kept
 }
 
 // Count returns the count of rules
 func (rg *RuleGroup) Count() int {
 	return len(rg.rules)
-}
-
-// Clear will remove each and every rule stored
-func (rg *RuleGroup) Clear() {
-	rg.rules = []*Rule{}
 }
 
 // Eval rules for the specified phase, between 1 and 5
@@ -226,9 +220,7 @@ RulesLoop:
 // You might use this function to replace the rules
 // and "reload" the WAF
 func NewRuleGroup() RuleGroup {
-	return RuleGroup{
-		rules: []*Rule{},
-	}
+	return RuleGroup{}
 }
 
 type transformationKey struct {

--- a/internal/corazawaf/rulegroup_test.go
+++ b/internal/corazawaf/rulegroup_test.go
@@ -27,15 +27,20 @@ func TestRG(t *testing.T) {
 		t.Error("Failed to add rule to rulegroup")
 	}
 
-	if len(rg.FindByMsg("test")) != 1 {
-		t.Error("Failed to find rules by msg")
+	rg.DeleteByTag("test")
+	if rg.Count() != 0 {
+		t.Error("Failed to remove rule from rulegroup")
 	}
 
-	if len(rg.FindByTag("test")) != 1 {
-		t.Error("Failed to find rules by tag")
+	if err := rg.Add(r); err != nil {
+		t.Error("Failed to add rule to rulegroup")
 	}
 
-	rg.DeleteByID(1)
+	if rg.Count() != 1 {
+		t.Error("Failed to add rule to rulegroup")
+	}
+
+	rg.DeleteByMsg("test")
 	if rg.Count() != 0 {
 		t.Error("Failed to remove rule from rulegroup")
 	}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -313,9 +313,7 @@ func directiveSecRuleRemoveByTag(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	for _, r := range options.WAF.Rules.FindByTag(options.Opts) {
-		options.WAF.Rules.DeleteByID(r.ID_)
-	}
+	options.WAF.Rules.DeleteByTag(options.Opts)
 	return nil
 }
 
@@ -324,9 +322,7 @@ func directiveSecRuleRemoveByMsg(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	for _, r := range options.WAF.Rules.FindByMsg(options.Opts) {
-		options.WAF.Rules.DeleteByID(r.ID_)
-	}
+	options.WAF.Rules.DeleteByMsg(options.Opts)
 	return nil
 }
 

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -434,7 +434,8 @@ func getLastRuleExpectingChain(w *corazawaf.WAF) *corazawaf.Rule {
 	if len(rules) == 0 {
 		return nil
 	}
-	lastRule := rules[len(rules)-1]
+
+	lastRule := &rules[len(rules)-1]
 	parent := lastRule
 	for parent.Chain != nil {
 		parent = parent.Chain
@@ -443,6 +444,7 @@ func getLastRuleExpectingChain(w *corazawaf.WAF) *corazawaf.Rule {
 	if parent.HasChain && parent.Chain == nil {
 		return lastRule
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
It is best to use a slice of structs rather than pointers wherever possible to reduce memory usage a little and improve iteration performance.

This also replaces some find+delete patterns with just delete since they are internal code anyways