### PR TITLE
fix: synthesizes Transfer-Encoding header inside the transaction

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -53,6 +53,12 @@ func processRequest(tx types.Transaction, req *http.Request) (*types.Interruptio
 		tx.SetServerName(req.Host)
 	}
 
+	// Transfer-Encoding header is removed by go/http
+	// We manually add it to make rules relying on it work (E.g. CRS rule 920171)
+	if req.TransferEncoding != nil {
+		tx.AddRequestHeader("Transfer-Encoding", req.TransferEncoding[0])
+	}
+
 	in = tx.ProcessRequestHeaders()
 	if in != nil {
 		return in, nil

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -88,8 +88,6 @@ func TestProcessRequestMultipart(t *testing.T) {
 func TestProcessRequestTransferEncodingChunked(t *testing.T) {
 	waf, _ := coraza.NewWAF(coraza.NewWAFConfig().
 		WithDirectives(`
-# This is a comment
-SecDebugLogLevel 9
 SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" "id:1,phase:1,deny"
 `))
 	tx := waf.NewTransaction()
@@ -102,9 +100,11 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" "id:1,phase:1,deny"
 		t.Fatal(err)
 	}
 	if it == nil {
-		t.Fatal("expected interruption")
+		t.Fatal("Expected interruption")
 	}
-
+	if it.RuleID != 1 {
+		t.Fatalf("Expected rule 1 to be triggered, got rule %d", it.RuleID)
+	}
 	if err := tx.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/testing/coreruleset/.ftw.yml
+++ b/testing/coreruleset/.ftw.yml
@@ -5,8 +5,6 @@ testoverride:
     920100-5: 'Invalid uri, Coraza not reached - 404 page not found'
     920100-8: 'Go/http allows a colon in the path. Test expects status 400 or 403 (Apache behaviour)'
     920170-3: 'HEAD request with data. Go/http does not allow it - 400 Bad Request'
-    920171-2: 'Go/http removes the Transfer-Encoding header after parsing it (https://github.com/golang/go/blob/master/src/net/http/transfer.go#L631). The test looks for it'
-    920171-3: 'Go/http removes the Transfer-Encoding header after parsing it (https://github.com/golang/go/blob/master/src/net/http/transfer.go#L631). The test looks for it'
     920270-4: 'Rule works, log contains 920270. Test expects status 400 (Apache behaviour)'
     920272-5: 'Rule works, log contains 920272. Test expects status 400 (Apache behaviour)'
     920290-1: 'Rule works, log contains 920290. Test expects status 400 (Apache behaviour)'


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza-caddy/issues/53#issuecomment-1500661146 reasoning.
The Go library removes the `Transfer-Encoding` header (see [here](https://github.com/golang/go/blob/master/src/net/http/transfer.go#L631)), therefore rules looking at it are not working.
This PR proposes to read the `TransferEncoding` (part of the http.Request) and populate the header inside Coraza accordingly.
It fixes `920171-2` and `920171-3`.

If it gets merged, I will follow up updating also the caddy connector (it is now sharing the same middleware) to fix https://github.com/corazawaf/coraza-caddy/issues/53.