### PR TITLE
chore(e2e): check response body read error only if a body is expected

### DIFF
--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -286,7 +286,7 @@ func Run(cfg Config) error {
 		}
 
 		if test.expectedBody != nil {
-			// Same servers might aborting the request before sending the body (E.g. triggering a phase 3 rule with deny action)
+			// Some servers might abort the request before sending the body (E.g. triggering a phase 3 rule with deny action)
 			// Therefore, we check if we properly read the body only if we expect a body to be received.
 			if errReadRespBody != nil {
 				return fmt.Errorf("could not read response body: %v", err)

--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -274,11 +274,8 @@ func Run(cfg Config) error {
 			return fmt.Errorf("could not do http request: %v", err)
 		}
 
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, errReadRespBody := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if err != nil {
-			return fmt.Errorf("could not read response body: %v", err)
-		}
 
 		if test.expectedStatusCode != nil {
 			if err := test.expectedStatusCode(resp.StatusCode); err != nil {
@@ -289,6 +286,11 @@ func Run(cfg Config) error {
 		}
 
 		if test.expectedBody != nil {
+			// Same servers might aborting the request before sending the body (E.g. triggering a phase 3 rule with deny action)
+			// Therefore, we check if we properly read the body only if we expect a body to be received.
+			if errReadRespBody != nil {
+				return fmt.Errorf("could not read response body: %v", err)
+			}
 			code, err := strconv.Atoi(resp.Header.Get("Content-Length"))
 			if err != nil {
 				return fmt.Errorf("could not convert content-length header to int: %v", err)


### PR DESCRIPTION
Working on https://github.com/corazawaf/coraza-caddy/pull/96 (e2e is failing I'm trying to update it with the new one), I found that Caddy properly aborts the response if at phase 3 a deny action is triggered. It means that the response body can not be read.
**Caddy Log:**
```
e2e-caddy-1  | {"level":"error","ts":1690387902.7979822,"logger":"http.handlers.waf","msg":"[client \"192.168.176.4\"] Coraza: Access denied (phase 3).  [file \"\"] [line \"10\"] [id \"103\"] [rev \"\"] [msg \"\"] [data \"\"] [severity \"emergency\"] [ver \"\"] [maturity \"0\"] [accuracy \"0\"] [hostname \"\"] [uri \"/response-headers?pass=leak\"] [unique_id \"RkQqgctUauuoQNPt\"]\n"}
e2e-caddy-1  | {"level":"error","ts":1690387902.798008,"logger":"http.handlers.reverse_proxy","msg":"aborting with incomplete response","error":"short write"}
```
e2e output:
```
e2e-tests-1  | [5/9] Running test: Denied request with a malicious response header
e2e-tests-1  | [Fail] could not read response body: unexpected EOF
e2e-tests-1  | exit status 1
```

This PR should fix the problem looking at the error generated by reading the response only when we actually want to check the response body. 