### PR TITLE
Remove Single.Set from API for now

### DIFF
--- a/bodyprocessors/multipart.go
+++ b/bodyprocessors/multipart.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/environment"
 	"github.com/corazawaf/coraza/v3/rules"
 )
@@ -88,7 +89,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v rules.Tran
 			totalSize += int64(len(data))
 			postCol.Add(p.FormName(), string(data))
 		}
-		filesCombinedSizeCol.Set(fmt.Sprintf("%d", totalSize))
+		filesCombinedSizeCol.(*collections.Single).Set(fmt.Sprintf("%d", totalSize))
 	}
 	return nil
 }

--- a/bodyprocessors/urlencoded.go
+++ b/bodyprocessors/urlencoded.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/url"
 	"github.com/corazawaf/coraza/v3/rules"
 )
@@ -27,8 +28,8 @@ func (*urlencodedBodyProcessor) ProcessRequest(reader io.Reader, v rules.Transac
 	for k, vs := range values {
 		argsCol.Set(k, vs)
 	}
-	v.RequestBody().Set(b)
-	v.RequestBodyLength().Set(strconv.Itoa(len(b)))
+	v.RequestBody().(*collections.Single).Set(b)
+	v.RequestBodyLength().(*collections.Single).Set(strconv.Itoa(len(b)))
 	return nil
 }
 

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -27,9 +27,6 @@ type Single interface {
 
 	// Get returns the value of this Single
 	Get() string
-
-	// Set sets the value of this Single
-	Set(string)
 }
 
 // Keyed is a Collection with elements that can be selected by key.

--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/debuglog"
+	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/rules"
@@ -164,7 +165,7 @@ func (a *ctlFn) Evaluate(_ rules.RuleMetadata, txS rules.TransactionState) {
 		}
 	case ctlRequestBodyProcessor:
 		if tx.LastPhase() <= types.PhaseRequestHeaders {
-			tx.Variables().RequestBodyProcessor().Set(strings.ToUpper(a.value))
+			tx.Variables().RequestBodyProcessor().(*collections.Single).Set(strings.ToUpper(a.value))
 		} else {
 			tx.DebugLogger().Warn().
 				Str("ctl", "RequestBodyProcessor").
@@ -280,7 +281,7 @@ func (a *ctlFn) Evaluate(_ rules.RuleMetadata, txS rules.TransactionState) {
 			// TODO(jcchavezs): Shall we validate such body processor exists or is it
 			// too ambitious as plugins might register their own at some point in the
 			// lifecycle which does not have to happen before this.
-			tx.Variables().ResponseBodyProcessor().Set(strings.ToUpper(a.value))
+			tx.Variables().ResponseBodyProcessor().(*collections.Single).Set(strings.ToUpper(a.value))
 		} else {
 			tx.DebugLogger().Warn().
 				Str("ctl", "ResponseBodyLimit").

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1326,7 +1326,7 @@ func TestResponseBodyForceProcessing(t *testing.T) {
 	waf.ResponseBodyAccess = true
 	tx := waf.NewTransaction()
 	tx.ForceResponseBodyVariable = true
-	tx.variables.ResponseBodyProcessor().Set("JSON")
+	tx.variables.ResponseBodyProcessor().(*collections.Single).Set("JSON")
 	tx.ProcessRequestHeaders()
 	if _, err := tx.ProcessRequestBody(); err != nil {
 		t.Fatal(err)
@@ -1349,7 +1349,7 @@ func TestForceRequestBodyOverride(t *testing.T) {
 	waf.RequestBodyAccess = true
 	tx := waf.NewTransaction()
 	tx.ForceRequestBodyVariable = true
-	tx.variables.RequestBodyProcessor().Set("JSON")
+	tx.variables.RequestBodyProcessor().(*collections.Single).Set("JSON")
 	tx.ProcessRequestHeaders()
 	if _, _, err := tx.WriteRequestBody([]byte("foo=bar&baz=qux")); err != nil {
 		t.Errorf("Failed to write request body: %v", err)


### PR DESCRIPTION
`Single` exposes `Set` mostly for updating variables in body processors, which are extensible via the experimental plugins API. However, the same type is used for many variables such as `REQUEST_LINE`, etc, which are immutable pieces of the request and should not have mutation exposed. Similarly, while `DURATION` is currently not implemented, it should be implemented with something that just returns a duration when queried, not using a setter.

To allow this to happen, this for now removes `Set` and switches current usage to internal types. This prevents body processor plugins from doing it - but I think we should decide which variables are mutable by plugins and then expose setting for them rather than having it for all variables.

`Map` has a similar issue (e.g., `REQUEST_HEADERS` shouldn't mutate), but I have limited this change to just single for now to confirm the approach.