### PR TITLE
Optimize structs

### DIFF
--- a/auditlog/auditlog.go
+++ b/auditlog/auditlog.go
@@ -22,9 +22,11 @@ type Log struct {
 // Transaction contains transaction specific
 // information
 type Transaction struct {
+	Request  *TransactionRequest  `json:"request,omitempty"`
+	Response *TransactionResponse `json:"response,omitempty"`
+	Producer *TransactionProducer `json:"producer,omitempty"`
 	// Timestamp "02/Jan/2006:15:04:20 -0700" format
-	Timestamp     string `json:"timestamp"`
-	UnixTimestamp int64  `json:"unix_timestamp"`
+	Timestamp string `json:"timestamp"`
 
 	// Unique ID
 	ID string `json:"id"`
@@ -32,22 +34,21 @@ type Transaction struct {
 	// Client IP Address string representation
 	ClientIP string `json:"client_ip"`
 
-	ClientPort int                  `json:"client_port"`
-	HostIP     string               `json:"host_ip"`
-	HostPort   int                  `json:"host_port"`
-	ServerID   string               `json:"server_id"`
-	Request    *TransactionRequest  `json:"request,omitempty"`
-	Response   *TransactionResponse `json:"response,omitempty"`
-	Producer   *TransactionProducer `json:"producer,omitempty"`
+	HostIP        string `json:"host_ip"`
+	ServerID      string `json:"server_id"`
+	UnixTimestamp int64  `json:"unix_timestamp"`
+
+	ClientPort int `json:"client_port"`
+	HostPort   int `json:"host_port"`
 }
 
 // TransactionResponse contains response specific
 // information
 type TransactionResponse struct {
-	Protocol string              `json:"protocol"`
-	Status   int                 `json:"status"`
 	Headers  map[string][]string `json:"headers"`
+	Protocol string              `json:"protocol"`
 	Body     string              `json:"body"`
+	Status   int                 `json:"status"`
 }
 
 // TransactionProducer contains producer specific
@@ -77,8 +78,8 @@ type TransactionRequest struct {
 // for the uploaded files using multipart forms
 type TransactionRequestFiles struct {
 	Name string `json:"name"`
-	Size int64  `json:"size"`
 	Mime string `json:"mime"`
+	Size int64  `json:"size"`
 }
 
 // Message contains information about the triggered
@@ -93,25 +94,23 @@ type Message struct {
 // rules in detail
 type MessageData struct {
 	File     string             `json:"file"`
-	Line     int                `json:"line"`
-	ID       int                `json:"id"`
 	Rev      string             `json:"rev"`
 	Msg      string             `json:"msg"`
 	Data     string             `json:"data"`
-	Severity types.RuleSeverity `json:"severity"`
 	Ver      string             `json:"ver"`
+	Raw      string             `json:"raw"`
+	Tags     []string           `json:"tags"`
+	Line     int                `json:"line"`
+	ID       int                `json:"id"`
+	Severity types.RuleSeverity `json:"severity"`
 	Maturity int                `json:"maturity"`
 	Accuracy int                `json:"accuracy"`
-	Tags     []string           `json:"tags"`
-	Raw      string             `json:"raw"`
 }
 
 // LEGACY FORMAT
 
 // Main struct for audit log data
 type logLegacy struct {
-	// Section A
-	Transaction logLegacyTransaction `json:"transaction"`
 
 	// Section B or C
 	Request *logLegacyRequest `json:"request,omitempty"`
@@ -124,6 +123,8 @@ type logLegacy struct {
 
 	// Section H
 	AuditData *logLegacyData `json:"audit_data,omitempty"`
+	// Section A
+	Transaction logLegacyTransaction `json:"transaction"`
 }
 
 type logLegacyTransaction struct {
@@ -131,33 +132,33 @@ type logLegacyTransaction struct {
 	Time          string `json:"time"`
 	TransactionID string `json:"transaction_id"`
 	RemoteAddress string `json:"remote_address"`
-	RemotePort    int    `json:"remote_port"`
 	LocalAddress  string `json:"local_address"`
+	RemotePort    int    `json:"remote_port"`
 	LocalPort     int    `json:"local_port"`
 }
 
 type logLegacyRequest struct {
-	RequestLine string `json:"request_line"`
 	// Headers should be a map of slices but in this case they are
 	// joined by comma (,)
-	Headers map[string]string `json:"headers,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	RequestLine string            `json:"request_line"`
 }
 
 type logLegacyResponse struct {
-	Status   int               `json:"status"`
-	Protocol string            `json:"protocol"`
 	Headers  map[string]string `json:"headers"`
+	Protocol string            `json:"protocol"`
+	Status   int               `json:"status"`
 }
 
 type logLegacyData struct {
-	Messages              []string           `json:"messages"`
-	ErrorMessages         []string           `json:"error_messages"`
 	Handler               string             `json:"handler"`
-	Stopwatch             logLegacyStopwatch `json:"stopwatch"`
-	ResponseBodyDechunked bool               `json:"response_body_dechunked"`
-	Producer              []string           `json:"producer"`
 	Server                string             `json:"server"`
 	EngineMode            string             `json:"engine_mode"`
+	Messages              []string           `json:"messages"`
+	ErrorMessages         []string           `json:"error_messages"`
+	Producer              []string           `json:"producer"`
+	Stopwatch             logLegacyStopwatch `json:"stopwatch"`
+	ResponseBodyDechunked bool               `json:"response_body_dechunked"`
 }
 
 type logLegacyStopwatch struct {

--- a/auditlog/concurrent_writer.go
+++ b/auditlog/concurrent_writer.go
@@ -17,13 +17,13 @@ import (
 )
 
 type concurrentWriter struct {
+	io.Closer
 	mux         *sync.RWMutex
 	log         *log.Logger
+	formatter   Formatter
 	logDir      string
 	logDirMode  fs.FileMode
 	logFileMode fs.FileMode
-	formatter   Formatter
-	io.Closer
 }
 
 func (cl *concurrentWriter) Init(c Config) error {

--- a/auditlog/logger.go
+++ b/auditlog/logger.go
@@ -11,20 +11,20 @@ import (
 
 // Config is the configuration of a Writer.
 type Config struct {
+
+	// Formatter is the formatter to use when writing formatted audit logs.
+	Formatter Formatter
 	// File is the path to the file to write the raw audit log to.
 	File string
-
-	// FileMode is the mode to use when creating File.
-	FileMode fs.FileMode
 
 	// Dir is the path to the directory to write formatted audit logs to.
 	Dir string
 
+	// FileMode is the mode to use when creating File.
+	FileMode fs.FileMode
+
 	// DirMode is the mode to use when creating Dir.
 	DirMode fs.FileMode
-
-	// Formatter is the formatter to use when writing formatted audit logs.
-	Formatter Formatter
 }
 
 // NewConfig returns a Config with default values.

--- a/auditlog/serial_writer.go
+++ b/auditlog/serial_writer.go
@@ -15,8 +15,8 @@ import (
 // serialWriter is used to store logs in a single file
 type serialWriter struct {
 	io.Closer
-	log       log.Logger
 	formatter Formatter
+	log       log.Logger
 }
 
 func (sl *serialWriter) Init(c Config) error {

--- a/config.go
+++ b/config.go
@@ -100,17 +100,17 @@ type wafRule struct {
 // int is a signed integer type that is at least 32 bits in size (platform-dependent size).
 // We still basically assume 64-bit usage where int are big sizes.
 type wafConfig struct {
-	rules                    []wafRule
+	debugLogger              debuglog.Logger
+	fsRoot                   fs.FS
 	auditLog                 *auditLogConfig
-	requestBodyAccess        bool
 	requestBodyLimit         *int
 	requestBodyInMemoryLimit *int
-	responseBodyAccess       bool
 	responseBodyLimit        *int
-	responseBodyMimeTypes    []string
-	debugLogger              debuglog.Logger
 	errorCallback            func(rule types.MatchedRule)
-	fsRoot                   fs.FS
+	rules                    []wafRule
+	responseBodyMimeTypes    []string
+	requestBodyAccess        bool
+	responseBodyAccess       bool
 }
 
 func (c *wafConfig) WithRules(rules ...*corazawaf.Rule) WAFConfig {
@@ -206,9 +206,9 @@ func (c *wafConfig) WithResponseBodyMimeTypes(mimeTypes []string) WAFConfig {
 }
 
 type auditLogConfig struct {
-	relevantOnly bool
-	parts        types.AuditLogParts
 	writer       auditlog.Writer
+	parts        types.AuditLogParts
+	relevantOnly bool
 }
 
 func (c *auditLogConfig) LogRelevantOnly() AuditLogConfig {

--- a/debuglog/default.go
+++ b/debuglog/default.go
@@ -12,9 +12,9 @@ import (
 )
 
 type defaultEvent struct {
-	level   Level
 	printer Printer
 	fields  []byte
+	level   Level
 }
 
 func (e *defaultEvent) Msg(msg string) {
@@ -90,8 +90,8 @@ func (defaultEvent) IsEnabled() bool {
 type defaultLogger struct {
 	printer       Printer
 	factory       PrinterFactory
-	level         Level
 	defaultFields []byte
+	level         Level
 }
 
 func (l defaultLogger) WithOutput(w io.Writer) Logger {

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -21,8 +21,8 @@ import (
 type rwInterceptor struct {
 	w                  http.ResponseWriter
 	tx                 types.Transaction
-	statusCode         int
 	proto              string
+	statusCode         int
 	isWriteHeaderFlush bool
 	wroteHeader        bool
 }

--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -44,10 +44,10 @@ const (
 )
 
 type ctlFn struct {
-	action     ctlFunctionType
 	value      string
-	collection variables.RuleVariable
 	colKey     string
+	action     ctlFunctionType
+	collection variables.RuleVariable
 }
 
 func (a *ctlFn) Init(_ rules.RuleMetadata, data string) error {

--- a/internal/actions/expirevar.go
+++ b/internal/actions/expirevar.go
@@ -14,8 +14,8 @@ import (
 
 type expirevarFn struct {
 	collection string
-	ttl        int
 	key        string
+	ttl        int
 }
 
 func (a *expirevarFn) Init(_ rules.RuleMetadata, data string) error {

--- a/internal/actions/initcol.go
+++ b/internal/actions/initcol.go
@@ -12,8 +12,8 @@ import (
 // Initializes a persistent collection and add the data to the standard collections coraza.
 type initcolFn struct {
 	collection string
-	variable   byte
 	key        string
+	variable   byte
 }
 
 func (a *initcolFn) Init(_ rules.RuleMetadata, data string) error {

--- a/internal/actions/setenv.go
+++ b/internal/actions/setenv.go
@@ -13,8 +13,8 @@ import (
 )
 
 type setenvFn struct {
-	key   string
 	value macro.Macro
+	key   string
 }
 
 func (a *setenvFn) Init(_ rules.RuleMetadata, data string) error {

--- a/internal/collections/named.go
+++ b/internal/collections/named.go
@@ -86,8 +86,8 @@ func (c *NamedCollection) String() string {
 }
 
 type NamedCollectionNames struct {
-	variable   variables.RuleVariable
 	collection *NamedCollection
+	variable   variables.RuleVariable
 }
 
 func (c *NamedCollectionNames) FindRegex(key *regexp.Regexp) []types.MatchData {

--- a/internal/corazarules/rule.go
+++ b/internal/corazarules/rule.go
@@ -10,19 +10,19 @@ import (
 // RuleMetadata is used to store rule metadata
 // that can be used across packages
 type RuleMetadata struct {
-	ID_       int
-	File_     string
-	Line_     int
-	Rev_      string
-	Severity_ types.RuleSeverity
-	Version_  string
-	Tags_     []string
-	Maturity_ int
-	Accuracy_ int
 	Operator_ string
-	Phase_    types.RulePhase
+	File_     string
+	Rev_      string
+	Version_  string
 	Raw_      string
 	SecMark_  string
+	Tags_     []string
+	Line_     int
+	Severity_ types.RuleSeverity
+	Maturity_ int
+	Accuracy_ int
+	ID_       int
+	Phase_    types.RulePhase
 }
 
 func (r *RuleMetadata) ID() int {

--- a/internal/corazarules/rule_match.go
+++ b/internal/corazarules/rule_match.go
@@ -15,8 +15,6 @@ import (
 // MatchData works like VariableKey but is used for logging,
 // so it contains the collection as a string, and it's value
 type MatchData struct {
-	// Variable
-	Variable_ variables.RuleVariable
 	// Key of the variable, blank if no key is required
 	Key_ string
 	// Value of the current VARIABLE:KEY
@@ -25,6 +23,8 @@ type MatchData struct {
 	Message_ string
 	// Macro expanded logdata
 	Data_ string
+	// Variable
+	Variable_ variables.RuleVariable
 }
 
 func (m *MatchData) Variable() variables.RuleVariable {
@@ -50,6 +50,7 @@ func (m *MatchData) Data() string {
 // MatchedRule contains a list of macro expanded messages,
 // matched variables and a pointer to the rule
 type MatchedRule struct {
+	Rule_ types.RuleMetadata
 	// Macro expanded message
 	Message_ string
 	// Macro expanded logdata
@@ -58,8 +59,6 @@ type MatchedRule struct {
 	URI_ string
 	// Transaction id
 	TransactionID_ string
-	// Is disruptive
-	Disruptive_ bool
 	// Server IP address
 	ServerIPAddress_ string
 	// Client IP address
@@ -67,7 +66,8 @@ type MatchedRule struct {
 	// A slice of matched variables
 	MatchedDatas_ []types.MatchData
 
-	Rule_ types.RuleMetadata
+	// Is disruptive
+	Disruptive_ bool
 }
 
 func (mr *MatchedRule) Message() string {

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -17,9 +17,9 @@ import (
 // It will handle memory usage for buffering and processing
 // It implements io.Copy(bodyBuffer, someReader) by inherit io.Writer
 type BodyBuffer struct {
-	options types.BodyBufferOptions
 	buffer  *bytes.Buffer
 	writer  *os.File
+	options types.BodyBufferOptions
 	length  int64
 }
 
@@ -94,8 +94,8 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 }
 
 type bodyBufferReader struct {
-	pos int
 	br  *BodyBuffer
+	pos int
 }
 
 func (b *bodyBufferReader) Read(p []byte) (n int, err error) {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -32,40 +32,41 @@ import (
 // All WAF instance fields are immutable, if you update any
 // of them in runtime you might create concurrency issues
 type WAF struct {
+
+	// AuditLogWriterConfig is configuration of audit logging, populated by multiple directives and consumed by
+	// SecAuditLog.
+	AuditLogWriterConfig auditlog.Config
+
+	// Used for the debug logger
+	Logger debuglog.Logger
+
+	auditLogWriter auditlog.Writer
+
 	txPool sync.Pool
-
-	// ruleGroup object, contains all rules and helpers
-	Rules RuleGroup
-
-	// If true, transactions will have access to the request body
-	RequestBodyAccess bool
-
-	// Request body page file limit
-	RequestBodyLimit int64
 
 	// Request body in memory limit
 	requestBodyInMemoryLimit *int64
 
-	// If true, transactions will have access to the response body
-	ResponseBodyAccess bool
+	ErrorLogCb func(rule types.MatchedRule)
 
-	// Response body memory limit
-	ResponseBodyLimit int64
+	// Contains the regular expression for relevant status audit logging
+	AuditLogRelevantStatus *regexp.Regexp
 
-	// Defines if rules are going to be evaluated
-	RuleEngine types.RuleEngineStatus
+	// UploadDir is the directory where the uploaded files will be stored
+	UploadDir string
 
-	// Responses will only be loaded if mime is listed here
-	ResponseBodyMimeTypes []string
+	// ProducerConnectorVersion is used by connectors to identify the producer
+	// version on audit logs
+	ProducerConnectorVersion string
 
 	// Web Application id, apps sharing the same id will share persistent collections
 	WebAppID string
 
-	// Add significant rule components to audit log
-	ComponentNames []string
+	// ProducerConnector is used by connectors to identify the producer
+	// on audit logs, for example, apache-modcoraza
+	ProducerConnector string
 
-	// If true WAF engine will fail when remote rules cannot be loaded
-	AbortOnRemoteRulesFail bool
+	ArgumentSeparator string
 
 	// Instructs the waf to change the Server response header
 	ServerSignature string
@@ -79,52 +80,55 @@ type WAF struct {
 	// Path to store data files (ex. cache)
 	DataDir string
 
-	// If true, the WAF will store the uploaded files in the UploadDir
-	// directory
-	UploadKeepFiles bool
-	// UploadFileMode instructs the waf to set the file mode for uploaded files
-	UploadFileMode fs.FileMode
-	// UploadFileLimit is the maximum size of the uploaded file to be stored
-	UploadFileLimit int
-	// UploadDir is the directory where the uploaded files will be stored
-	UploadDir string
+	// Responses will only be loaded if mime is listed here
+	ResponseBodyMimeTypes []string
 
-	// Request body in memory limit excluding the size of any files being transported in the request.
-	RequestBodyNoFilesLimit int64
+	// Add significant rule components to audit log
+	ComponentNames []string
 
-	RequestBodyLimitAction types.BodyLimitAction
-
-	ResponseBodyLimitAction types.BodyLimitAction
-
-	ArgumentSeparator string
-
-	// ProducerConnector is used by connectors to identify the producer
-	// on audit logs, for example, apache-modcoraza
-	ProducerConnector string
-
-	// ProducerConnectorVersion is used by connectors to identify the producer
-	// version on audit logs
-	ProducerConnectorVersion string
-
-	// Used for the debug logger
-	Logger debuglog.Logger
-
-	ErrorLogCb func(rule types.MatchedRule)
-
-	// Audit mode status
-	AuditEngine types.AuditEngineStatus
+	// ruleGroup object, contains all rules and helpers
+	Rules RuleGroup
 
 	// Array of logging parts to be used
 	AuditLogParts types.AuditLogParts
 
-	// Contains the regular expression for relevant status audit logging
-	AuditLogRelevantStatus *regexp.Regexp
+	RequestBodyLimitAction types.BodyLimitAction
 
-	auditLogWriter auditlog.Writer
+	// Request body page file limit
+	RequestBodyLimit int64
 
-	// AuditLogWriterConfig is configuration of audit logging, populated by multiple directives and consumed by
-	// SecAuditLog.
-	AuditLogWriterConfig auditlog.Config
+	ResponseBodyLimitAction types.BodyLimitAction
+
+	// UploadFileLimit is the maximum size of the uploaded file to be stored
+	UploadFileLimit int
+
+	// Request body in memory limit excluding the size of any files being transported in the request.
+	RequestBodyNoFilesLimit int64
+
+	// Defines if rules are going to be evaluated
+	RuleEngine types.RuleEngineStatus
+
+	// Response body memory limit
+	ResponseBodyLimit int64
+
+	// Audit mode status
+	AuditEngine types.AuditEngineStatus
+
+	// UploadFileMode instructs the waf to set the file mode for uploaded files
+	UploadFileMode fs.FileMode
+
+	// If true, transactions will have access to the response body
+	ResponseBodyAccess bool
+
+	// If true, the WAF will store the uploaded files in the UploadDir
+	// directory
+	UploadKeepFiles bool
+
+	// If true, transactions will have access to the request body
+	RequestBodyAccess bool
+
+	// If true WAF engine will fail when remote rules cannot be loaded
+	AbortOnRemoteRulesFail bool
 
 	auditLogWriterInitialized bool
 }

--- a/internal/operators/rbl.go
+++ b/internal/operators/rbl.go
@@ -18,8 +18,8 @@ import (
 const timeout = 500 * time.Millisecond
 
 type rbl struct {
-	service  string
 	resolver *net.Resolver
+	service  string
 }
 
 var _ rules.Operator = (*rbl)(nil)

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -25,14 +25,14 @@ import (
 // TODO(anuraaga): Propagation of config probably should be separated from a directive's options.
 type DirectiveOptions struct {
 	WAF      *corazawaf.WAF
-	Raw      string
-	Opts     string
-	Path     []string
 	Datasets map[string][]string
 
 	// Parser is configuration of the parser, populated by multiple directives and consumed by
 	// directives that parse.
 	Parser ParserConfig
+	Raw    string
+	Opts   string
+	Path   []string
 }
 
 type directive = func(options *DirectiveOptions) error

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -22,11 +22,11 @@ const maxIncludeRecursion = 100
 
 // Parser provides functions to evaluate (compile) SecLang directives
 type Parser struct {
+	root         fs.FS
 	options      *DirectiveOptions
-	currentLine  int
 	currentFile  string
 	currentDir   string
-	root         fs.FS
+	currentLine  int
 	includeCount int
 }
 
@@ -212,14 +212,14 @@ func NewParser(waf *corazawaf.WAF) *Parser {
 }
 
 type ParserConfig struct {
+	Root                        fs.FS
+	ConfigFile                  string
+	ConfigDir                   string
+	WorkingDir                  string
 	DisabledRuleActions         []string
 	DisabledRuleOperators       []string
 	RuleDefaultActions          []string
+	LastLine                    int
 	HasRuleDefaultActions       bool
 	IgnoreRuleCompilationErrors bool
-	LastLine                    int
-	ConfigFile                  string
-	ConfigDir                   string
-	Root                        fs.FS
-	WorkingDir                  string
 }

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -20,10 +20,10 @@ import (
 var defaultActionsPhase2 = "phase:2,log,auditlog,pass"
 
 type ruleAction struct {
+	F     rules.Action
 	Key   string
 	Value string
 	Atype rules.ActionType
-	F     rules.Action
 }
 
 // RuleParser is used to programatically create new rules using seclang formatted strings
@@ -303,12 +303,12 @@ func (p *RuleParser) Rule() *corazawaf.Rule {
 
 // RuleOptions contains the options used to compile a rule
 type RuleOptions struct {
-	WithOperator bool
 	WAF          *corazawaf.WAF
 	ParserConfig ParserConfig
 	Raw          string
 	Directive    string
 	Data         string
+	WithOperator bool
 }
 
 // ParseRule parses a rule from a string

--- a/internal/transformations/normalise_path_win.go
+++ b/internal/transformations/normalise_path_win.go
@@ -145,9 +145,9 @@ func isSlash(c uint8) bool {
 
 type lazybuf struct {
 	path       string
+	volAndPath string
 	buf        []byte
 	w          int
-	volAndPath string
 	volLen     int
 }
 

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -36,8 +36,8 @@ func NewMacro(data string) (Macro, error) {
 
 type macroToken struct {
 	text     string
-	variable variables.RuleVariable
 	key      string
+	variable variables.RuleVariable
 }
 
 // macro is used to create tokenized strings that can be

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -107,9 +107,7 @@ func (m *macro) compile(input string) error {
 			if currentToken.Len() > 0 {
 				// we add the text token
 				m.tokens = append(m.tokens, macroToken{
-					text:     currentToken.String(),
-					variable: variables.Unknown,
-					key:      "",
+					text: currentToken.String(),
 				})
 			}
 			currentToken.Reset()

--- a/macro/macro_test.go
+++ b/macro/macro_test.go
@@ -78,7 +78,7 @@ func TestCompile(t *testing.T) {
 			t.Fatalf("unexpected number of tokens: want %d, have %d", want, have)
 		}
 
-		expectedMacro := macroToken{"tx.count", variables.TX, "count"}
+		expectedMacro := macroToken{text: "tx.count", variable: variables.TX, key: "count"}
 		if want, have := m.tokens[0], expectedMacro; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
@@ -95,27 +95,27 @@ func TestCompile(t *testing.T) {
 			t.Fatalf("unexpected number of tokens: want %d, have %d", want, have)
 		}
 
-		expectedMacro0 := macroToken{"tx.id", variables.TX, "id"}
+		expectedMacro0 := macroToken{text: "tx.id", variable: variables.TX, key: "id"}
 		if want, have := m.tokens[0], expectedMacro0; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
 
-		expectedMacro1 := macroToken{" got ", variables.Unknown, ""}
+		expectedMacro1 := macroToken{text: " got "}
 		if want, have := m.tokens[1], expectedMacro1; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
 
-		expectedMacro2 := macroToken{"tx.count", variables.TX, "count"}
+		expectedMacro2 := macroToken{text: "tx.count", variable: variables.TX, key: "count"}
 		if want, have := m.tokens[2], expectedMacro2; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
 
-		expectedMacro3 := macroToken{" in this transaction and as zero ", variables.Unknown, ""}
+		expectedMacro3 := macroToken{text: " in this transaction and as zero "}
 		if want, have := m.tokens[3], expectedMacro3; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
 
-		expectedMacro4 := macroToken{"tx.0", variables.TX, "0"}
+		expectedMacro4 := macroToken{text: "tx.0", variable: variables.TX, key: "0"}
 		if want, have := m.tokens[4], expectedMacro4; want != have {
 			t.Errorf("unexpected token: want %v, have %v", want, have)
 		}
@@ -125,9 +125,7 @@ func TestCompile(t *testing.T) {
 func TestExpand(t *testing.T) {
 	t.Run("no expansion", func(t *testing.T) {
 		m := &macro{
-			tokens: []macroToken{
-				{"text", variables.Unknown, ""},
-			},
+			tokens: []macroToken{{text: "text"}},
 		}
 
 		if want, have := "text", m.Expand(nil); want != have {

--- a/rules/operator.go
+++ b/rules/operator.go
@@ -7,17 +7,17 @@ import "io/fs"
 
 // OperatorOptions is used to store the options for a rule operator
 type OperatorOptions struct {
-	// Arguments is used to store the operator args
-	Arguments string
-
-	// Path is used to store a list of possible data paths
-	Path []string
 
 	// Root is the root to resolve Path from.
 	Root fs.FS
 
 	// Datasets contains input datasets or dictionaries
 	Datasets map[string][]string
+	// Arguments is used to store the operator args
+	Arguments string
+
+	// Path is used to store a list of possible data paths
+	Path []string
 }
 
 // Operator interface is used to define rule @operators

--- a/testing/engine.go
+++ b/testing/engine.go
@@ -17,39 +17,40 @@ import (
 // Test represents a unique transaction within
 // a WAF instance for a test case
 type Test struct {
+	// Expected contains the expected result of the test
+	ExpectedOutput profile.ExpectedOutput
 	// waf contains a waf instance pointer
 	waf coraza.WAF
 	// transaction contains the current transaction
 	transaction types.Transaction
-	magic       bool
-	Name        string
-	body        string
+	// ResponseHeaders contains the headers of the response
+	ResponseHeaders map[string]string
+	// RequestHeaders contains the headers of the request
+	RequestHeaders map[string]string
+	// RequestMethod contains the method of the request
+	RequestMethod string
+	// RequestURI contains the uri of the request
+	RequestURI string
 
 	// public variables
 	// RequestAddress contains the address of the request
 	RequestAddress string
-	// RequestPort contains the port of the request
-	RequestPort int
-	// RequestURI contains the uri of the request
-	RequestURI string
-	// RequestMethod contains the method of the request
-	RequestMethod string
 	// RequestProtocol contains the protocol of the request
 	RequestProtocol string
-	// RequestHeaders contains the headers of the request
-	RequestHeaders map[string]string
-	// ResponseHeaders contains the headers of the response
-	ResponseHeaders map[string]string
-	// ResponseCode contains the response code of the response
-	ResponseCode int
+	body            string
+
+	Name string
 	// ResponseProtocol contains the protocol of the response
 	ResponseProtocol string
 	// ServerAddress contains the address of the server
 	ServerAddress string
+	// RequestPort contains the port of the request
+	RequestPort int
+	// ResponseCode contains the response code of the response
+	ResponseCode int
 	// ServerPort contains the port of the server
 	ServerPort int
-	// Expected contains the expected result of the test
-	ExpectedOutput profile.ExpectedOutput
+	magic      bool
 }
 
 // SetWAF sets the waf instance pointer

--- a/testing/profile/profile.go
+++ b/testing/profile/profile.go
@@ -7,21 +7,21 @@ package profile
 type Meta struct {
 	Author      string `yaml:"author,omitempty"`
 	Description string `yaml:"description,omitempty"`
-	Enabled     bool   `yaml:"enabled,omitempty"`
 	Name        string `yaml:"name,omitempty"`
+	Enabled     bool   `yaml:"enabled,omitempty"`
 }
 
 // StageInput contains the input data for tests
 type StageInput struct {
+	Headers        map[string]string `yaml:"headers,omitempty"`
 	DestAddr       string            `yaml:"dest_addr,omitempty"`
-	Port           int               `yaml:"port,omitempty"`
 	Method         string            `yaml:"method,omitempty"`
 	URI            string            `yaml:"uri,omitempty"`
 	Version        string            `yaml:"version,omitempty"`
 	Data           string            `yaml:"data,omitempty"` // Accepts array or string
-	Headers        map[string]string `yaml:"headers,omitempty"`
-	RawRequest     []byte            `yaml:"raw_request,omitempty"`
 	EncodedRequest string            `yaml:"encoded_request,omitempty"`
+	RawRequest     []byte            `yaml:"raw_request,omitempty"`
+	Port           int               `yaml:"port,omitempty"`
 	StopMagic      bool              `yaml:"stop_magic,omitempty"`
 }
 
@@ -34,8 +34,8 @@ type Stage struct {
 // SubStage contains the input data and expected output
 // for tests
 type SubStage struct {
-	Input  StageInput     `yaml:"input,omitempty"`
 	Output ExpectedOutput `yaml:"output,omitempty"`
+	Input  StageInput     `yaml:"input,omitempty"`
 }
 
 // Test contains the title and test stages
@@ -49,31 +49,31 @@ type Test struct {
 // It contains metadata and instructions for a test
 // It requires more documentation
 type Profile struct {
-	Rules string `yaml:"rules,omitempty"`
-	Pass  bool   `yaml:"pass,omitempty"`
 	Meta  Meta   `yaml:"meta,omitempty"`
+	Rules string `yaml:"rules,omitempty"`
 	Tests []Test `yaml:"tests,omitempty"`
+	Pass  bool   `yaml:"pass,omitempty"`
 }
 
 // ExpectedOutput contains the expected output results for a test
 type ExpectedOutput struct {
-	Headers           map[string]string     `yaml:"headers,omitempty"`
 	Data              interface{}           `yaml:"data,omitempty"` // Accepts array or string
+	Status            interface{}           `yaml:"status,omitempty"`
+	Headers           map[string]string     `yaml:"headers,omitempty"`
+	Interruption      *ExpectedInterruption `yaml:"interruption,omitempty"`
 	LogContains       string                `yaml:"log_contains,omitempty"`
 	NoLogContains     string                `yaml:"no_log_contains,omitempty"`
-	ExpectError       bool                  `yaml:"expect_error,omitempty"`
 	TriggeredRules    []int                 `yaml:"triggered_rules,omitempty"`
 	NonTriggeredRules []int                 `yaml:"non_triggered_rules,omitempty"`
-	Status            interface{}           `yaml:"status,omitempty"`
-	Interruption      *ExpectedInterruption `yaml:"interruption,omitempty"`
+	ExpectError       bool                  `yaml:"expect_error,omitempty"`
 }
 
 // ExpectedInterruption contains the expected interruption results for a test
 type ExpectedInterruption struct {
-	RuleID int    `yaml:"rule_id,omitempty"`
 	Action string `yaml:"action,omitempty"`
-	Status int    `yaml:"status,omitempty"`
 	Data   string `yaml:"data,omitempty"`
+	RuleID int    `yaml:"rule_id,omitempty"`
+	Status int    `yaml:"status,omitempty"`
 }
 
 // Profiles is a map of registered profiles used by test runners

--- a/types/waf.go
+++ b/types/waf.go
@@ -140,17 +140,17 @@ const (
 //		return show403()
 //	}
 type Interruption struct {
-	// Rule that caused the interruption
-	RuleID int
 
 	// drop, deny, redirect
 	Action string
 
-	// Force this status code
-	Status int
-
 	// Parameters used by proxy and redirect
 	Data string
+	// Rule that caused the interruption
+	RuleID int
+
+	// Force this status code
+	Status int
 }
 
 // BodyBufferOptions is used to feed a coraza.BodyBuffer with parameters


### PR DESCRIPTION
This PR detect structs that would use less memory if their fields were sorted.

```shell
$betteralign -apply ./...   
                               
~/Workspace/source/github.com/corazawaf/coraza/debuglog/default.go:14:19: struct with 24 pointer bytes could be 16
~/Workspace/source/github.com/corazawaf/coraza/debuglog/default.go:90:20: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/types/waf.go:142:19: struct with 40 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:24:18: struct with 128 pointer bytes could be 96
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:46:26: struct with 40 pointer bytes could be 32
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:78:30: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:94:18: struct with 152 pointer bytes could be 104
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:112:16: struct with 104 pointer bytes could be 88
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:129:27: struct with 64 pointer bytes could be 56
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:139:23: struct with 24 pointer bytes could be 16
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:146:24: struct with 32 pointer bytes could be 16
~/Workspace/source/github.com/corazawaf/coraza/auditlog/auditlog.go:152:20: struct with 200 pointer bytes could be 104
~/Workspace/source/github.com/corazawaf/coraza/auditlog/concurrent_writer.go:19:23: struct with 64 pointer bytes could be 48
~/Workspace/source/github.com/corazawaf/coraza/auditlog/logger.go:13:13: struct of size 56 could be 48
~/Workspace/source/github.com/corazawaf/coraza/auditlog/serial_writer.go:16:19: struct with 104 pointer bytes could be 80
~/Workspace/source/github.com/corazawaf/coraza/rules/operator.go:9:22: struct with 64 pointer bytes could be 48
~/Workspace/source/github.com/corazawaf/coraza/internal/corazarules/rule.go:12:19: struct with 160 pointer bytes could be 104
~/Workspace/source/github.com/corazawaf/coraza/internal/corazarules/rule_match.go:17:16: struct with 64 pointer bytes could be 56
~/Workspace/source/github.com/corazawaf/coraza/internal/corazarules/rule_match.go:52:18: struct with 144 pointer bytes could be 120
~/Workspace/source/github.com/corazawaf/coraza/internal/collections/named.go:88:27: struct with 16 pointer bytes could be 8
~/Workspace/source/github.com/corazawaf/coraza/macro/macro.go:37:17: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/body_buffer.go:19:17: struct with 48 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/body_buffer.go:96:23: struct with 16 pointer bytes could be 8
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/rule.go:24:23: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/rule.go:45:28: struct with 24 pointer bytes could be 16
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/rule.go:58:25: struct with 40 pointer bytes could be 32
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/rule.go:94:11: struct of size 328 could be 320
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/transaction.go:40:18: struct of size 944 could be 912
~/Workspace/source/github.com/corazawaf/coraza/internal/corazawaf/waf.go:34:10: struct of size 472 could be 448
~/Workspace/source/github.com/corazawaf/coraza/internal/transformations/normalise_path_win.go:146:14: struct with 56 pointer bytes could be 40
~/Workspace/source/github.com/corazawaf/coraza/internal/actions/ctl.go:46:12: struct with 40 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/actions/expirevar.go:15:18: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/actions/initcol.go:13:16: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/actions/setenv.go:15:15: struct with 32 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/internal/operators/rbl.go:20:10: struct with 24 pointer bytes could be 16
~/Workspace/source/github.com/corazawaf/coraza/internal/seclang/directives.go:26:23: struct with 216 pointer bytes could be 208
~/Workspace/source/github.com/corazawaf/coraza/internal/seclang/parser.go:24:13: struct with 64 pointer bytes could be 48
~/Workspace/source/github.com/corazawaf/coraza/internal/seclang/parser.go:214:19: struct with 144 pointer bytes could be 120
~/Workspace/source/github.com/corazawaf/coraza/internal/seclang/rule_parser.go:22:17: struct with 56 pointer bytes could be 40
~/Workspace/source/github.com/corazawaf/coraza/internal/seclang/rule_parser.go:305:18: struct with 208 pointer bytes could be 200
~/Workspace/source/github.com/corazawaf/coraza/config.go:102:16: struct of size 136 could be 128
~/Workspace/source/github.com/corazawaf/coraza/config.go:208:21: struct with 48 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/http/interceptor.go:21:20: struct with 48 pointer bytes could be 40
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:7:11: struct with 48 pointer bytes could be 40
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:15:17: struct with 128 pointer bytes could be 112
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:36:15: struct with 280 pointer bytes could be 264
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:51:14: struct with 88 pointer bytes could be 80
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:59:21: struct with 136 pointer bytes could be 112
~/Workspace/source/github.com/corazawaf/coraza/testing/profile/profile.go:72:27: struct with 40 pointer bytes could be 24
~/Workspace/source/github.com/corazawaf/coraza/testing/engine.go:19:11: struct with 344 pointer bytes could be 304
```

PENDING: benchmarks comparison

cc @anuraaga 

Question: shall we include this tool in the format task?