### PR TITLE
Export http helper functions

### DIFF
--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -43,7 +43,7 @@ func (i *rwInterceptor) WriteHeader(statusCode int) {
 
 	i.statusCode = statusCode
 	if it := i.tx.ProcessResponseHeaders(statusCode, i.proto); it != nil {
-		i.statusCode = obtainStatusCodeFromInterruptionOrDefault(it, i.statusCode)
+		i.statusCode = ObtainStatusCodeFromInterruptionOrDefault(it, i.statusCode)
 		i.flushWriteHeader()
 		return
 	}
@@ -109,13 +109,13 @@ func (i *rwInterceptor) Header() http.Header {
 
 var _ http.ResponseWriter = (*rwInterceptor)(nil)
 
-// wrap wraps the interceptor into a response writer that also preserves
+// Wrap wraps the interceptor into a response writer that also preserves
 // the http interfaces implemented by the original response writer to avoid
 // the observer effect. It also returns the response processor which takes care
 // of the response body copyback from the transaction buffer.
 //
 // Heavily inspired in https://github.com/openzipkin/zipkin-go/blob/master/middleware/http/server.go#L218
-func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
+func Wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	http.ResponseWriter,
 	func(types.Transaction, *http.Request) error,
 ) { // nolint:gocyclo
@@ -136,7 +136,7 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 				i.flushWriteHeader()
 				return err
 			} else if it != nil {
-				i.overrideWriteHeader(obtainStatusCodeFromInterruptionOrDefault(it, i.statusCode))
+				i.overrideWriteHeader(ObtainStatusCodeFromInterruptionOrDefault(it, i.statusCode))
 				i.flushWriteHeader()
 				return nil
 			}

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -24,7 +24,7 @@ func TestWriteHeader(t *testing.T) {
 	tx := waf.NewTransaction()
 	req, _ := http.NewRequest("GET", "", nil)
 	res := httptest.NewRecorder()
-	rw, responseProcessor := wrap(res, req, tx)
+	rw, responseProcessor := Wrap(res, req, tx)
 	rw.WriteHeader(204)
 	rw.WriteHeader(205)
 	// although we called WriteHeader, status code should be applied until

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -32,7 +32,7 @@ func TestProcessRequest(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://www.coraza.io/test", strings.NewReader("test=456"))
 	waf, _ := coraza.NewWAF(coraza.NewWAFConfig())
 	tx := waf.NewTransaction().(*corazawaf.Transaction)
-	if _, err := processRequest(tx, req); err != nil {
+	if _, err := ProcessRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
 	if tx.Variables().RequestMethod().Get() != "POST" {
@@ -48,7 +48,7 @@ func TestProcessRequestEngineOff(t *testing.T) {
 	// TODO(jcchavezs): Shall we make RuleEngine a first class method in WAF config?
 	waf, _ := coraza.NewWAF(coraza.NewWAFConfig().WithDirectives("SecRuleEngine OFF"))
 	tx := waf.NewTransaction().(*corazawaf.Transaction)
-	if _, err := processRequest(tx, req); err != nil {
+	if _, err := ProcessRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
 	if tx.Variables().RequestMethod().Get() != "POST" {
@@ -66,7 +66,7 @@ func TestProcessRequestMultipart(t *testing.T) {
 
 	req := createMultipartRequest(t)
 
-	if _, err := processRequest(tx, req); err != nil {
+	if _, err := ProcessRequest(tx, req); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ SecRule &REQUEST_HEADERS:Transfer-Encoding "!@eq 0" "id:1,phase:1,deny"
 	req, _ := http.NewRequest("GET", "https://www.coraza.io/test", nil)
 	req.TransferEncoding = []string{"chunked"}
 
-	it, err := processRequest(tx, req)
+	it, err := ProcessRequest(tx, req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,7 +187,7 @@ func TestDirectiveSecAuditLog(t *testing.T) {
 		t.Errorf("Description HTTP request parsing failed")
 	}
 
-	_, err = processRequest(tx, req)
+	_, err = ProcessRequest(tx, req)
 	if err != nil {
 		t.Errorf("Failed to load the HTTP request")
 	}
@@ -504,7 +504,7 @@ func TestObtainStatusCodeFromInterruptionOrDefault(t *testing.T) {
 	for name, tCase := range tCases {
 		t.Run(name, func(t *testing.T) {
 			want := tCase.expectedCode
-			have := obtainStatusCodeFromInterruptionOrDefault(&types.Interruption{
+			have := ObtainStatusCodeFromInterruptionOrDefault(&types.Interruption{
 				Status: tCase.interruptionCode,
 				Action: tCase.interruptionAction,
 			}, tCase.defaultCode)


### PR DESCRIPTION
The http handler wrapper is great, but when compiling a custom transaction flow doesn't allow access to `ProcessRequest` and `ProcessResponse` anymore. The wrapper itself is cool, but in a lot of cases access to the actual transaction flow would be required. An example would be taking actions if an interruption occurred. e.g. producing metrics, notifying something, etc.

So in general to have an easier time writing a custom, wrapper-like flow with the nice `Process` helpers, would be great to have them exported again.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: