### PR TITLE
feat(ci): stale only awaiting for feedback's issue

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -15,9 +15,9 @@ jobs:
           days-before-issue-stale: 30
           days-before-issue-close: 14
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          stale-issue-message: "This issue has been open 30 days waiting for feedback. Remove the stale label or comment, or this will be closed in 14 days."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          exempt-issue-labels: v4
+          only-issue-labels: "awaiting feedback"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems that among maintainers it was considered to update the stale issues policy. This PR is meant to propose the change and discuss it. If agreed, from now on, only issues that are labeled `awaiting feedback` will be marked as stale and later on closed by the bot.
If the PRs get merged, I would update the `question` `(Further information is requested)` label to `awaiting feedback`.

Inspired by current CRS policy: https://github.com/coreruleset/coreruleset/pull/2948