### PR TITLE
first persistence draft

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -64,3 +64,14 @@ type Map interface {
 	// Remove deletes the key from the CollectionMap
 	Remove(key string)
 }
+
+// Persistent collections won't use arrays as values
+// They are designed for collections that will be stored
+type Persistent interface {
+	Collection
+
+	Set(key string, value string)
+
+	// Remove deletes the key
+	Remove(key string)
+}

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -43,35 +43,45 @@ type Keyed interface {
 	FindString(key string) []types.MatchData
 }
 
+type Editable interface {
+	Keyed
+
+	// Remove deletes the key from the CollectionMap
+	Remove(key string)
+
+	// Set will replace the key's value with this slice
+	Set(key string, values []string)
+
+	// TODO: in v4 this should contain setters for Map and Persistence
+}
+
 // Map are used to store VARIABLE data
 // for transactions, this data structured is designed
 // to store slices of data for keys
 // Important: CollectionMaps ARE NOT concurrent safe
 type Map interface {
-	Keyed
+	Editable
 
 	// Add a value to some key
 	Add(key string, value string)
-
-	// Set will replace the key's value with this slice
-	Set(key string, values []string)
 
 	// SetIndex will place the value under the index
 	// If the index is higher than the current size of the CollectionMap
 	// it will be appended
 	SetIndex(key string, index int, value string)
-
-	// Remove deletes the key from the CollectionMap
-	Remove(key string)
 }
 
 // Persistent collections won't use arrays as values
 // They are designed for collections that will be stored
 type Persistent interface {
-	Collection
+	Editable
 
-	Set(key string, value string)
+	// Initializes the input as the collection key
+	Init(key string)
 
-	// Remove deletes the key
-	Remove(key string)
+	// Sum will add the value to the key
+	Sum(key string, sum int)
+
+	// SetOne will replace the key's value with this string
+	SetOne(key string, value string)
 }

--- a/experimental/plugins/persistence.go
+++ b/experimental/plugins/persistence.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package plugins
@@ -10,5 +10,5 @@ import (
 
 // RegisterPersistenceEngine registers a new persistence engine
 func RegisterPersistenceEngine(name string, engine plugintypes.PersistenceEngine) {
-	persistence.RegisterPersistenceEngine(name, engine)
+	persistence.Register(name, engine)
 }

--- a/experimental/plugins/persistence.go
+++ b/experimental/plugins/persistence.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package plugins
+
+import (
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/persistence"
+)
+
+// RegisterPersistenceEngine registers a new persistence engine
+func RegisterPersistenceEngine(name string, engine plugintypes.PersistenceEngine) {
+	persistence.RegisterPersistenceEngine(name, engine)
+}

--- a/experimental/plugins/plugintypes/persistence.go
+++ b/experimental/plugins/plugintypes/persistence.go
@@ -8,5 +8,8 @@ type PersistenceEngine interface {
 	Close() error
 	Sum(collectionName string, collectionKey string, key string, sum int) error
 	Get(collectionName string, collectionKey string, key string) (string, error)
+
+	All(collectionName string, collectionKey string) (map[string]string, error)
 	Set(collection string, collectionKey string, key string, value string) error
+	Remove(collection string, collectionKey string, key string) error
 }

--- a/experimental/plugins/plugintypes/persistence.go
+++ b/experimental/plugins/plugintypes/persistence.go
@@ -1,0 +1,12 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package plugintypes
+
+type PersistenceEngine interface {
+	Open(uri string, ttl int) error
+	Close() error
+	Sum(collectionName string, collectionKey string, key string, sum int) error
+	Get(collectionName string, collectionKey string, key string) (string, error)
+	Set(collection string, collectionKey string, key string, value string) error
+}

--- a/experimental/plugins/plugintypes/transaction.go
+++ b/experimental/plugins/plugintypes/transaction.go
@@ -115,4 +115,10 @@ type TransactionVariables interface {
 	ArgsNames() collection.Collection
 	ArgsGetNames() collection.Collection
 	ArgsPostNames() collection.Collection
+	// TODO(v4: Add these)
+	//  Session() collection.Persistent
+	//  User() collection.Persistent
+	//  IP() collection.Persistent
+	//  Global() collection.Persistent
+	//  Resource() collection.Persistent
 }

--- a/internal/actions/initcol_test.go
+++ b/internal/actions/initcol_test.go
@@ -1,24 +1,33 @@
 // Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package actions
+package actions_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/actions"
+)
 
 func TestInitcolInit(t *testing.T) {
+	waf, _ := coraza.NewWAF(coraza.NewWAFConfig()) //nolint:errcheck
+	initcol, err := actions.Get("initcol")
+	if err != nil {
+		t.Error(err)
+	}
 	t.Run("invalid argument", func(t *testing.T) {
-		initcol := initcol()
-		err := initcol.Init(nil, "foo")
-		if err == nil {
-			t.Errorf("expected error")
+		if err := initcol.Init(&md{}, "test"); err == nil {
+			t.Error("expected error")
 		}
 	})
 
-	t.Run("passing argument", func(t *testing.T) {
-		initcol := initcol()
-		err := initcol.Init(nil, "foo=bar")
-		if err != nil {
-			t.Errorf("unexpected error: %s", err.Error())
+	t.Run("editable variable", func(t *testing.T) {
+		if err := initcol.Init(&md{}, "session=abcdef"); err != nil {
+			t.Error(err)
 		}
+		txs := waf.NewTransaction().(plugintypes.TransactionState)
+		initcol.Evaluate(&md{}, txs)
 	})
 }

--- a/internal/actions/setvar_persistence_test.go
+++ b/internal/actions/setvar_persistence_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/corazawaf/coraza/v3"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/actions"
+	_ "github.com/corazawaf/coraza/v3/internal/persistence"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 

--- a/internal/actions/setvar_persistence_test.go
+++ b/internal/actions/setvar_persistence_test.go
@@ -1,6 +1,9 @@
 // Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !tinygo
+// +build !tinygo
+
 package actions_test
 
 import (
@@ -9,7 +12,6 @@ import (
 	"github.com/corazawaf/coraza/v3"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/actions"
-	_ "github.com/corazawaf/coraza/v3/internal/persistence"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
@@ -20,7 +22,7 @@ func TestPersistenceSetvar(t *testing.T) {
 	}
 	waf, err := coraza.NewWAF(coraza.NewWAFConfig().WithDirectives("SecPersistenceEngine default"))
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	t.Run("SESSION should be set", func(t *testing.T) {
 		if err := a.Init(&md{}, "SESSION.test=test"); err != nil {

--- a/internal/actions/setvar_persistence_test.go
+++ b/internal/actions/setvar_persistence_test.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package actions_test
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/actions"
+	"github.com/corazawaf/coraza/v3/types/variables"
+)
+
+func TestPersistenceSetvar(t *testing.T) {
+	a, err := actions.Get("setvar")
+	if err != nil {
+		t.Error("failed to get setvar action")
+	}
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig().WithDirectives("SecPersistenceEngine default"))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Run("SESSION should be set", func(t *testing.T) {
+		if err := a.Init(&md{}, "SESSION.test=test"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		tx := waf.NewTransaction()
+		txs := tx.(plugintypes.TransactionState)
+		a.Evaluate(&md{}, txs)
+		col := txs.Collection(variables.Session)
+		col.FindAll()
+	})
+}

--- a/internal/actions/setvar_test.go
+++ b/internal/actions/setvar_test.go
@@ -1,10 +1,12 @@
 // Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package actions
+package actions_test
 
 import (
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/actions"
 )
 
 type md struct {
@@ -21,27 +23,27 @@ func (_ md) Status() int {
 }
 
 func TestSetvarInit(t *testing.T) {
+	a, err := actions.Get("setvar")
+	if err != nil {
+		t.Error("failed to get setvar action")
+	}
 	t.Run("no arguments", func(t *testing.T) {
-		a := setvar()
-		if err := a.Init(nil, ""); err == nil || err != ErrMissingArguments {
+		if err := a.Init(nil, ""); err == nil || err != actions.ErrMissingArguments {
 			t.Error("expected error ErrMissingArguments")
 		}
 	})
 	t.Run("non-map variable", func(t *testing.T) {
-		a := setvar()
 		if err := a.Init(&md{}, "PATH_INFO=test"); err == nil {
 			t.Error("expected error")
 		}
 	})
 	t.Run("TX set ok", func(t *testing.T) {
-		a := setvar()
 		if err := a.Init(&md{}, "TX.some=test"); err != nil {
 			t.Error(err)
 		}
 	})
-	t.Run("TX without key should fail", func(t *testing.T) {
-		a := setvar()
-		if err := a.Init(&md{}, "TX=test"); err == nil {
+	t.Run("SESSION without key should fail", func(t *testing.T) {
+		if err := a.Init(&md{}, "SESSION=test"); err == nil {
 			t.Error("expected error")
 		}
 	})

--- a/internal/auditlog/concurrent_writer_test.go
+++ b/internal/auditlog/concurrent_writer_test.go
@@ -34,7 +34,7 @@ func TestConcurrentWriterNoop(t *testing.T) {
 
 func TestConcurrentWriterFailsOnInit(t *testing.T) {
 	config := NewConfig()
-	config.Target = "/unexisting.log"
+	config.Target = "/invalid/unexisting.log"
 	config.Dir = t.TempDir()
 	config.FileMode = fs.FileMode(0777)
 	config.DirMode = fs.FileMode(0777)

--- a/internal/auditlog/serial_writer_test.go
+++ b/internal/auditlog/serial_writer_test.go
@@ -57,7 +57,7 @@ func TestSerialLoggerSuccessOnInit(t *testing.T) {
 
 func TestSerialWriterFailsOnInitForUnexistingFile(t *testing.T) {
 	config := NewConfig()
-	config.Target = "/unexisting.log"
+	config.Target = "/invalid/unexisting.log"
 	config.Dir = t.TempDir()
 	config.FileMode = fs.FileMode(0777)
 	config.DirMode = fs.FileMode(0777)

--- a/internal/bodyprocessors/multipart_test.go
+++ b/internal/bodyprocessors/multipart_test.go
@@ -26,7 +26,7 @@ func TestProcessRequestFailsDueToIncorrectMimeType(t *testing.T) {
 
 	expectedError := "not a multipart body"
 
-	if err := mp.ProcessRequest(strings.NewReader(""), corazawaf.NewTransactionVariables(), plugintypes.BodyProcessorOptions{
+	if err := mp.ProcessRequest(strings.NewReader(""), corazawaf.NewTransactionVariables(nil), plugintypes.BodyProcessorOptions{
 		Mime: "application/json",
 	}); err == nil || err.Error() != expectedError {
 		t.Fatal("expected error")
@@ -56,7 +56,7 @@ Content-Type: text/html
 
 	mp := multipartProcessor(t)
 
-	v := corazawaf.NewTransactionVariables()
+	v := corazawaf.NewTransactionVariables(nil)
 	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
 		Mime: "multipart/form-data; boundary=---------------------------9051914041544843365972754266",
 	}); err != nil {
@@ -87,7 +87,7 @@ text default
 -----------------------------9051914041544843365972754266
 `)
 	mp := multipartProcessor(t)
-	v := corazawaf.NewTransactionVariables()
+	v := corazawaf.NewTransactionVariables(nil)
 	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
 		Mime: "multipart/form-data; boundary=---------------------------9051914041544843365972754266; a=1; a=2",
 	}); err == nil {

--- a/internal/bodyprocessors/urlencoded_test.go
+++ b/internal/bodyprocessors/urlencoded_test.go
@@ -18,7 +18,7 @@ func TestURLEncode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	v := corazawaf.NewTransactionVariables()
+	v := corazawaf.NewTransactionVariables(nil)
 	m := map[string]string{
 		"a": "1",
 		"b": "2",

--- a/internal/collections/persistent.go
+++ b/internal/collections/persistent.go
@@ -5,29 +5,36 @@ package collections
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/corazarules"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 // Persistent uses collection.Map.
 type Persistent struct {
-	variable variables.RuleVariable
+	variable      variables.RuleVariable
+	engine        plugintypes.PersistenceEngine
+	collectionKey string
 }
 
-var _ collection.Map = &Map{}
-
-func NewPersistent(variable variables.RuleVariable, key string) *Map {
-	return &Map{
-		variable: variable,
-		data:     map[string][]keyValue{},
+func NewPersistent(variable variables.RuleVariable, engine plugintypes.PersistenceEngine) *Persistent {
+	return &Persistent{
+		variable:      variable,
+		engine:        engine,
+		collectionKey: "",
 	}
 }
 
+func (c *Persistent) Init(key string) {
+	c.collectionKey = key
+}
+
 func (c *Persistent) Get(key string) []string {
-	return nil
+	res, _ := c.engine.Get(c.variable.Name(), c.collectionKey, key) //nolint:errcheck
+	return []string{res}
 }
 
 func (c *Persistent) FindRegex(key *regexp.Regexp) []types.MatchData {
@@ -35,45 +42,37 @@ func (c *Persistent) FindRegex(key *regexp.Regexp) []types.MatchData {
 }
 
 func (c *Persistent) FindString(key string) []types.MatchData {
-	return nil
+	res, _ := c.engine.Get(c.variable.Name(), c.collectionKey, key) //nolint:errcheck
+	return []types.MatchData{&corazarules.MatchData{
+		Variable_: c.variable,
+		Key_:      key,
+		Value_:    res,
+	},
+	}
 }
 
 func (c *Persistent) FindAll() []types.MatchData {
 	return nil
 }
 
-func (c *Persistent) Add(key string, value string) {
-
+func (c *Persistent) SetOne(key string, value string) {
+	c.engine.Set(c.variable.Name(), c.collectionKey, key, value) //nolint:errcheck
 }
 
 func (c *Persistent) Set(key string, values []string) {
-
-}
-
-func (c *Persistent) SetIndex(key string, index int, value string) {
-
+	c.engine.Set(c.variable.Name(), c.collectionKey, key, values[0]) //nolint:errcheck
 }
 
 func (c *Persistent) Remove(key string) {
+	c.engine.Remove(c.variable.Name(), c.collectionKey, key) //nolint:errcheck
+}
 
+func (c *Persistent) Sum(key string, sum int) {
+	c.engine.Sum(c.variable.Name(), c.collectionKey, key, sum) //nolint:errcheck
 }
 
 func (c *Persistent) Name() string {
 	return c.variable.Name()
 }
 
-func (c *Persistent) Reset() {
-
-}
-
-func (c *Persistent) Format(res *strings.Builder) {
-
-}
-
-func (c *Persistent) String() string {
-	return ""
-}
-
-func (c *Persistent) Len() int {
-	return 0
-}
+var _ collection.Persistent = &Persistent{}

--- a/internal/collections/persistent.go
+++ b/internal/collections/persistent.go
@@ -38,7 +38,18 @@ func (c *Persistent) Get(key string) []string {
 }
 
 func (c *Persistent) FindRegex(key *regexp.Regexp) []types.MatchData {
-	return nil
+	all, _ := c.engine.All(c.variable.Name(), c.collectionKey) //nolint:errcheck
+	matches := make([]types.MatchData, 0, len(all))
+	for i, v := range all {
+		if key.MatchString(i) {
+			matches = append(matches, &corazarules.MatchData{
+				Variable_: c.variable,
+				Key_:      i,
+				Value_:    v,
+			})
+		}
+	}
+	return matches
 }
 
 func (c *Persistent) FindString(key string) []types.MatchData {
@@ -52,7 +63,16 @@ func (c *Persistent) FindString(key string) []types.MatchData {
 }
 
 func (c *Persistent) FindAll() []types.MatchData {
-	return nil
+	all, _ := c.engine.All(c.variable.Name(), c.collectionKey) //nolint:errcheck
+	matches := make([]types.MatchData, 0, len(all))
+	for i, v := range all {
+		matches = append(matches, &corazarules.MatchData{
+			Variable_: c.variable,
+			Key_:      i,
+			Value_:    v,
+		})
+	}
+	return matches
 }
 
 func (c *Persistent) SetOne(key string, value string) {

--- a/internal/collections/persistent.go
+++ b/internal/collections/persistent.go
@@ -1,0 +1,79 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package collections
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/types"
+	"github.com/corazawaf/coraza/v3/types/variables"
+)
+
+// Persistent uses collection.Map.
+type Persistent struct {
+	variable variables.RuleVariable
+}
+
+var _ collection.Map = &Map{}
+
+func NewPersistent(variable variables.RuleVariable, key string) *Map {
+	return &Map{
+		variable: variable,
+		data:     map[string][]keyValue{},
+	}
+}
+
+func (c *Persistent) Get(key string) []string {
+	return nil
+}
+
+func (c *Persistent) FindRegex(key *regexp.Regexp) []types.MatchData {
+	return nil
+}
+
+func (c *Persistent) FindString(key string) []types.MatchData {
+	return nil
+}
+
+func (c *Persistent) FindAll() []types.MatchData {
+	return nil
+}
+
+func (c *Persistent) Add(key string, value string) {
+
+}
+
+func (c *Persistent) Set(key string, values []string) {
+
+}
+
+func (c *Persistent) SetIndex(key string, index int, value string) {
+
+}
+
+func (c *Persistent) Remove(key string) {
+
+}
+
+func (c *Persistent) Name() string {
+	return c.variable.Name()
+}
+
+func (c *Persistent) Reset() {
+
+}
+
+func (c *Persistent) Format(res *strings.Builder) {
+
+}
+
+func (c *Persistent) String() string {
+	return ""
+}
+
+func (c *Persistent) Len() int {
+	return 0
+}

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -131,6 +131,9 @@ type WAF struct {
 
 	// Configures the maximum number of ARGS that will be accepted for processing.
 	ArgumentLimit int
+
+	// PersistenceEngine is used to store persistent collections
+	PersistenceEngine plugintypes.PersistenceEngine
 }
 
 // NewTransaction Creates a new initialized transaction for this WAF instance

--- a/internal/persistence/default.go
+++ b/internal/persistence/default.go
@@ -32,7 +32,8 @@ func (d *defaultEngine) Open(uri string, ttl int) error {
 }
 
 func (d *defaultEngine) Close() error {
-	d.data = sync.Map{}
+	// Close will just stop the GC
+	// it won't delete the data as it would cause race conditions.
 	d.stopGC <- true
 	return nil
 }
@@ -119,7 +120,6 @@ func (d *defaultEngine) gc() {
 			})
 		}
 	}
-
 }
 
 func (d *defaultEngine) getCollection(collectionName string, collectionKey string) map[string]interface{} {

--- a/internal/persistence/default.go
+++ b/internal/persistence/default.go
@@ -1,0 +1,146 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type defaultEngine struct {
+	data   sync.Map
+	ttl    int
+	stopGC chan bool
+}
+
+func (d *defaultEngine) Open(uri string, ttl int) error {
+	d.data = sync.Map{}
+	// we start the garbage collector
+	go d.gc()
+	return nil
+}
+
+func (d *defaultEngine) Close() error {
+	d.data = sync.Map{}
+	d.stopGC <- true
+	return nil
+}
+
+func (d *defaultEngine) Sum(collectionName string, collectionKey string, key string, sum int) error {
+	col := d.getCollection(collectionName, collectionKey)
+	if col == nil {
+		d.set(collectionName, collectionKey, key, sum)
+	} else {
+		if v, ok := col[key]; ok {
+			if v2, ok := v.(int); ok {
+				d.set(collectionName, collectionKey, key, v2+sum)
+			}
+		} else {
+			d.set(collectionName, collectionKey, key, sum)
+		}
+	}
+	return nil
+}
+
+func (d *defaultEngine) Get(collectionName string, collectionKey string, key string) (string, error) {
+	res := d.get(collectionName, collectionKey, key)
+	switch v := res.(type) {
+	case string:
+		return v, nil
+	case int:
+		return strconv.Itoa(v), nil
+	case nil:
+		return "", nil
+	}
+
+	return "", nil
+}
+
+func (d *defaultEngine) Set(collection string, collectionKey string, key string, value string) error {
+	d.set(collection, collectionKey, key, value)
+	return nil
+}
+
+func (d *defaultEngine) gc() {
+	for {
+		select {
+		case <-d.stopGC:
+			return
+		default:
+			d.data.Range(func(key, value interface{}) bool {
+				col := value.(map[string]interface{})
+				if col["TIMEOUT"].(int) < int(time.Now().Unix()) {
+					d.data.Delete(key)
+				}
+				return true
+			})
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+}
+
+func (d *defaultEngine) getCollection(collectionName string, collectionKey string) map[string]interface{} {
+	k := d.getCollectionName(collectionName, collectionKey)
+	data, ok := d.data.Load(k)
+	if !ok {
+		return nil
+	}
+	return data.(map[string]interface{})
+}
+
+func (d *defaultEngine) get(collectionName string, collectionKey string, key string) interface{} {
+	data := d.getCollection(collectionName, collectionKey)
+	if data == nil {
+		return nil
+	}
+	if res, ok := data[key]; ok {
+		return res
+	}
+	return nil
+}
+
+func (d *defaultEngine) set(collection string, collectionKey string, key string, value interface{}) {
+	data := d.getCollection(collection, collectionKey)
+	now := time.Now().Unix()
+	if data == nil {
+		data := map[string]interface{}{
+			key:                value,
+			"CREATE_TIME":      int(now),
+			"IS_NEW":           1,
+			"KEY":              collectionKey,
+			"LAST_UPDATE_TIME": 0,
+			// we timeout at now + d.ttl
+			"TIMEOUT":        int(now) + d.ttl,
+			"UPDATE_COUNTER": 0,
+			"UPDATE_RATE":    0,
+		}
+		d.data.Store(d.getCollectionName(collection, collectionKey), data)
+	} else {
+		data[key] = value
+		d.updateCollection(data)
+	}
+}
+
+func (*defaultEngine) getCollectionName(collectionName string, collectionKey string) string {
+	return fmt.Sprintf("%s_%s", collectionName, collectionKey)
+}
+
+func (d *defaultEngine) updateCollection(col map[string]interface{}) {
+	update_counter := col["UPDATE_COUNTER"].(int)
+	time_now := int(time.Now().Unix())
+	col["IS_NEW"] = 0
+	col["LAST_UPDATE_TIME"] = time_now
+	col["UPDATE_COUNTER"] = update_counter + 1
+	// we compute the update rate by using UPDATE_COUNTER and CREATE_TIME
+	// UPDATE_RATE = UPDATE_COUNTER / (CURRENT_TIME - CREATE_TIME)
+	delta := (time_now - col["CREATE_TIME"].(int))
+	if delta > 0 {
+		col["UPDATE_RATE"] = int(update_counter / delta)
+	}
+	// we update the timeout
+	col["TIMEOUT"] = time_now + d.ttl
+}

--- a/internal/persistence/default_test.go
+++ b/internal/persistence/default_test.go
@@ -80,13 +80,14 @@ func TestDefaultEngineSetAndGet(t *testing.T) {
 
 func TestDefaultGC(t *testing.T) {
 	engine := &defaultEngine{}
-	engine.Open("", 1) //nolint:errcheck
+	engine.Open("", 1)   //nolint:errcheck
+	defer engine.Close() //nolint:errcheck
 	err := engine.Set("testCol", "testColKey", "testKey", "testValue")
 	if err != nil {
 		t.Errorf("Set failed: %v", err)
 	}
-	// we sleep 1.3 second
-	time.Sleep(1300 * time.Millisecond)
+	// we sleep 2 second
+	time.Sleep(2000 * time.Millisecond)
 	// now we should have no data
 	val, err := engine.Get("testCol", "testColKey", "testKey")
 	if err != nil {
@@ -96,4 +97,20 @@ func TestDefaultGC(t *testing.T) {
 		t.Errorf("Value was not deleted")
 	}
 
+}
+
+func TestDefaultAll(t *testing.T) {
+	engine := &defaultEngine{}
+	engine.Open("", 3600) //nolint:errcheck
+	defer engine.Close()  //nolint:errcheck
+	if err := engine.Set("testCol", "testColKey", "testKey", "testValue"); err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+	all, err := engine.All("testCol", "testColKey")
+	if err != nil {
+		t.Errorf("All failed: %v", err)
+	}
+	if all["testKey"] != "testValue" {
+		t.Errorf("All failed: %v", all)
+	}
 }

--- a/internal/persistence/default_test.go
+++ b/internal/persistence/default_test.go
@@ -1,6 +1,9 @@
 // Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !tinygo
+// +build !tinygo
+
 package persistence
 
 import (
@@ -63,6 +66,14 @@ func TestDefaultEngineSetAndGet(t *testing.T) {
 		t.Errorf("Set failed: %v", err)
 	}
 	if val := engine.get("testCol", "testColKey", "sum"); val != 7 {
+		t.Errorf("Sum failed, got %v", val)
+	}
+
+	err = engine.Remove("testCol", "testColKey", "sum")
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+	if val := engine.get("testCol", "testColKey", "sum"); val != nil {
 		t.Errorf("Sum failed, got %v", val)
 	}
 }

--- a/internal/persistence/default_test.go
+++ b/internal/persistence/default_test.go
@@ -1,0 +1,88 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultEngineSetAndGet(t *testing.T) {
+	engine := &defaultEngine{ttl: int(time.Now().Add(10 * time.Minute).Unix())}
+	err := engine.Set("testCol", "testColKey", "testKey", "testValue")
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+
+	val, err := engine.Get("testCol", "testColKey", "testKey")
+	if err != nil || val != "testValue" {
+		t.Errorf("Get failed or returned incorrect value: %v, %v", err, val)
+	}
+
+	// now we test the updates
+
+	err = engine.Set("testCol", "testColKey", "testKey", "testValue2")
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+
+	val, err = engine.Get("testCol", "testColKey", "testKey")
+	if err != nil || val != "testValue2" {
+		t.Errorf("Get failed or returned incorrect value: %v, %v", err, val)
+	}
+
+	// now we validate the time update worked
+	time_now := int(time.Now().Unix())
+	create_time := engine.get("testCol", "testColKey", "CREATE_TIME")
+	if err != nil {
+		t.Errorf("Get failed: %v", err)
+	}
+	ct, ok := create_time.(int)
+	if !ok {
+		t.Errorf("Create time is not an int: %v", create_time)
+	}
+	if ct == 0 {
+		t.Errorf("Create time is 0")
+	}
+	// time difference should be small
+	if time_now-ct > 10 {
+		t.Errorf("Time difference is too big: %v", time_now-int(ct))
+	}
+
+	err = engine.Sum("testCol", "testColKey", "sum", 5)
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+	if val := engine.get("testCol", "testColKey", "sum"); val != 5 {
+		t.Errorf("Sum failed, got %v", val)
+	}
+
+	err = engine.Sum("testCol", "testColKey", "sum", 2)
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+	if val := engine.get("testCol", "testColKey", "sum"); val != 7 {
+		t.Errorf("Sum failed, got %v", val)
+	}
+}
+
+func TestDefaultGC(t *testing.T) {
+	engine := &defaultEngine{}
+	engine.Open("", 1) //nolint:errcheck
+	err := engine.Set("testCol", "testColKey", "testKey", "testValue")
+	if err != nil {
+		t.Errorf("Set failed: %v", err)
+	}
+	// we sleep 1.3 second
+	time.Sleep(1300 * time.Millisecond)
+	// now we should have no data
+	val, err := engine.Get("testCol", "testColKey", "testKey")
+	if err != nil {
+		t.Errorf("Get failed or returned incorrect value: %v, %v", err, val)
+	}
+	if val == "testValue" {
+		t.Errorf("Value was not deleted")
+	}
+
+}

--- a/internal/persistence/noop.go
+++ b/internal/persistence/noop.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+type noopEngine struct{}
+
+func (n noopEngine) Open(uri string, ttl int) error {
+	return nil
+}
+
+func (noopEngine) Close() error {
+	return nil
+}
+
+func (noopEngine) Sum(collectionName string, collectionKey string, key string, sum int) error {
+	return nil
+}
+
+func (noopEngine) Get(collectionName string, collectionKey string, key string) (string, error) {
+	return "", nil
+}
+
+func (noopEngine) Set(collection string, collectionKey string, key string, value string) error {
+	return nil
+}
+
+func (noopEngine) Remove(collection string, collectionKey string, key string) error {
+	return nil
+}
+
+func (noopEngine) All(collection string, collectionKey string) (map[string]string, error) {
+	return nil, nil
+}
+
+func init() {
+	Register("noop", noopEngine{})
+}

--- a/internal/persistence/noop_test.go
+++ b/internal/persistence/noop_test.go
@@ -1,0 +1,18 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+import "testing"
+
+func TestNoopEngine(t *testing.T) {
+	ne, err := Get("noop")
+	if err != nil {
+		t.Error("Failed to get noop engine")
+	}
+	ne.Open("", 100)                       //nolint:errcheck
+	ne.Close()                             //nolint:errcheck
+	ne.Get("test", "test", "test")         //nolint:errcheck
+	ne.Set("test", "test", "test", "test") //nolint:errcheck
+	ne.Remove("test", "test", "test")      //nolint:errcheck
+}

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -16,8 +16,9 @@ func Register(name string, engine plugintypes.PersistenceEngine) {
 }
 
 func Get(name string) (plugintypes.PersistenceEngine, error) {
-	if persistenceEngines[name] == nil {
+	if e, ok := persistenceEngines[name]; !ok {
 		return nil, fmt.Errorf("persistence engine %s not found", name)
+	} else {
+		return e, nil
 	}
-	return persistenceEngines[name], nil
 }

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -1,0 +1,16 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistence
+
+import "github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+
+var persistenceEngines = map[string]plugintypes.PersistenceEngine{}
+
+func RegisterPersistenceEngine(name string, engine plugintypes.PersistenceEngine) {
+	persistenceEngines[name] = engine
+}
+
+func GetPersistenceEngine(name string) plugintypes.PersistenceEngine {
+	return persistenceEngines[name]
+}

--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -3,14 +3,21 @@
 
 package persistence
 
-import "github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+import (
+	"fmt"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+)
 
 var persistenceEngines = map[string]plugintypes.PersistenceEngine{}
 
-func RegisterPersistenceEngine(name string, engine plugintypes.PersistenceEngine) {
+func Register(name string, engine plugintypes.PersistenceEngine) {
 	persistenceEngines[name] = engine
 }
 
-func GetPersistenceEngine(name string) plugintypes.PersistenceEngine {
-	return persistenceEngines[name]
+func Get(name string) (plugintypes.PersistenceEngine, error) {
+	if persistenceEngines[name] == nil {
+		return nil, fmt.Errorf("persistence engine %s not found", name)
+	}
+	return persistenceEngines[name], nil
 }

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -477,6 +477,7 @@ func directiveSecPersistenceEngine(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
 		return errEmptyOptions
 	}
+	options.WAF.Logger.Warn().Msg("Persistence is a experimental feature, be careful.")
 	engine, err := persistence.Get(options.Opts)
 	if err != nil {
 		return err

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -17,6 +17,7 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/auditlog"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/persistence"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -463,6 +464,24 @@ func directiveSecRequestBodyInMemoryLimit(options *DirectiveOptions) error {
 		return err
 	}
 	options.WAF.SetRequestBodyInMemoryLimit(limit)
+	return nil
+}
+
+// Description: Set the persistence engine to be used by Coraza.
+// Default: noop
+// Syntax: SecPersistenceEngine [noop|default]
+// ---
+// The default persistence engine is a noop engine that does not store any data.
+// New engines can be implemented by using experimental/plugins/persistence.go
+func directiveSecPersistenceEngine(options *DirectiveOptions) error {
+	if len(options.Opts) == 0 {
+		return errEmptyOptions
+	}
+	engine, err := persistence.Get(options.Opts)
+	if err != nil {
+		return err
+	}
+	options.WAF.PersistenceEngine = engine
 	return nil
 }
 

--- a/internal/seclang/directivesmap.gen.go
+++ b/internal/seclang/directivesmap.gen.go
@@ -25,6 +25,7 @@ var (
 	_ directive = directiveSecResponseBodyLimit
 	_ directive = directiveSecRequestBodyLimitAction
 	_ directive = directiveSecRequestBodyInMemoryLimit
+	_ directive = directiveSecPersistenceEngine
 	_ directive = directiveSecRemoteRulesFailAction
 	_ directive = directiveSecRemoteRules
 	_ directive = directiveSecConnWriteStateLimit
@@ -85,6 +86,7 @@ var directivesMap = map[string]directive{
 	"secresponsebodylimit":           directiveSecResponseBodyLimit,
 	"secrequestbodylimitaction":      directiveSecRequestBodyLimitAction,
 	"secrequestbodyinmemorylimit":    directiveSecRequestBodyInMemoryLimit,
+	"secpersistenceengine":           directiveSecPersistenceEngine,
 	"secremoterulesfailaction":       directiveSecRemoteRulesFailAction,
 	"secremoterules":                 directiveSecRemoteRules,
 	"secconnwritestatelimit":         directiveSecConnWriteStateLimit,

--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -222,12 +222,20 @@ const (
 	MultipartUnmatchedBoundary
 	// PathInfo is kept for compatibility
 	PathInfo
-	// Sessionid is not supported
+	// Sessionid is the session id
 	Sessionid
-	// Userid is not supported
+	// Userid is a persistent collection of user ids
 	Userid
-	// IP is kept for compatibility
+	// IP is a persistent collection of IP addresses
 	IP
+	// Global is a persistent collection of global variables
+	Global
+	// Resource is a persistent collection of resources
+	Resource
+	// User is a persistent collection of user variables
+	User
+	// Session is a persistent collection of session variables
+	Session
 	// ResBodyError
 	ResBodyError
 	// ResBodyErrorMsg

--- a/internal/variables/variablesmap.gen.go
+++ b/internal/variables/variablesmap.gen.go
@@ -198,6 +198,14 @@ func (v RuleVariable) Name() string {
 		return "USERID"
 	case IP:
 		return "IP"
+	case Global:
+		return "GLOBAL"
+	case Resource:
+		return "RESOURCE"
+	case User:
+		return "USER"
+	case Session:
+		return "SESSION"
 	case ResBodyError:
 		return "RES_BODY_ERROR"
 	case ResBodyErrorMsg:
@@ -305,6 +313,10 @@ var rulemapRev = map[string]RuleVariable{
 	"SESSIONID":                        Sessionid,
 	"USERID":                           Userid,
 	"IP":                               IP,
+	"GLOBAL":                           Global,
+	"RESOURCE":                         Resource,
+	"USER":                             User,
+	"SESSION":                          Session,
 	"RES_BODY_ERROR":                   ResBodyError,
 	"RES_BODY_ERROR_MSG":               ResBodyErrorMsg,
 	"RES_BODY_PROCESSOR_ERROR":         ResBodyProcessorError,

--- a/magefile.go
+++ b/magefile.go
@@ -210,6 +210,11 @@ func Doc() error {
 	return sh.RunV("go", "run", "golang.org/x/tools/cmd/godoc@latest", "-http=:6060")
 }
 
+// Generate generates code using available generators.
+func Generate() error {
+	return sh.RunV("go", "generate", "./...")
+}
+
 // Precommit installs a git hook to run check when committing
 func Precommit() error {
 	if _, err := os.Stat(filepath.Join(".git", "hooks")); os.IsNotExist(err) {

--- a/testing/engine/persistence.go
+++ b/testing/engine/persistence.go
@@ -1,6 +1,9 @@
 // Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !tinygo
+// +build !tinygo
+
 package engine
 
 import (

--- a/testing/engine/persistence.go
+++ b/testing/engine/persistence.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"github.com/corazawaf/coraza/v3/testing/profile"
+)
+
+var _ = profile.RegisterProfile(profile.Profile{
+	Meta: profile.Meta{
+		Author:      "jptosso",
+		Description: "Test if persistence works",
+		Enabled:     true,
+		Name:        "persistence.yaml",
+	},
+	Tests: []profile.Test{
+		{
+			Title: "persistence",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI: "/test1",
+							Headers: map[string]string{
+								"ghi":    "pineapple",
+								"cookie": "session=test;",
+							},
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules: []int{1, 2},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "persistence",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI: "/test2",
+							Headers: map[string]string{
+								"ghi":    "pineapple",
+								"cookie": "session=test;",
+							},
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules: []int{1, 3},
+						},
+					},
+				},
+			},
+		},
+	},
+	Rules: `
+SecPersistenceEngine default
+SecAction "id:1,phase:1,initcol:session=%{REQUEST_COOKIES.session},pass,nolog"
+SecRule REQUEST_URI "test1" "id:2,phase:2,pass,nolog,setvar:session.test=1"
+SecRule REQUEST_URI "test2" "id:3,phase:2,pass,nolog,chain"
+	SecRule SESSION:test "1" "log"
+`,
+})

--- a/testing/engine/persistence.go
+++ b/testing/engine/persistence.go
@@ -62,6 +62,7 @@ SecPersistenceEngine default
 SecAction "id:1,phase:1,initcol:session=%{REQUEST_COOKIES.session},pass,nolog"
 SecRule REQUEST_URI "test1" "id:2,phase:2,pass,nolog,setvar:session.test=1"
 SecRule REQUEST_URI "test2" "id:3,phase:2,pass,nolog,chain"
-	SecRule SESSION:test "1" "log"
+	SecRule SESSION:test "1" "log,chain"
+	SecRule SESSION:/te.*/ "1" "log"
 `,
 })

--- a/types/variables/variables.go
+++ b/types/variables/variables.go
@@ -194,6 +194,16 @@ const (
 	ResBodyProcessorError = variables.ResBodyProcessorError
 	// ResBodyProcessorErrorMsg contains the error message if the response body processor failed
 	ResBodyProcessorErrorMsg = variables.ResBodyProcessorErrorMsg
+	// Global contains global persistent data
+	Global = variables.Global
+	// Resource contains the persistent resource data
+	Resource = variables.Resource
+	// IP contains the persistent IP information
+	IP = variables.IP
+	// Session contains the persistent session information
+	Session = variables.Session
+	// User contains the persistent user information
+	User = variables.User
 )
 
 // Parse returns the byte interpretation


### PR DESCRIPTION
Adds persistence support using in-memory storage.

Current challenges
- It only contains a test implementation. It **must not** be used in production
- Right now there is no way to kill connections, we should implement WAF close in v4
- There are race conditions for writing under high concurrency
- I refactored `collections.Map`, now it implements `collection.Editable`, which is also implemented by `collection.Persistent`. That way, both persistent and map collections can be easily edited in `setvar`. Maps are still the same, the only difference is that some methods come from editable.

## Usage
```apache
SecPersistenceEngine default
SecPersistenceTTL 3600
SecRule &REQUEST_COOKIES:session "@gt 0" "id:1,phase:1, initcol:session=%{REQUEST_COOKIES.session}"
SecRule REQUEST_URL "/login.php" "id:2, phase:4, setvar:session.username=%{RESPONSE_ARGS.json.username}"

SecAction "id:3,phase:5,log,msg:'User: %{SESSION.username}'"
```
