### PR TITLE
fix: aligns multimatch to modsec behavior

### DIFF
--- a/experimental/plugins/plugintypes/transformation.go
+++ b/experimental/plugins/plugintypes/transformation.go
@@ -8,4 +8,4 @@ package plugintypes
 // If a transformation fails to run it will return the same string
 // and an error, errors are only used for logging, it won't stop
 // the execution of the rule
-type Transformation = func(input string) (string, error)
+type Transformation = func(input string) (string, bool, error)

--- a/experimental/plugins/transformations_test.go
+++ b/experimental/plugins/transformations_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestTransformation(t *testing.T) {
 	t.Run("get existing transformation", func(t *testing.T) {
-		transformation := func(input string) (string, error) {
-			return "", nil
+		transformation := func(input string) (string, bool, error) {
+			return "", false, nil
 		}
 
 		plugins.RegisterTransformation("custom_transformation", transformation)

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -494,16 +494,20 @@ func (r *Rule) executeOperator(data string, tx *Transaction) (result bool) {
 }
 
 func (r *Rule) executeTransformationsMultimatch(value string) ([]string, []error) {
+	// The original value will be evaluated
 	res := []string{value}
 	var errs []error
-	var err error
 	for _, t := range r.transformations {
-		value, err = t.Function(value)
+		transformedValue, err := t.Function(value)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		res = append(res, value)
+		// Every time a transformation generates a new value different from the previous one, the new value is collected to be evaluated
+		if transformedValue != value {
+			res = append(res, transformedValue)
+			value = transformedValue
+		}
 	}
 	return res, errs
 }

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -498,13 +498,13 @@ func (r *Rule) executeTransformationsMultimatch(value string) ([]string, []error
 	res := []string{value}
 	var errs []error
 	for _, t := range r.transformations {
-		transformedValue, err := t.Function(value)
+		transformedValue, changed, err := t.Function(value)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
 		// Every time a transformation generates a new value different from the previous one, the new value is collected to be evaluated
-		if transformedValue != value {
+		if changed {
 			res = append(res, transformedValue)
 			value = transformedValue
 		}
@@ -515,7 +515,7 @@ func (r *Rule) executeTransformationsMultimatch(value string) ([]string, []error
 func (r *Rule) executeTransformations(value string) (string, []error) {
 	var errs []error
 	for _, t := range r.transformations {
-		v, err := t.Function(value)
+		v, _, err := t.Function(value)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -10,10 +10,11 @@ import (
 )
 
 // base64decode decodes a Base64-encoded string.
-func base64decode(data string) (string, error) {
+func base64decode(data string) (string, bool, error) {
 	dec, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
-		return data, nil
+		// Forgiving implementation, which ignores invalid characters
+		return data, false, nil
 	}
-	return stringsutil.WrapUnsafe(dec), nil
+	return stringsutil.WrapUnsafe(dec), true, nil
 }

--- a/internal/transformations/base64decode_test.go
+++ b/internal/transformations/base64decode_test.go
@@ -20,7 +20,7 @@ func BenchmarkB64Decode(b *testing.B) {
 	for _, tt := range b64DecodeTests {
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := base64decode(tt)
+				_, _, err := base64decode(tt)
 				if err != nil {
 					b.Error(err)
 				}
@@ -34,7 +34,7 @@ func FuzzB64Decode(f *testing.F) {
 		f.Add(tc)
 	}
 	f.Fuzz(func(t *testing.T, tc string) {
-		data, err := base64decode(tc)
+		data, _, err := base64decode(tc)
 		// We decode base64 within non-base64 so there is no
 		// error case.
 		if err != nil {

--- a/internal/transformations/cmd_line.go
+++ b/internal/transformations/cmd_line.go
@@ -20,13 +20,13 @@ replacing all commas [,] and semicolon [;] into a space
 replacing all multiple spaces (including tab, newline, etc.) into one space
 transform all characters to lowercase
 */
-func cmdLine(data string) (string, error) {
+func cmdLine(data string) (string, bool, error) {
 	for i := 0; i < len(data); i++ {
 		if needsTransform(data[i]) {
-			return doCMDLine(data, i), nil
+			return doCMDLine(data, i), true, nil
 		}
 	}
-	return data, nil
+	return data, false, nil
 }
 
 func doCMDLine(input string, pos int) string {

--- a/internal/transformations/cmd_line_test.go
+++ b/internal/transformations/cmd_line_test.go
@@ -20,7 +20,7 @@ func BenchmarkCMDLine(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := cmdLine(tt); err != nil {
+				if _, _, err := cmdLine(tt); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -33,7 +33,7 @@ func FuzzCMDLine(f *testing.F) {
 		f.Add(tc)
 	}
 	f.Fuzz(func(t *testing.T, tc string) {
-		data, err := cmdLine(tc)
+		data, _, err := cmdLine(tc)
 		if err != nil {
 			t.Error(err)
 		}

--- a/internal/transformations/compress_whitespace.go
+++ b/internal/transformations/compress_whitespace.go
@@ -7,24 +7,27 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func compressWhitespace(value string) (string, error) {
+func compressWhitespace(value string) (string, bool, error) {
 	for i := 0; i < len(value); i++ {
 		if isLatinSpace(value[i]) {
-			return doCompressWhitespace(value, i), nil
+			transformedValue, changed := doCompressWhitespace(value, i)
+			return transformedValue, changed, nil
 		}
 	}
-	return value, nil
+	return value, false, nil
 }
 
-func doCompressWhitespace(input string, pos int) string {
-	// The output may be significantly different length than input, so we don't preallocate
+func doCompressWhitespace(input string, pos int) (string, bool) {
+	// The output may be significantly different in length (shorter) than the input, so we don't preallocate
 	ret := []byte(input[0:pos])
 
+	changed := false
 	inWhiteSpace := false
 	for i := pos; i < len(input); {
 		if isLatinSpace(input[i]) {
 			if inWhiteSpace {
 				i++
+				changed = true
 				continue
 			} else {
 				inWhiteSpace = true
@@ -37,7 +40,7 @@ func doCompressWhitespace(input string, pos int) string {
 		i++
 	}
 
-	return strings.WrapUnsafe(ret)
+	return strings.WrapUnsafe(ret), changed
 }
 
 func isLatinSpace(c byte) bool { // copied from unicode.IsSpace

--- a/internal/transformations/compress_whitespace_test.go
+++ b/internal/transformations/compress_whitespace_test.go
@@ -5,6 +5,42 @@ package transformations
 
 import "testing"
 
+func TestCompressWhiteSpace(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "Single space",
+			want:  "Single space",
+		},
+		{
+			input: "Multiple    spaces",
+			want:  "Multiple spaces",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := compressWhitespace(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkCompressWhitespace(b *testing.B) {
 	tests := []string{
 		"",
@@ -18,7 +54,7 @@ func BenchmarkCompressWhitespace(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := compressWhitespace(tt); err != nil {
+				if _, _, err := compressWhitespace(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/css_decode.go
+++ b/internal/transformations/css_decode.go
@@ -9,13 +9,13 @@ import (
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func cssDecode(data string) (string, error) {
+func cssDecode(data string) (string, bool, error) {
 	if i := strings.IndexByte(data, '\\'); i != -1 {
 		// TODO: This will transform even if the backslash isn't followed by hex,
 		// but keep it simple for now.
-		return cssDecodeInplace(data, i), nil
+		return cssDecodeInplace(data, i), true, nil
 	}
-	return data, nil
+	return data, false, nil
 }
 
 func cssDecodeInplace(input string, pos int) string {

--- a/internal/transformations/css_decode_test.go
+++ b/internal/transformations/css_decode_test.go
@@ -5,6 +5,42 @@ package transformations
 
 import "testing"
 
+func TestCSSDecode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "Test\u0000Case",
+			want:  "Test\u0000Case",
+		},
+		{
+			input: "test\\a\\b\\f\\n\\r\\t\\v\\?\\'\\\"\\\u0000\\12\\123\\1234\\12345\\123456\\ff01\\ff5e\\\n\\\u0000  string",
+			want:  "test\n\u000b\u000fnrtv?'\"\u0000\u0012#4EV!~\u0000  string",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := cssDecode(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkCSSDecode(b *testing.B) {
 	tests := []string{
 		"",
@@ -16,7 +52,7 @@ func BenchmarkCSSDecode(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := cssDecode(tt); err != nil {
+				if _, _, err := cssDecode(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/css_decode_test.go
+++ b/internal/transformations/css_decode_test.go
@@ -31,7 +31,7 @@ func TestCSSDecode(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/escape_seq_decode.go
+++ b/internal/transformations/escape_seq_decode.go
@@ -10,19 +10,20 @@ import (
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func escapeSeqDecode(input string) (string, error) {
+func escapeSeqDecode(input string) (string, bool, error) {
 	if i := strings.IndexByte(input, '\\'); i != -1 {
 		// TODO: This will transform even if the backslash isn't followed by an escape,
 		// but keep it simple for now.
-		return doEscapeSeqDecode(input, i), nil
+		transformedInput, changed := doEscapeSeqDecode(input, i)
+		return transformedInput, changed, nil
 	}
-	return input, nil
+	return input, false, nil
 }
 
-func doEscapeSeqDecode(input string, pos int) string {
+func doEscapeSeqDecode(input string, pos int) (string, bool) {
 	inputLen := len(input)
 	data := []byte(input)
-
+	changed := false
 	d := pos
 	i := pos
 
@@ -103,6 +104,7 @@ func doEscapeSeqDecode(input string, pos int) string {
 			} else {
 				/* Converted the encoding. */
 				data[d] = byte(c)
+				changed = true
 				d++
 			}
 		} else {
@@ -112,7 +114,7 @@ func doEscapeSeqDecode(input string, pos int) string {
 			i++
 		}
 	}
-	return utils.WrapUnsafe(data[:d])
+	return utils.WrapUnsafe(data[:d]), changed
 }
 
 func isODigit(c byte) bool {

--- a/internal/transformations/escape_seq_decode_test.go
+++ b/internal/transformations/escape_seq_decode_test.go
@@ -35,7 +35,7 @@ func TestEscapeSeqDecode(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/escape_seq_decode_test.go
+++ b/internal/transformations/escape_seq_decode_test.go
@@ -5,6 +5,46 @@ package transformations
 
 import "testing"
 
+func TestEscapeSeqDecode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "TestCase",
+			want:  "TestCase",
+		},
+		{
+			input: "\\",
+			want:  "\\",
+		},
+		{
+			input: "\\\\u0000",
+			want:  "\\u0000",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := escapeSeqDecode(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkEscapeSeqDecode(b *testing.B) {
 	tests := []string{
 		"",
@@ -16,7 +56,7 @@ func BenchmarkEscapeSeqDecode(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := escapeSeqDecode(tt); err != nil {
+				if _, _, err := escapeSeqDecode(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/hex_encode.go
+++ b/internal/transformations/hex_encode.go
@@ -7,8 +7,8 @@ import (
 	"encoding/hex"
 )
 
-func hexEncode(data string) (string, error) {
+func hexEncode(data string) (string, bool, error) {
 	src := []byte(data)
 
-	return hex.EncodeToString(src), nil
+	return hex.EncodeToString(src), true, nil
 }

--- a/internal/transformations/html_entity_decode.go
+++ b/internal/transformations/html_entity_decode.go
@@ -9,5 +9,5 @@ import (
 
 func htmlEntityDecode(data string) (string, bool, error) {
 	transformedData := html.UnescapeString(data)
-	return transformedData, data != transformedData, nil
+	return transformedData, len(data) != len(transformedData), nil
 }

--- a/internal/transformations/html_entity_decode.go
+++ b/internal/transformations/html_entity_decode.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/html"
 )
 
-func htmlEntityDecode(data string) (string, error) {
-	return html.UnescapeString(data), nil
+func htmlEntityDecode(data string) (string, bool, error) {
+	transformedData := html.UnescapeString(data)
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/js_decode.go
+++ b/internal/transformations/js_decode.go
@@ -10,13 +10,14 @@ import (
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func jsDecode(data string) (string, error) {
+func jsDecode(data string) (string, bool, error) {
 	if i := strings.IndexByte(data, '\\'); i != -1 {
 		// TODO: This will transform even if the backslash isn't followed by an escape,
 		// but keep it simple for now.
-		return doJsDecode(data, i), nil
+		transformedData := doJsDecode(data, i)
+		return transformedData, data != transformedData, nil
 	}
-	return data, nil
+	return data, false, nil
 }
 
 // https://github.com/SpiderLabs/ModSecurity/blob/b66224853b4e9d30e0a44d16b29d5ed3842a6b11/src/actions/transformations/js_decode.cc

--- a/internal/transformations/js_decode.go
+++ b/internal/transformations/js_decode.go
@@ -14,16 +14,17 @@ func jsDecode(data string) (string, bool, error) {
 	if i := strings.IndexByte(data, '\\'); i != -1 {
 		// TODO: This will transform even if the backslash isn't followed by an escape,
 		// but keep it simple for now.
-		transformedData := doJsDecode(data, i)
-		return transformedData, data != transformedData, nil
+		transformedData, changed := doJsDecode(data, i)
+		return transformedData, changed, nil
 	}
 	return data, false, nil
 }
 
 // https://github.com/SpiderLabs/ModSecurity/blob/b66224853b4e9d30e0a44d16b29d5ed3842a6b11/src/actions/transformations/js_decode.cc
-func doJsDecode(input string, pos int) string {
+func doJsDecode(input string, pos int) (string, bool) {
 	d := []byte(input)
 	inputLen := len(input)
+	changed := false
 
 	i := pos
 	c := pos
@@ -39,10 +40,12 @@ func doJsDecode(input string, pos int) string {
 
 				/* Use only the lower byte. */
 				d[c] = utils.X2c(input[i+4:])
+				changed = true
 
 				/* Full width ASCII (ff01 - ff5e) needs 0x20 added */
 				if (d[c] > 0x00) && (d[c] < 0x5f) && ((input[i+2] == 'f') || (input[i+2] == 'F')) && ((input[i+3] == 'f') || (input[i+3] == 'F')) {
 					d[c] += 0x20
+					changed = true
 				}
 
 				c++
@@ -50,6 +53,7 @@ func doJsDecode(input string, pos int) string {
 			case (i+3 < inputLen) && (input[i+1] == 'x') && utils.ValidHex(input[i+2]) && utils.ValidHex(input[i+3]):
 				/* \xHH */
 				d[c] = utils.X2c(input[i+2:])
+				changed = true
 				c++
 				i += 4
 			case (i+1 < inputLen) && isodigit(input[i+1]):
@@ -74,6 +78,7 @@ func doJsDecode(input string, pos int) string {
 					}
 					nn, _ := strconv.ParseInt(string(buf), 8, 8)
 					d[c] = byte(nn)
+					changed = true
 					c++
 					i += 1 + j
 				}
@@ -101,6 +106,7 @@ func doJsDecode(input string, pos int) string {
 				}
 
 				d[c] = cc
+				changed = true
 				c++
 				i += 2
 			default:
@@ -118,7 +124,7 @@ func doJsDecode(input string, pos int) string {
 		}
 	}
 
-	return utils.WrapUnsafe(d[:c])
+	return utils.WrapUnsafe(d[:c]), changed
 
 }
 

--- a/internal/transformations/js_decode_test.go
+++ b/internal/transformations/js_decode_test.go
@@ -35,7 +35,7 @@ func TestCJSDecode(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/js_decode_test.go
+++ b/internal/transformations/js_decode_test.go
@@ -5,6 +5,46 @@ package transformations
 
 import "testing"
 
+func TestCJSDecode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "hello world",
+			want:  "hello world",
+		},
+		{
+			input: "\\\\0",
+			want:  "\\0",
+		},
+		{
+			input: "\\",
+			want:  "\\",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := jsDecode(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkJSDecode(b *testing.B) {
 	tests := []string{
 		"",
@@ -16,7 +56,7 @@ func BenchmarkJSDecode(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := jsDecode(tt); err != nil {
+				if _, _, err := jsDecode(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/length.go
+++ b/internal/transformations/length.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 )
 
-func length(data string) (string, error) {
-	return strconv.Itoa(len(data)), nil
+func length(data string) (string, bool, error) {
+	transformedData := strconv.Itoa(len(data))
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/length.go
+++ b/internal/transformations/length.go
@@ -9,5 +9,5 @@ import (
 
 func length(data string) (string, bool, error) {
 	transformedData := strconv.Itoa(len(data))
-	return transformedData, data != transformedData, nil
+	return transformedData, true, nil
 }

--- a/internal/transformations/length_test.go
+++ b/internal/transformations/length_test.go
@@ -3,7 +3,9 @@
 
 package transformations
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestLength(t *testing.T) {
 	tests := []struct {
@@ -22,14 +24,21 @@ func TestLength(t *testing.T) {
 			input:  "ハローワールド",
 			length: "21",
 		},
+		{
+			input:  "1",
+			length: "1",
+		},
 	}
 
 	for _, tc := range tests {
 		tt := tc
 		t.Run(tt.input, func(t *testing.T) {
-			have, err := length(tt.input)
+			have, changed, err := length(tt.input)
 			if err != nil {
 				t.Error(err)
+			}
+			if tt.input == have && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.length {
 				t.Errorf("Expected %s, have %s", tt.length, have)

--- a/internal/transformations/length_test.go
+++ b/internal/transformations/length_test.go
@@ -24,10 +24,12 @@ func TestLength(t *testing.T) {
 			input:  "ハローワールド",
 			length: "21",
 		},
-		{
-			input:  "1",
-			length: "1",
-		},
+		// length("1") will be a corner case that returns changed = true. Conceptually the transformation
+		// returns the length of the string, so it might be considered a change.
+		// {
+		// 	input:  "1",
+		// 	length: "1",
+		// },
 	}
 
 	for _, tc := range tests {

--- a/internal/transformations/lowercase.go
+++ b/internal/transformations/lowercase.go
@@ -8,6 +8,8 @@ import (
 )
 
 func lowerCase(data string) (string, bool, error) {
+	// TODO: Explicit implementation of ToLower would allow optimizing away the byte by byte comparison for returning the changed boolean
+	// See https://github.com/corazawaf/coraza/pull/778#discussion_r1186963422
 	transformedData := strings.ToLower(data)
 	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/lowercase.go
+++ b/internal/transformations/lowercase.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
-func lowerCase(data string) (string, error) {
-	return strings.ToLower(data), nil
+func lowerCase(data string) (string, bool, error) {
+	transformedData := strings.ToLower(data)
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/lowercase_test.go
+++ b/internal/transformations/lowercase_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func TestLowerCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "TestCase",
+			want:  "testcase",
+		},
+		{
+			input: "test\u0000case",
+			want:  "test\u0000case",
+		},
+		{
+			input: "testcase",
+			want:  "testcase",
+		},
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "ThIs Is A tExT fOr TeStInG lOwErCaSe FuNcTiOnAlItY.",
+			want:  "this is a text for testing lowercase functionality.",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := lowerCase(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkLowercase(b *testing.B) {
+	tests := []string{
+		"tesTcase",
+		"ThIs Is A tExT fOr TeStInG lOwErCaSe FuNcTiOnAlItY.ThIs Is A tExT fOr TeStInG lOwErCaSe FuNcTiOnAlItY. ThIs Is A tExT fOr TeStInG lOwErCaSe FuNcTiOnAlItY.ThIs Is A tExT fOr TeStInG lOwErCaSe FuNcTiOnAlItY.",
+	}
+	for i := 0; i < b.N; i++ {
+		for _, tt := range tests {
+			b.Run(tt, func(b *testing.B) {
+				for j := 0; j < b.N; j++ {
+					_, _, err := lowerCase(tt)
+					if err != nil {
+						b.Error(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/transformations/md5.go
+++ b/internal/transformations/md5.go
@@ -14,7 +14,7 @@ var emptyMD5 string
 
 func md5T(data string) (string, bool, error) {
 	if len(data) == 0 {
-		return emptyMD5, false, nil
+		return emptyMD5, true, nil
 	}
 
 	h := md5.New()

--- a/internal/transformations/md5.go
+++ b/internal/transformations/md5.go
@@ -12,17 +12,19 @@ import (
 
 var emptyMD5 string
 
-func md5T(data string) (string, error) {
+func md5T(data string) (string, bool, error) {
 	if len(data) == 0 {
-		return emptyMD5, nil
+		return emptyMD5, false, nil
 	}
 
 	h := md5.New()
 	_, err := io.WriteString(h, data)
 	if err != nil {
-		return data, err
+		return data, false, err
 	}
-	return strings.WrapUnsafe(h.Sum(nil)), nil
+	// The occurrence of an invariant transformation is so unlikely that we can assume the transformation returns a changed value
+	// https://crypto.stackexchange.com/questions/68674/md5-existence-of-invariant-fixed-point
+	return strings.WrapUnsafe(h.Sum(nil)), true, nil
 }
 
 func init() {

--- a/internal/transformations/md5_test.go
+++ b/internal/transformations/md5_test.go
@@ -14,7 +14,7 @@ func BenchmarkMD5(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := md5T(tt); err != nil {
+				if _, _, err := md5T(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/none.go
+++ b/internal/transformations/none.go
@@ -3,7 +3,7 @@
 
 package transformations
 
-func none(data string) (string, error) {
+func none(data string) (string, bool, error) {
 	// This case is special and is hardcoded in the seclang parser
-	return data, nil
+	return data, false, nil
 }

--- a/internal/transformations/normalise_path.go
+++ b/internal/transformations/normalise_path.go
@@ -7,17 +7,17 @@ import (
 	"path/filepath"
 )
 
-func normalisePath(data string) (string, error) {
+func normalisePath(data string) (string, bool, error) {
 	leng := len(data)
 	if leng < 1 {
-		return data, nil
+		return data, false, nil
 	}
 	clean := filepath.Clean(data)
 	if clean == "." {
-		return "", nil
+		return "", true, nil
 	}
 	if data[len(data)-1] == '/' {
-		return clean + "/", nil
+		return clean + "/", true, nil
 	}
-	return clean, nil
+	return clean, data != clean, nil
 }

--- a/internal/transformations/normalise_path_win.go
+++ b/internal/transformations/normalise_path_win.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 )
 
-func normalisePathWin(data string) (string, error) {
+func normalisePathWin(data string) (string, bool, error) {
 	leng := len(data)
 	if leng < 1 {
-		return data, nil
+		return data, false, nil
 	}
 	data = strings.ReplaceAll(data, "\\", "/")
 	return normalisePath(data)

--- a/internal/transformations/remove_comments.go
+++ b/internal/transformations/remove_comments.go
@@ -3,12 +3,13 @@
 
 package transformations
 
-func removeComments(value string) (string, error) {
+func removeComments(value string) (string, bool, error) {
 	inputLen := len(value)
 	// we must add one pad to the right
 	input := []byte(value + "\x00")
 
 	var i, j int
+	changed := false
 	incomment := false
 
 charLoop:
@@ -23,9 +24,11 @@ charLoop:
 				i += 4
 			case (input[i] == '-') && (i+1 < inputLen) && (input[i+1] == '-'):
 				input[i] = ' '
+				changed = true
 				break charLoop
 			case input[i] == '#':
 				input[i] = ' '
+				changed = true
 				break charLoop
 			default:
 				input[j] = input[i]
@@ -53,8 +56,9 @@ charLoop:
 	}
 
 	if incomment {
+		changed = true
 		input[j] = ' '
 		j++
 	}
-	return string(input[0:j]), nil
+	return string(input[0:j]), changed, nil
 }

--- a/internal/transformations/remove_comments_char.go
+++ b/internal/transformations/remove_comments_char.go
@@ -5,34 +5,42 @@ package transformations
 
 import stringsutil "github.com/corazawaf/coraza/v3/internal/strings"
 
-func removeCommentsChar(value string) (string, error) {
-	res := make([]byte, 0, len(value))
-	for i := 0; i < len(value); {
+func removeCommentsChar(value string) (string, bool, error) {
+	inputLen := len(value)
+	res := make([]byte, 0, inputLen)
+	changed := false
+	for i := 0; i < inputLen; {
 		switch {
-		case value[i] == '/' && (i+1 < len(value)) && value[i+1] == '*':
+		case value[i] == '/' && (i+1 < inputLen) && value[i+1] == '*':
 			i += 2
-		case value[i] == '*' && (i+1 < len(value)) && value[i+1] == '/':
+			changed = true
+		case value[i] == '*' && (i+1 < inputLen) && value[i+1] == '/':
 			i += 2
+			changed = true
 		case value[i] == '<' &&
-			(i+1 < len(value)) &&
+			(i+1 < inputLen) &&
 			value[i+1] == '!' &&
-			(i+2 < len(value)) &&
+			(i+2 < inputLen) &&
 			value[i+2] == '-' &&
-			(i+3 < len(value)) &&
+			(i+3 < inputLen) &&
 			value[i+3] == '-':
 			i += 4
+			changed = true
 		case value[i] == '-' &&
-			(i+1 < len(value)) && value[i+1] == '-' &&
-			(i+2 < len(value)) && value[i+2] == '>':
+			(i+1 < inputLen) && value[i+1] == '-' &&
+			(i+2 < inputLen) && value[i+2] == '>':
 			i += 3
-		case value[i] == '-' && (i+1 < len(value)) && value[i+1] == '-':
+			changed = true
+		case value[i] == '-' && (i+1 < inputLen) && value[i+1] == '-':
 			i += 2
+			changed = true
 		case value[i] == '#':
 			i += 1
+			changed = true
 		default:
 			res = append(res, value[i])
 			i += 1
 		}
 	}
-	return stringsutil.WrapUnsafe(res), nil
+	return stringsutil.WrapUnsafe(res), changed, nil
 }

--- a/internal/transformations/remove_nulls.go
+++ b/internal/transformations/remove_nulls.go
@@ -8,6 +8,7 @@ import (
 )
 
 // removeNulls removes NUL bytes in input.
-func removeNulls(data string) (string, error) {
-	return strings.ReplaceAll(data, "\x00", ""), nil
+func removeNulls(data string) (string, bool, error) {
+	transformedData := strings.ReplaceAll(data, "\x00", "")
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/remove_nulls.go
+++ b/internal/transformations/remove_nulls.go
@@ -10,5 +10,5 @@ import (
 // removeNulls removes NUL bytes in input.
 func removeNulls(data string) (string, bool, error) {
 	transformedData := strings.ReplaceAll(data, "\x00", "")
-	return transformedData, data != transformedData, nil
+	return transformedData, len(data) != len(transformedData), nil
 }

--- a/internal/transformations/remove_whitespace.go
+++ b/internal/transformations/remove_whitespace.go
@@ -9,13 +9,17 @@ import (
 )
 
 // removeWhitespace removes all whitespace characters from input.
-func removeWhitespace(data string) (string, error) {
-	return strings.Map(func(r rune) rune {
+func removeWhitespace(data string) (string, bool, error) {
+	changed := false
+	transformedData := strings.Map(func(r rune) rune {
 		if unicode.IsSpace(r) {
 			// if the character is a space, drop it
+			changed = true
 			return -1
 		}
 		// else keep it in the string
 		return r
-	}, data), nil
+	}, data)
+
+	return transformedData, changed, nil
 }

--- a/internal/transformations/remove_whitespace_test.go
+++ b/internal/transformations/remove_whitespace_test.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func TestRemoveWhiteSpace(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "test",
+			want:  "test",
+		},
+		{
+			input: "t e s t",
+			want:  "test",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := removeWhitespace(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}

--- a/internal/transformations/remove_whitespace_test.go
+++ b/internal/transformations/remove_whitespace_test.go
@@ -31,7 +31,7 @@ func TestRemoveWhiteSpace(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/replace_comments.go
+++ b/internal/transformations/replace_comments.go
@@ -19,6 +19,7 @@ func doReplaceComments(value string) (string, bool) {
 		if !incomment {
 			if (input[i] == '/') && (i+1 < inputLen) && (input[i+1] == '*') {
 				incomment = true
+				changed = true
 				i += 2
 			} else {
 				input[j] = input[i]
@@ -39,7 +40,6 @@ func doReplaceComments(value string) (string, bool) {
 
 	if incomment {
 		input[j] = ' '
-		changed = true
 		j++
 	}
 

--- a/internal/transformations/replace_comments.go
+++ b/internal/transformations/replace_comments.go
@@ -3,13 +3,15 @@
 
 package transformations
 
-func replaceComments(data string) (string, error) {
-	return doReplaceComments(data), nil
+func replaceComments(data string) (string, bool, error) {
+	transformedData, changed := doReplaceComments(data)
+	return transformedData, changed, nil
 }
 
-func doReplaceComments(value string) string {
+func doReplaceComments(value string) (string, bool) {
 	var i, j int
 	incomment := false
+	changed := false
 
 	input := []byte(value)
 	inputLen := len(input)
@@ -37,8 +39,9 @@ func doReplaceComments(value string) string {
 
 	if incomment {
 		input[j] = ' '
+		changed = true
 		j++
 	}
 
-	return string(input[0:j])
+	return string(input[0:j]), changed
 }

--- a/internal/transformations/replace_comments_test.go
+++ b/internal/transformations/replace_comments_test.go
@@ -43,7 +43,7 @@ func TestReplaceComments(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/replace_comments_test.go
+++ b/internal/transformations/replace_comments_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func TestReplaceComments(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "This is/*this is a comment*/text",
+			want:  "This is text",
+		},
+		{
+			input: "/*this is a comment*/a comment",
+			want:  " a comment",
+		},
+		{
+			input: "/**/",
+			want:  " ",
+		},
+		{
+			input: "/*comment",
+			want:  " ",
+		},
+		{
+			input: "Not a comment",
+			want:  "Not a comment",
+		},
+		{
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := replaceComments(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}

--- a/internal/transformations/replace_nulls.go
+++ b/internal/transformations/replace_nulls.go
@@ -5,6 +5,7 @@ package transformations
 
 import "strings"
 
-func replaceNulls(data string) (string, error) {
-	return strings.ReplaceAll(data, "\x00", " "), nil
+func replaceNulls(data string) (string, bool, error) {
+	transformedData := strings.ReplaceAll(data, "\x00", " ")
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/sha1.go
+++ b/internal/transformations/sha1.go
@@ -12,16 +12,17 @@ import (
 
 var emptySHA1 string
 
-func sha1T(data string) (string, error) {
+func sha1T(data string) (string, bool, error) {
 	if len(data) == 0 {
-		return emptySHA1, nil
+		return emptySHA1, false, nil
 	}
 	h := sha1.New()
 	_, err := io.WriteString(h, data)
 	if err != nil {
-		return data, err
+		return data, false, err
 	}
-	return strings.WrapUnsafe(h.Sum(nil)), nil
+	// The occurrence of an invariant transformation is so unlikely that we can assume the transformation returns a changed value
+	return strings.WrapUnsafe(h.Sum(nil)), true, nil
 }
 
 func init() {

--- a/internal/transformations/sha1.go
+++ b/internal/transformations/sha1.go
@@ -14,7 +14,7 @@ var emptySHA1 string
 
 func sha1T(data string) (string, bool, error) {
 	if len(data) == 0 {
-		return emptySHA1, false, nil
+		return emptySHA1, true, nil
 	}
 	h := sha1.New()
 	_, err := io.WriteString(h, data)

--- a/internal/transformations/sha1_test.go
+++ b/internal/transformations/sha1_test.go
@@ -14,7 +14,7 @@ func BenchmarkSHA1(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := sha1T(tt); err != nil {
+				if _, _, err := sha1T(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/transformations_test.go
+++ b/internal/transformations/transformations_test.go
@@ -56,7 +56,7 @@ func TestTransformations(t *testing.T) {
 					// Cannot use t.Skip for TinyGo support
 					return
 				}
-				out, err := trans(data.Input)
+				out, _, err := trans(data.Input)
 				if err != nil {
 					t.Error(err)
 				}

--- a/internal/transformations/trim.go
+++ b/internal/transformations/trim.go
@@ -17,5 +17,5 @@ const trimSpaces = " \t\n\r\f\v"
 
 func trim(data string) (string, bool, error) {
 	transformedData := strings.Trim(data, trimSpaces)
-	return transformedData, data != transformedData, nil
+	return transformedData, len(data) != len(transformedData), nil
 }

--- a/internal/transformations/trim.go
+++ b/internal/transformations/trim.go
@@ -15,6 +15,7 @@ import "strings"
 
 const trimSpaces = " \t\n\r\f\v"
 
-func trim(data string) (string, error) {
-	return strings.Trim(data, trimSpaces), nil
+func trim(data string) (string, bool, error) {
+	transformedData := strings.Trim(data, trimSpaces)
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/trim_left.go
+++ b/internal/transformations/trim_left.go
@@ -7,5 +7,5 @@ import "strings"
 
 func trimLeft(data string) (string, bool, error) {
 	transformedData := strings.TrimLeft(data, trimSpaces)
-	return transformedData, data != transformedData, nil
+	return transformedData, len(data) != len(transformedData), nil
 }

--- a/internal/transformations/trim_left.go
+++ b/internal/transformations/trim_left.go
@@ -5,6 +5,7 @@ package transformations
 
 import "strings"
 
-func trimLeft(data string) (string, error) {
-	return strings.TrimLeft(data, trimSpaces), nil
+func trimLeft(data string) (string, bool, error) {
+	transformedData := strings.TrimLeft(data, trimSpaces)
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/trim_right.go
+++ b/internal/transformations/trim_right.go
@@ -7,5 +7,5 @@ import "strings"
 
 func trimRight(data string) (string, bool, error) {
 	transformedData := strings.TrimRight(data, trimSpaces)
-	return transformedData, data != transformedData, nil
+	return transformedData, len(data) != len(transformedData), nil
 }

--- a/internal/transformations/trim_right.go
+++ b/internal/transformations/trim_right.go
@@ -5,6 +5,7 @@ package transformations
 
 import "strings"
 
-func trimRight(data string) (string, error) {
-	return strings.TrimRight(data, trimSpaces), nil
+func trimRight(data string) (string, bool, error) {
+	transformedData := strings.TrimRight(data, trimSpaces)
+	return transformedData, data != transformedData, nil
 }

--- a/internal/transformations/url_decode.go
+++ b/internal/transformations/url_decode.go
@@ -7,14 +7,14 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func urlDecode(data string) (string, error) {
+func urlDecode(data string) (string, bool, error) {
 	for i := 0; i < len(data); i++ {
 		if data[i] == '%' || data[i] == '+' {
 			// TODO add error?
-			return doURLDecode(data, []byte(data), i), nil
+			return doURLDecode(data, []byte(data), i), true, nil
 		}
 	}
-	return data, nil
+	return data, false, nil
 }
 
 // extracted from https://github.com/senghoo/modsecurity-go/blob/master/utils/urlencode.go

--- a/internal/transformations/url_decode_uni.go
+++ b/internal/transformations/url_decode_uni.go
@@ -7,13 +7,13 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func urlDecodeUni(data string) (string, error) {
+func urlDecodeUni(data string) (string, bool, error) {
 	for i := 0; i < len(data); i++ {
 		if data[i] == '%' || data[i] == '+' {
-			return inplaceUniDecode(data, []byte(data), i), nil
+			return inplaceUniDecode(data, []byte(data), i), true, nil
 		}
 	}
-	return data, nil
+	return data, false, nil
 }
 
 func inplaceUniDecode(input string, d []byte, pos int) string {

--- a/internal/transformations/url_decode_uni_test.go
+++ b/internal/transformations/url_decode_uni_test.go
@@ -25,7 +25,7 @@ func BenchmarkURLDecode(b *testing.B) {
 			tt := tc
 			b.Run(fmt.Sprintf("%s/%s", mode, tt), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err := f(tt); err != nil {
+					if _, _, err := f(tt); err != nil {
 						b.Fatal(err)
 					}
 				}

--- a/internal/transformations/url_encode.go
+++ b/internal/transformations/url_encode.go
@@ -5,8 +5,9 @@ package transformations
 
 import "strings"
 
-func urlEncode(data string) (string, error) {
-	return doURLEncode(data), nil
+func urlEncode(data string) (string, bool, error) {
+	transformedData := doURLEncode(data)
+	return transformedData, data != transformedData, nil
 }
 
 func doURLEncode(input string) string {

--- a/internal/transformations/url_encode.go
+++ b/internal/transformations/url_encode.go
@@ -6,15 +6,16 @@ package transformations
 import "strings"
 
 func urlEncode(data string) (string, bool, error) {
-	transformedData := doURLEncode(data)
-	return transformedData, data != transformedData, nil
+	transformedData, changed := doURLEncode(data)
+	return transformedData, changed, nil
 }
 
-func doURLEncode(input string) string {
+func doURLEncode(input string) (string, bool) {
 	inputLen := len(input)
 	if inputLen == 0 {
-		return ""
+		return "", false
 	}
+	changed := false
 	leng := inputLen * 3
 	var d strings.Builder
 	d.Grow(leng)
@@ -27,14 +28,16 @@ func doURLEncode(input string) string {
 
 		if cc == ' ' {
 			d.WriteByte('+')
+			changed = true
 		} else {
 			if (cc == 42) || ((cc >= 48) && (cc <= 57)) || ((cc >= 65) && (cc <= 90)) || ((cc >= 97) && (cc <= 122)) {
 				d.WriteByte(cc)
 			} else {
 				d.Write([]byte{'%', c2xTable[(cc&0xff)>>4], c2xTable[(cc&0xff)&0x0f]})
+				changed = true
 			}
 		}
 	}
 
-	return d.String()
+	return d.String(), changed
 }

--- a/internal/transformations/url_encode_test.go
+++ b/internal/transformations/url_encode_test.go
@@ -35,7 +35,7 @@ func TestEncode(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {

--- a/internal/transformations/url_encode_test.go
+++ b/internal/transformations/url_encode_test.go
@@ -5,6 +5,46 @@ package transformations
 
 import "testing"
 
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: "helloWorld",
+			want:  "helloWorld",
+		},
+		{
+			input: "hello world",
+			want:  "hello+world",
+		},
+		{
+			input: "https://www.coraza.io",
+			want:  "https%3a%2f%2fwww%2ecoraza%2eio",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := urlEncode(tt.input)
+			if err != nil {
+				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
 func BenchmarkURLEncode(b *testing.B) {
 	tests := []string{
 		" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}",
@@ -16,7 +56,7 @@ func BenchmarkURLEncode(b *testing.B) {
 		for _, tt := range tests {
 			b.Run(tt, func(b *testing.B) {
 				for j := 0; j < b.N; j++ {
-					_, err := urlEncode(tt)
+					_, _, err := urlEncode(tt)
 					if err != nil {
 						b.Error(err)
 					}

--- a/internal/transformations/utf8_to_unicode.go
+++ b/internal/transformations/utf8_to_unicode.go
@@ -21,13 +21,13 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/strings"
 )
 
-func utf8ToUnicode(str string) (string, error) {
+func utf8ToUnicode(str string) (string, bool, error) {
 	for i, c := range str {
 		if c >= utf8.RuneSelf {
-			return doUTF8ToUnicode(str, i), nil
+			return doUTF8ToUnicode(str, i), true, nil
 		}
 	}
-	return str, nil
+	return str, false, nil
 }
 
 func doUTF8ToUnicode(input string, pos int) string {

--- a/internal/transformations/utf8_to_unicode_test.go
+++ b/internal/transformations/utf8_to_unicode_test.go
@@ -43,9 +43,12 @@ func TestUTF8ToUnicode(t *testing.T) {
 	for _, tc := range tests {
 		tt := tc
 		t.Run(tt.input, func(t *testing.T) {
-			have, err := utf8ToUnicode(tt.input)
+			have, changed, err := utf8ToUnicode(tt.input)
 			if err != nil {
 				t.Error(err)
+			}
+			if tt.input == tt.want && changed {
+				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {
 				t.Errorf("have %q, want %q", have, tt.want)
@@ -65,7 +68,7 @@ func BenchmarkUTF8ToUnicode(b *testing.B) {
 		tt := tc
 		b.Run(tt, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				if _, err := utf8ToUnicode(tt); err != nil {
+				if _, _, err := utf8ToUnicode(tt); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/internal/transformations/utf8_to_unicode_test.go
+++ b/internal/transformations/utf8_to_unicode_test.go
@@ -47,7 +47,7 @@ func TestUTF8ToUnicode(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			if tt.input == tt.want && changed {
+			if tt.input == tt.want && changed || tt.input != tt.want && !changed {
 				t.Errorf("input %q, have %q with changed %t", tt.input, have, changed)
 			}
 			if have != tt.want {


### PR DESCRIPTION
Investigating different anomaly scores reported by `Coraza` vs `Modsec v2`, I found that we are behaving in a different way with `multimatch` enabled.
The documentation states: `Description: If enabled, ModSecurity will perform multiple operator invocations for every target, before and after every anti-evasion transformation is performed.` And later on `With multiMatch, variables are checked against the operator before and after every transformation function that changes the input.`
Currently Coraza is just considering the main `Description`: every time a transformation returns an output, we store it and it will be analyzed (see [here](https://github.com/corazawaf/coraza/blob/42d4ae85b98bcb146694b86d6843fa63b3e5bfea/internal/corazawaf/rule.go#L496)). It means that, even if the transformation does not make any change to the value, that value is added as another variable and will trigger the same rules more than once.

Modsec provides a different approach. Quoting a comment from the codebase: `In multi-match mode, we execute the operator once at the beginning and then once every time the variable is changed by the transformation function.`
It overall results on different variables matched and a reduced increase of anomaly score raised by the same rules against the same values.

An example is provided by following rule:
```
SecRule REQUEST_URI "@rx this_very_specific_uri" \
    "id:101, phase:1, pass, log,\
    t:urlDecodeUni,t:removeNulls,t:lowercase,\
    multiMatch,\
    setvar:'tx.matched_times=+1'"
```
All the transformations are not effective against a request like `/this_very_specific_uri`. But Coraza generates 4 different variables and overall the `matched_times` goes up to `4`, while ModSec detects that no changes are performed by the transformations, therefore `matched_times` stops at `1`.

This PR provides a way to align `multimatch` to ModSec behavior, **if** we feel that the latter is actually better. 

Initial comment from where the investigation started: https://github.com/corazawaf/coraza/issues/760#issuecomment-1500207852. It shows a total of 4 more matches (+20 anomaly score discrepancy) compared to ModSec.
