### PR TITLE
fix: adds full support for ruleRemoveById.

### DIFF
--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -204,7 +204,7 @@ func (a *ctlFn) Evaluate(_ rules.RuleMetadata, txS rules.TransactionState) {
 				return
 			}
 			for _, id := range ran {
-				tx.RemoveRuleTargetByID(id, a.collection, a.colKey)
+				tx.RemoveRuleByID(id)
 			}
 		}
 	case ctlRuleRemoveByMsg:

--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -182,16 +182,31 @@ func (a *ctlFn) Evaluate(_ rules.RuleMetadata, txS rules.TransactionState) {
 		}
 		tx.RuleEngine = re
 	case ctlRuleRemoveByID:
-		id, err := strconv.Atoi(a.value)
-		if err != nil {
-			tx.DebugLogger().Error().
-				Str("ctl", "RuleRemoveByID").
-				Str("value", a.value).
-				Err(err).
-				Msg("Invalid rule ID")
-			return
+		if idx := strings.Index(a.value, "-"); idx == -1 {
+			id, err := strconv.Atoi(a.value)
+			if err != nil {
+				tx.DebugLogger().Error().
+					Str("ctl", "RuleRemoveByID").
+					Str("value", a.value).
+					Err(err).
+					Msg("Invalid rule ID")
+				return
+			}
+
+			tx.RemoveRuleByID(id)
+		} else {
+			ran, err := rangeToInts(tx.WAF.Rules.GetRules(), a.value)
+			if err != nil {
+				tx.DebugLogger().Error().
+					Str("ctl", "RuleRemoveByID").
+					Err(err).
+					Msg("Invalid range")
+				return
+			}
+			for _, id := range ran {
+				tx.RemoveRuleTargetByID(id, a.collection, a.colKey)
+			}
 		}
-		tx.RemoveRuleByID(id)
 	case ctlRuleRemoveByMsg:
 		rules := tx.WAF.Rules.GetRules()
 		for _, r := range rules {
@@ -374,6 +389,10 @@ func rangeToInts(rules []corazawaf.Rule, input string) ([]int, error) {
 		end, err = strconv.Atoi(in1)
 		if err != nil {
 			return nil, err
+		}
+
+		if start > end {
+			return nil, errors.New("invalid range, start > end")
 		}
 	} else {
 		id, err := strconv.Atoi(input)

--- a/internal/actions/ctl_test.go
+++ b/internal/actions/ctl_test.go
@@ -171,10 +171,21 @@ func TestCtl(t *testing.T) {
 		"ruleRemoveById": {
 			input: "ruleRemoveById=123",
 		},
+		"ruleRemoveById range": {
+			input: "ruleRemoveById=1-3",
+		},
 		"ruleRemoveById incorrect": {
 			input: "ruleRemoveById=W",
 			checkTX: func(t *testing.T, tx *corazawaf.Transaction, logEntry string) {
 				if wantToContain, have := "[ERROR] Invalid rule ID", logEntry; !strings.Contains(have, wantToContain) {
+					t.Errorf("Failed to log entry, want to contain %q, have %q", wantToContain, have)
+				}
+			},
+		},
+		"ruleRemoveById range incorrect": {
+			input: "ruleRemoveById=a-2",
+			checkTX: func(t *testing.T, tx *corazawaf.Transaction, logEntry string) {
+				if wantToContain, have := "[ERROR] Invalid range", logEntry; !strings.Contains(have, wantToContain) {
 					t.Errorf("Failed to log entry, want to contain %q, have %q", wantToContain, have)
 				}
 			},

--- a/internal/actions/ctl_test.go
+++ b/internal/actions/ctl_test.go
@@ -395,6 +395,7 @@ func TestParseCtl(t *testing.T) {
 		{"forceResponseBodyVariable=On", ctlForceResponseBodyVariable, "On", variables.Unknown, ""},
 		{"ruleEngine=On", ctlRuleEngine, "On", variables.Unknown, ""},
 		{"ruleRemoveById=1", ctlRuleRemoveByID, "1", variables.Unknown, ""},
+		{"ruleRemoveById=1-9", ctlRuleRemoveByID, "1-9", variables.Unknown, ""},
 		{"ruleRemoveByMsg=MY_MSG", ctlRuleRemoveByMsg, "MY_MSG", variables.Unknown, ""},
 		{"ruleRemoveByTag=MY_TAG", ctlRuleRemoveByTag, "MY_TAG", variables.Unknown, ""},
 		{"ruleRemoveTargetByMsg=MY_MSG;ARGS:user", ctlRuleRemoveTargetByMsg, "MY_MSG", variables.Args, "user"},

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -64,7 +64,7 @@ func (rg *RuleGroup) FindByID(id int) *Rule {
 	return nil
 }
 
-// DeleteByID removes a rule by it's Id
+// DeleteByID removes a rule by its ID
 func (rg *RuleGroup) DeleteByID(id int) {
 	for i, r := range rg.rules {
 		if r.ID_ == id {
@@ -72,6 +72,17 @@ func (rg *RuleGroup) DeleteByID(id int) {
 			return
 		}
 	}
+}
+
+// DeleteByRange removes rules by their ID in a range
+func (rg *RuleGroup) DeleteByRange(start, end int) {
+	var kept []Rule
+	for _, r := range rg.rules {
+		if r.ID_ < start || r.ID_ > end {
+			kept = append(kept, r)
+		}
+	}
+	rg.rules = kept
 }
 
 // DeleteByMsg deletes rules with the given message.

--- a/internal/corazawaf/rulegroup_test.go
+++ b/internal/corazawaf/rulegroup_test.go
@@ -9,14 +9,18 @@ import (
 	"github.com/corazawaf/coraza/v3/macro"
 )
 
-func TestRG(t *testing.T) {
+func newTestRule(id int) *Rule {
 	r := NewRule()
-	macroMsg, _ := macro.NewMacro("test")
-	r.Msg = macroMsg
-	r.ID_ = 1
+	r.ID_ = id
+	r.Msg, _ = macro.NewMacro("test")
 	r.Tags_ = []string{
 		"test",
 	}
+	return r
+}
+
+func TestRuleGroupDeleteByTag(t *testing.T) {
+	r := newTestRule(1)
 
 	rg := NewRuleGroup()
 	if err := rg.Add(r); err != nil {
@@ -31,7 +35,12 @@ func TestRG(t *testing.T) {
 	if rg.Count() != 0 {
 		t.Error("Failed to remove rule from rulegroup")
 	}
+}
 
+func TestRuleGroupDeleteByMsg(t *testing.T) {
+	r := newTestRule(1)
+
+	rg := NewRuleGroup()
 	if err := rg.Add(r); err != nil {
 		t.Error("Failed to add rule to rulegroup")
 	}
@@ -43,5 +52,36 @@ func TestRG(t *testing.T) {
 	rg.DeleteByMsg("test")
 	if rg.Count() != 0 {
 		t.Error("Failed to remove rule from rulegroup")
+	}
+}
+
+func TestRuleGroupDeleteByID(t *testing.T) {
+	var (
+		r1 = newTestRule(1)
+		r2 = newTestRule(2)
+		r3 = newTestRule(3)
+		r4 = newTestRule(4)
+		r5 = newTestRule(5)
+	)
+
+	rg := NewRuleGroup()
+	for _, r := range []*Rule{r1, r2, r3, r4, r5} {
+		if err := rg.Add(r); err != nil {
+			t.Fatalf("Failed to add rule to rulegroup: %s", err.Error())
+		}
+	}
+
+	if rg.Count() != 5 {
+		t.Fatal("Unexpected rules in the rulegroup")
+	}
+
+	rg.DeleteByID(1)
+	if rg.Count() != 4 {
+		t.Fatal("Unexpected remaining rules in the rulegroup")
+	}
+
+	rg.DeleteByRange(2, 4)
+	if rg.Count() != 1 || rg.GetRules()[0].ID() != 5 {
+		t.Fatal("Unexpected remaining rule in the rulegroup")
 	}
 }

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -164,6 +164,10 @@ func TestDirectives(t *testing.T) {
 		},
 		"SecRuleRemoveById": {
 			{"", expectErrorOnDirective},
+			{"a", expectErrorOnDirective},
+			{"1-a", expectErrorOnDirective},
+			{"a-2", expectErrorOnDirective},
+			{"2-1", expectErrorOnDirective},
 			{"1", expectNoErrorOnDirective},
 			{"1 2", expectNoErrorOnDirective},
 			{"1 2 3-4", expectNoErrorOnDirective},

--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -102,6 +102,7 @@ func TestSecDataset(t *testing.T) {
 }
 
 var expectErrorOnDirective func(*corazawaf.WAF) bool = nil
+var expectNoErrorOnDirective func(*corazawaf.WAF) bool = func(*corazawaf.WAF) bool { return true }
 
 func TestDirectives(t *testing.T) {
 	type directiveCase struct {
@@ -163,6 +164,9 @@ func TestDirectives(t *testing.T) {
 		},
 		"SecRuleRemoveById": {
 			{"", expectErrorOnDirective},
+			{"1", expectNoErrorOnDirective},
+			{"1 2", expectNoErrorOnDirective},
+			{"1 2 3-4", expectNoErrorOnDirective},
 		},
 		"SecResponseBodyMimeTypesClear": {
 			{"", func(w *corazawaf.WAF) bool { return len(w.ResponseBodyMimeTypes) == 0 }},


### PR DESCRIPTION
Currently ctl:RuleRemoveById and SecRuleRemoveById were focusing in a single value only, however for retrocompatibility with modsec we should accept many values and they can be either ID or range. See:
- https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v3.x%29\#user-content-SecRuleRemoveById
- https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v3.x%29\#user-content-ctl

This PR fixes that behaviour and allows this feature to be supported https://github.com/coreruleset/modsecurity-crs-docker/pull/119

Ping @M4tteoP @fzipi 