### PR TITLE
registers pmFromDataset, fixes Dataset propagation, adds tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Go build tags can tweak certain functionality at compile-time. These are for adv
 have compatibility guarantees across minor versions - use with care.
 
 - coraza.disabled_operators.* - excludes the specified operator from compilation. Particularly useful if overriding
-the operator with `operators.Register` to reduce binary size / startup overhead.
+the operator with `plugins.RegisterOperator` to reduce binary size / startup overhead.
 - `coraza.rule.multiphase_valuation` - enables evaluation of rule variables in the phases that they are ready, not
 only the phase the rule is defined for.
 

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -123,7 +123,7 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	i := &rwInterceptor{w: w, tx: tx, proto: r.Proto, statusCode: 200}
 
 	responseProcessor := func(tx types.Transaction, r *http.Request) error {
-		// We look for interruptions triggered at phase 4 (response headers)
+		// We look for interruptions triggered at phase 3 (response headers)
 		// and during writing the response body. If so, response status code
 		// has been sent over the flush already.
 		if tx.IsInterrupted() {

--- a/internal/operators/pm_from_dataset.go
+++ b/internal/operators/pm_from_dataset.go
@@ -28,3 +28,7 @@ func newPMFromDataset(options plugintypes.OperatorOptions) (plugintypes.Operator
 
 	return &pm{matcher: builder.Build(dataset)}, nil
 }
+
+func init() {
+	Register("pmFromDataset", newPMFromDataset)
+}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -181,6 +181,7 @@ func directiveSecRule(options *DirectiveOptions) error {
 		Raw:          options.Raw,
 		Directive:    "SecRule",
 		Data:         options.Opts,
+		Datasets:     options.Datasets,
 	})
 	if err != nil && !ignoreErrors {
 		return err

--- a/testing/engine/operators_with_dataset.go
+++ b/testing/engine/operators_with_dataset.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"github.com/corazawaf/coraza/v3/testing/profile"
+)
+
+var _ = profile.RegisterProfile(profile.Profile{
+	Meta: profile.Meta{
+		Author:      "M4tteoP",
+		Description: "Test if operators with datasets works",
+		Enabled:     true,
+		Name:        "operators_with_datasets.yaml",
+	},
+	Tests: []profile.Test{
+		{
+			Title: "operators with dataset",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI: "/uri2",
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules: []int{1, 2},
+						},
+					},
+				},
+			},
+		},
+	},
+	Rules: `
+	SecDataset pm_dataset ` + "`" + `
+	uri1
+	uri2
+	` + "`" + `
+	SecDataset ip_dataset ` + "`" + `
+	127.0.0.1
+	` + "`" + `
+SecRule REQUEST_URI "@pmFromDataset pm_dataset" "id:1,log,phase:1,pass,msg:'Match pm_dataset'"
+SecRule REMOTE_ADDR "@ipMatchFromDataset ip_dataset" "id:2,log,phase:1,pass,msg:'Match ip_dataset'"
+`,
+})


### PR DESCRIPTION
This PR proses to:
- Register `pmFromDataset` operator. It has been added alongside ipMatchFromDataset, the latter is properly registered, but not the first. I guess we just forgot it, I think that it is still a valuable operator.
- Fixes `options.Datasets` propagation: Inside pmFromDataset and ipMatchFromDataset the Datasets slice was always ending to be empty resulting in an error not being able to find the dataset.
- Adds `operators_with_dataset` tests for both pmFromDataset and ipMatchFromDataset.