### PR TITLE
Enable multiline mode for rx

### DIFF
--- a/operators/rx.go
+++ b/operators/rx.go
@@ -6,6 +6,7 @@
 package operators
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/corazawaf/coraza/v3/rules"
@@ -19,6 +20,7 @@ var _ rules.Operator = (*rx)(nil)
 
 func newRX(options rules.OperatorOptions) (rules.Operator, error) {
 	data := options.Arguments
+	data = fmt.Sprintf("(?sm)%s", data)
 
 	re, err := regexp.Compile(data)
 	if err != nil {

--- a/operators/rx_test.go
+++ b/operators/rx_test.go
@@ -38,6 +38,11 @@ func TestRx(t *testing.T) {
 			input:   "グッバイワールド",
 			want:    false,
 		},
+		{
+			pattern: `hello.*world`,
+			input:   "hello\nworld",
+			want:    true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/testing/coreruleset/.ftw.yml
+++ b/testing/coreruleset/.ftw.yml
@@ -22,5 +22,4 @@ testoverride:
     934120-39: 'regex matches arbitrary bytes'
     941310-1: 'regex matches arbitrary bytes'
     941310-3: 'regex matches arbitrary bytes'
-    942522-7: ''
     944200-1: 'regex matches arbitrary bytes'


### PR DESCRIPTION
I noticed ModSec uses dotall / multiline for regex

https://github.com/SpiderLabs/ModSecurity/blob/1feaa7d24b3ae19e6d9d2a4c055d64cd8a305aa1/src/utils/regex.cc#L68

Currently one CRS test fails because of the lack of multiline. I added dotall as well to match modsec though no CRS tests fail without it.