### PR TITLE
fix: removes multiline from default regex modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ dictionaries to reduce memory consumption in deployments that launch several cor
 instances. For more context check [this issue](https://github.com/corazawaf/coraza-caddy/issues/76)
 * `no_fs_access` - indicates that the target environment has no access to FS in order to not leverage OS' filesystem related functionality e.g. file body buffers.
 * `coraza.rule.case_sensitive_args_keys` - enables case-sensitive matching for ARGS keys, aligning Coraza behavior with RFC 3986 specification. It will be enabled by default in the next major version.
+* `coraza.rule.no_regex_multiline` - disables enabling by default regexes multiline modifiers in `@rx` operator. It aligns with CRS expected behavior, reduces false positives and might improve performances. No multiline regexes by default will be enabled in the next major version. For more context check [this PR](https://github.com/corazawaf/coraza/pull/876)
 
 ## E2E Testing
 

--- a/internal/operators/multilineregex.go
+++ b/internal/operators/multilineregex.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build coraza.rule.no_regex_multiline
+
+package operators
+
+var shouldNotUseMultilineRegexesOperatorByDefault = true

--- a/internal/operators/multilineregex_default.go
+++ b/internal/operators/multilineregex_default.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !coraza.rule.no_regex_multiline
+
+package operators
+
+var shouldNotUseMultilineRegexesOperatorByDefault = false

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -24,10 +24,19 @@ type rx struct {
 var _ plugintypes.Operator = (*rx)(nil)
 
 func newRX(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
-	// (?s) enables dotall mode, required by some CRS rules and matching ModSec behavior, see
-	// - https://github.com/google/re2/wiki/Syntax
-	// - Flag usage: https://groups.google.com/g/golang-nuts/c/jiVdamGFU9E
-	data := fmt.Sprintf("(?s)%s", options.Arguments)
+	var data string
+	if shouldNotUseMultilineRegexesOperatorByDefault {
+		// (?s) enables dotall mode, required by some CRS rules and matching ModSec behavior, see
+		// - https://github.com/google/re2/wiki/Syntax
+		// - Flag usage: https://groups.google.com/g/golang-nuts/c/jiVdamGFU9E
+		data = fmt.Sprintf("(?s)%s", options.Arguments)
+	} else {
+		// TODO: deprecate multiline modifier set by default in Coraza v4
+		// CRS rules will explicitly set the multiline modifier when needed
+		// Having it enabled by default can lead to false positives and less performance
+		// See https://github.com/corazawaf/coraza/pull/876
+		data = fmt.Sprintf("(?sm)%s", options.Arguments)
+	}
 
 	if matchesArbitraryBytes(data) {
 		// Use binary regex matcher if expression matches non-utf8 bytes. The binary matcher does

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -24,10 +24,10 @@ type rx struct {
 var _ plugintypes.Operator = (*rx)(nil)
 
 func newRX(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
-	// (?sm) enables multiline and dotall mode, required by some CRS rules and matching ModSec behavior, see
-	// - https://stackoverflow.com/a/27680233
-	// - https://groups.google.com/g/golang-nuts/c/jiVdamGFU9E
-	data := fmt.Sprintf("(?sm)%s", options.Arguments)
+	// (?s) enables dotall mode, required by some CRS rules and matching ModSec behavior, see
+	// - https://github.com/google/re2/wiki/Syntax
+	// - Flag usage: https://groups.google.com/g/golang-nuts/c/jiVdamGFU9E
+	data := fmt.Sprintf("(?s)%s", options.Arguments)
 
 	if matchesArbitraryBytes(data) {
 		// Use binary regex matcher if expression matches non-utf8 bytes. The binary matcher does

--- a/internal/operators/rx_no_multiline_test.go
+++ b/internal/operators/rx_no_multiline_test.go
@@ -1,13 +1,12 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !coraza.rule.no_regex_multiline
+//go:build coraza.rule.no_regex_multiline
 
 package operators
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
@@ -57,22 +56,42 @@ func TestRx(t *testing.T) {
 			want:    true,
 		},
 		{
-			// Requires multiline
+			// Requires multiline disabled by default
 			pattern: `^hello.*world`,
+			input:   "test\nhello\nworld",
+			want:    false,
+		},
+		{
+			// Makes sure multiline can be enabled by the user
+			pattern: `(?m)^hello.*world`,
 			input:   "test\nhello\nworld",
 			want:    true,
 		},
 		{
-			// Makes sure, (?sm) passed by the user does not
+			// Makes sure, (?s) passed by the user does not
 			// break the regex.
-			pattern: `(?sm)hello.*world`,
+			pattern: `(?s)hello.*world`,
 			input:   "hello\nworld",
 			want:    true,
 		},
 		{
 			// Make sure user flags are also applied
-			pattern: `(?i)^hello.*world`,
-			input:   "test\nHELLO\nworld",
+			pattern: `(?i)hello.*world`,
+			input:   "testHELLO\nworld",
+			want:    true,
+		},
+		{
+			// The so called DOLLAR_ENDONLY modifier in PCRE2 is meant to tweak the meaning of dollar '$'
+			// so that it matches only at the very end of the string (see: https://www.pcre.org/current/doc/html/pcre2pattern.html#SEC6)
+			// It seems that re2 already behaves like that by default.
+			pattern: `123$`,
+			input:   "123\n",
+			want:    false,
+		},
+		{
+			// Dollar endonly match
+			pattern: `123$`,
+			input:   "test123",
 			want:    true,
 		},
 	}
@@ -95,29 +114,6 @@ func TestRx(t *testing.T) {
 			if res != tt.want {
 				t.Errorf("want %v, got %v", tt.want, res)
 			}
-			/*
-				vars := tx.GetCollection(variables.TX).Data()
-				if vars["0"][0] != "somedata" {
-					t.Error("rx1 failed")
-				}
-				if vars["1"][0] != "eda" {
-					t.Error("rx1 failed")
-				}
-			*/
 		})
 	}
-}
-
-func BenchmarkRxSubstringVsMatch(b *testing.B) {
-	str := "hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;hello world; heelloo Woorld; hello; heeeelloooo wooooooorld;"
-	rx := regexp.MustCompile(`((h.*e.*l.*l.*o.*)|\d+)`)
-	b.Run("Find all RX", func(b *testing.B) {
-		rx.FindStringSubmatch(str)
-	})
-	b.Run("Find only first", func(b *testing.B) {
-		rx.MatchString(str)
-	})
-	b.Run("Find only N", func(b *testing.B) {
-		rx.FindAllString(str, 3)
-	})
 }

--- a/internal/operators/rx_test.go
+++ b/internal/operators/rx_test.go
@@ -55,22 +55,42 @@ func TestRx(t *testing.T) {
 			want:    true,
 		},
 		{
-			// Requires multiline
+			// Requires multiline disabled by default
 			pattern: `^hello.*world`,
+			input:   "test\nhello\nworld",
+			want:    false,
+		},
+		{
+			// Makes sure multiline can be enabled by the user
+			pattern: `(?m)^hello.*world`,
 			input:   "test\nhello\nworld",
 			want:    true,
 		},
 		{
-			// Makes sure, (?sm) passed by the user does not
+			// Makes sure, (?s) passed by the user does not
 			// break the regex.
-			pattern: `(?sm)hello.*world`,
+			pattern: `(?s)hello.*world`,
 			input:   "hello\nworld",
 			want:    true,
 		},
 		{
 			// Make sure user flags are also applied
-			pattern: `(?i)^hello.*world`,
-			input:   "test\nHELLO\nworld",
+			pattern: `(?i)hello.*world`,
+			input:   "testHELLO\nworld",
+			want:    true,
+		},
+		{
+			// The so called DOLLAR_ENDONLY modifier in PCRE2 is meant to tweak the meaning of dollar '$'
+			// so that it matches only at the very end of the string (see: https://www.pcre.org/current/doc/html/pcre2pattern.html#SEC6)
+			// It seems that re2 already behaves like that by default.
+			pattern: `123$`,
+			input:   "123\n",
+			want:    false,
+		},
+		{
+			// Dollar endonly match
+			pattern: `123$`,
+			input:   "test123",
 			want:    true,
 		},
 	}

--- a/magefile.go
+++ b/magefile.go
@@ -183,7 +183,7 @@ func Coverage() error {
 	if err := sh.RunV("go", "test", tagsCmd, "-coverprofile=build/coverage-ftw.txt", "-covermode=atomic", "-coverpkg=./...", "./testing/coreruleset"); err != nil {
 		return err
 	}
-	// we run tinygo tag only if memoize_builders is is not enabled
+	// we run tinygo tag only if memoize_builders is not enabled
 	if !strings.Contains(tags, "memoize_builders") {
 		if tagsCmd != "" {
 			tagsCmd += ",tinygo"
@@ -280,6 +280,7 @@ func combinations(tags []string) []string {
 func TagsMatrix() error {
 	tags := []string{
 		"coraza.rule.case_sensitive_args_keys",
+		"coraza.rule.no_regex_multiline",
 		"memoize_builders",
 		"coraza.rule.multiphase_valuation",
 		"no_fs_access",

--- a/magefile.go
+++ b/magefile.go
@@ -130,6 +130,15 @@ func Test() error {
 		return err
 	}
 
+	// Execute FTW tests with coraza.rule.no_regex_multiline as well
+	if err := sh.RunV("go", "test", "-tags=coraza.rule.no_regex_multiline", "./testing/coreruleset"); err != nil {
+		return err
+	}
+
+	if err := sh.RunV("go", "test", "-tags=coraza.rule.no_regex_multiline", "-run=^TestRx", "./..."); err != nil {
+		return err
+	}
+
 	if err := sh.RunV("go", "test", "-tags=coraza.rule.case_sensitive_args_keys", "-run=^TestCaseSensitive", "./..."); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR evaluates the needed changes to align Coraza to Modsec v2 behavior rather than Modsec v3 in terms of default modifiers when compiling regexes. This necessity has been raised by https://github.com/coreruleset/coreruleset/issues/3277. 

We are currently running with two default modifiers: 
- s (dotall)
- m (multiline mode)

While Modsec v2 (the reference implementation for the CRS) has:
- PCRE2_DOTALL
- PCRE2_DOLLAR_ENDONLY

Running the CRS rules with multiline may lead to false positives and lower performance.

Opening the PR to further discuss this, and whether we accept a breaking change for `v3.*` or not.

EDIT: The change has been implemented under the `coraza.rule.no_regex_multiline` build flag and is disabled by default.