### PR TITLE
chore: lazy load regexes to save memory.

### DIFF
--- a/collection/collection.go
+++ b/collection/collection.go
@@ -4,7 +4,7 @@
 package collection
 
 import (
-	"regexp"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -37,7 +37,7 @@ type Keyed interface {
 	Get(key string) []string
 
 	// FindRegex returns a slice of MatchData for the regex
-	FindRegex(key *regexp.Regexp) []types.MatchData
+	FindRegex(key regexp.Regexp) []types.MatchData
 
 	// FindString returns a slice of MatchData for the string
 	FindString(key string) []types.MatchData

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -5,7 +5,6 @@ package collection
 
 import (
 	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/types"
 )
 

--- a/experimental/regexp.go
+++ b/experimental/regexp.go
@@ -1,0 +1,24 @@
+package experimental
+
+import (
+	"fmt"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
+)
+
+// SetRegexpCompiler sets the regex compiler used by the WAF. This is specially
+// useful when we want to lazily compile regexes in a mono thread environment as
+// we don't need to synchronize the regex compilation.
+func SetRegexpCompiler(fn func(expr string) (regexp.Regexp, error)) {
+	if fn == nil {
+		fmt.Println("invalid regex compiler")
+		return
+	}
+
+	if regexp.RegexCompiler != nil {
+		fmt.Println("regex compiler already set")
+		return
+	}
+
+	regexp.RegexCompiler = fn
+}

--- a/experimental/regexp/regexp.go
+++ b/experimental/regexp/regexp.go
@@ -1,15 +1,19 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package experimental
 
 import (
 	"fmt"
 
+	"github.com/corazawaf/coraza/v3/experimental/regexp/regexptypes"
 	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 // SetRegexpCompiler sets the regex compiler used by the WAF. This is specially
 // useful when we want to lazily compile regexes in a mono thread environment as
 // we don't need to synchronize the regex compilation.
-func SetRegexpCompiler(fn func(expr string) (regexp.Regexp, error)) {
+func SetRegexpCompiler(fn func(expr string) (regexptypes.Regexp, error)) {
 	if fn == nil {
 		fmt.Println("invalid regex compiler")
 		return

--- a/experimental/regexp/regexptypes/types.go
+++ b/experimental/regexp/regexptypes/types.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package regexptypes
+
+import "regexp"
+
+// Regexp is the interface that wraps the basic MatchString, FindStringSubmatch,
+// FindAllStringSubmatch, SubexpNames, Match and String methods.
+type Regexp interface {
+	MatchString(s string) bool
+	FindStringSubmatch(s string) []string
+	FindAllStringSubmatch(s string, n int) [][]string
+	SubexpNames() []string
+	Match(s []byte) bool
+	String() string
+}
+
+var _ Regexp = (*regexp.Regexp)(nil)

--- a/internal/collections/concat.go
+++ b/internal/collections/concat.go
@@ -6,10 +6,9 @@ package collections
 import (
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/concat.go
+++ b/internal/collections/concat.go
@@ -4,8 +4,9 @@
 package collections
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
@@ -67,7 +68,7 @@ func (c *ConcatKeyed) Get(key string) []string {
 }
 
 // FindRegex returns a slice of MatchData for the regex
-func (c *ConcatKeyed) FindRegex(key *regexp.Regexp) []types.MatchData {
+func (c *ConcatKeyed) FindRegex(key regexp.Regexp) []types.MatchData {
 	var res []types.MatchData
 	for _, d := range c.data {
 		res = append(res, replaceVariable(c.variable, d.FindRegex(key))...)

--- a/internal/collections/concat_test.go
+++ b/internal/collections/concat_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/concat_test.go
+++ b/internal/collections/concat_test.go
@@ -4,9 +4,10 @@
 package collections
 
 import (
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -6,10 +6,9 @@ package collections
 import (
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -4,8 +4,9 @@
 package collections
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
@@ -40,7 +41,7 @@ func (c *Map) Get(key string) []string {
 	return values
 }
 
-func (c *Map) FindRegex(key *regexp.Regexp) []types.MatchData {
+func (c *Map) FindRegex(key regexp.Regexp) []types.MatchData {
 	var result []types.MatchData
 	for k, data := range c.data {
 		if key.MatchString(k) {

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -15,8 +15,9 @@ package collections
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 

--- a/internal/collections/named.go
+++ b/internal/collections/named.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/named.go
+++ b/internal/collections/named.go
@@ -5,8 +5,9 @@ package collections
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
@@ -94,7 +95,7 @@ type NamedCollectionNames struct {
 	collection *NamedCollection
 }
 
-func (c *NamedCollectionNames) FindRegex(key *regexp.Regexp) []types.MatchData {
+func (c *NamedCollectionNames) FindRegex(key regexp.Regexp) []types.MatchData {
 	panic("selection operator not supported")
 }
 

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -5,8 +5,9 @@ package collections
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/sized.go
+++ b/internal/collections/sized.go
@@ -8,10 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/collections/sized.go
+++ b/internal/collections/sized.go
@@ -5,9 +5,10 @@ package collections
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
@@ -32,7 +33,7 @@ func NewSizeCollection(variable variables.RuleVariable, data ...*NamedCollection
 }
 
 // FindRegex returns a slice of MatchData for the regex
-func (c *SizeCollection) FindRegex(*regexp.Regexp) []types.MatchData {
+func (c *SizeCollection) FindRegex(regexp.Regexp) []types.MatchData {
 	return c.FindAll()
 }
 

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -11,12 +11,11 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -6,11 +6,12 @@ package corazawaf
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
@@ -50,7 +51,7 @@ type ruleVariableException struct {
 
 	// The key for the variable that is going to be requested
 	// If nil, KeyStr is going to be used
-	KeyRx *regexp.Regexp
+	KeyRx regexp.Regexp
 }
 
 // RuleVariable is compiled during runtime by transactions
@@ -65,7 +66,7 @@ type ruleVariableParams struct {
 
 	// The key for the variable that is going to be requested
 	// If nil, KeyStr is going to be used
-	KeyRx *regexp.Regexp
+	KeyRx regexp.Regexp
 
 	// The string key for the variable that is going to be requested
 	// If KeyRx is not nil, KeyStr is ignored
@@ -454,14 +455,14 @@ func (r *Rule) AddAction(name string, action plugintypes.Action) error {
 // it will be used to match the variable, in case of string it will
 // be a fixed match, in case of nil it will match everything
 func (r *Rule) AddVariable(v variables.RuleVariable, key string, iscount bool) error {
-	var re *regexp.Regexp
+	var re regexp.Regexp
 	if len(key) > 2 && key[0] == '/' && key[len(key)-1] == '/' {
 		key = key[1 : len(key)-1]
 
 		if vare, err := memoize.Do(key, func() (interface{}, error) { return regexp.Compile(key) }); err != nil {
 			return err
 		} else {
-			re = vare.(*regexp.Regexp)
+			re = vare.(regexp.Regexp)
 		}
 	}
 
@@ -524,13 +525,13 @@ func (r *Rule) AddVariable(v variables.RuleVariable, key string, iscount bool) e
 // OK: SecRule !ARGS:id "..."
 // ERROR: SecRule !ARGS: "..."
 func (r *Rule) AddVariableNegation(v variables.RuleVariable, key string) error {
-	var re *regexp.Regexp
+	var re regexp.Regexp
 	if len(key) > 2 && key[0] == '/' && key[len(key)-1] == '/' {
 		key = key[1 : len(key)-1]
 		if vare, err := memoize.Do(key, func() (interface{}, error) { return regexp.Compile(key) }); err != nil {
 			return err
 		} else {
-			re = vare.(*regexp.Regexp)
+			re = vare.(regexp.Regexp)
 		}
 	}
 	// Prevent sigsev

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -12,14 +12,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/types"
 	"github.com/corazawaf/coraza/v3/types/variables"

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -7,11 +7,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/debuglog"

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -13,12 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/auditlog"
 	"github.com/corazawaf/coraza/v3/internal/environment"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	stringutils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/internal/sync"
 	"github.com/corazawaf/coraza/v3/types"

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -9,10 +9,11 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
@@ -119,7 +120,7 @@ type WAF struct {
 	AuditLogParts types.AuditLogParts
 
 	// Contains the regular expression for relevant status audit logging
-	AuditLogRelevantStatus *regexp.Regexp
+	AuditLogRelevantStatus regexp.Regexp
 
 	auditLogWriter plugintypes.AuditLogWriter
 

--- a/internal/operators/restpath.go
+++ b/internal/operators/restpath.go
@@ -7,8 +7,9 @@ package operators
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
@@ -21,7 +22,7 @@ var rePathTokenRe = regexp.MustCompile(`\{([^\}]+)\}`)
 // It will later transform the path to a regex and assign the variables to
 // ARGS_PATH
 type restpath struct {
-	re *regexp.Regexp
+	re regexp.Regexp
 }
 
 var _ plugintypes.Operator = (*restpath)(nil)
@@ -36,7 +37,7 @@ func newRESTPath(options plugintypes.OperatorOptions) (plugintypes.Operator, err
 	if err != nil {
 		return nil, err
 	}
-	return &restpath{re: re.(*regexp.Regexp)}, nil
+	return &restpath{re: re.(regexp.Regexp)}, nil
 }
 
 func (o *restpath) Evaluate(tx plugintypes.TransactionState, value string) bool {

--- a/internal/operators/restpath.go
+++ b/internal/operators/restpath.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 var rePathTokenRe = regexp.MustCompile(`\{([^\}]+)\}`)

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -7,9 +7,10 @@ package operators
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"unicode/utf8"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"rsc.io/binaryregexp"
 
@@ -18,7 +19,7 @@ import (
 )
 
 type rx struct {
-	re *regexp.Regexp
+	re regexp.Regexp
 }
 
 var _ plugintypes.Operator = (*rx)(nil)
@@ -40,7 +41,7 @@ func newRX(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &rx{re: re.(*regexp.Regexp)}, nil
+	return &rx{re: re.(regexp.Regexp)}, nil
 }
 
 func (o *rx) Evaluate(tx plugintypes.TransactionState, value string) bool {

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -10,12 +10,11 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"rsc.io/binaryregexp"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 type rx struct {

--- a/internal/operators/rx_test.go
+++ b/internal/operators/rx_test.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 func TestRx(t *testing.T) {

--- a/internal/operators/rx_test.go
+++ b/internal/operators/rx_test.go
@@ -5,8 +5,9 @@ package operators
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"

--- a/internal/operators/validate_nid.go
+++ b/internal/operators/validate_nid.go
@@ -10,10 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 type validateNidFunction = func(input string) bool

--- a/internal/operators/validate_nid.go
+++ b/internal/operators/validate_nid.go
@@ -7,9 +7,10 @@ package operators
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
@@ -19,7 +20,7 @@ type validateNidFunction = func(input string) bool
 
 type validateNid struct {
 	fn validateNidFunction
-	re *regexp.Regexp
+	re regexp.Regexp
 }
 
 var _ plugintypes.Operator = (*validateNid)(nil)
@@ -46,7 +47,7 @@ func newValidateNID(options plugintypes.OperatorOptions) (plugintypes.Operator, 
 		return nil, err
 	}
 
-	return &validateNid{fn: fn, re: re.(*regexp.Regexp)}, nil
+	return &validateNid{fn: fn, re: re.(regexp.Regexp)}, nil
 }
 
 func (o *validateNid) Evaluate(tx plugintypes.TransactionState, value string) bool {

--- a/internal/regexp/regex.go
+++ b/internal/regexp/regex.go
@@ -1,0 +1,82 @@
+package regexp
+
+import (
+	"regexp"
+	"sync"
+)
+
+func MustCompile(str string) *regexp.Regexp {
+	return regexp.MustCompile(str)
+}
+
+type Regexp interface {
+	MatchString(s string) bool
+	FindStringSubmatch(s string) []string
+	FindAllStringSubmatch(s string, n int) [][]string
+	SubexpNames() []string
+	Match(s []byte) bool
+	String() string
+}
+
+type lazyRegexp struct {
+	expr string
+	re   *regexp.Regexp
+	once sync.Once
+}
+
+var _ Regexp = (*lazyRegexp)(nil)
+
+func (r *lazyRegexp) MatchString(s string) bool {
+	r.once.Do(func() {
+		r.re = regexp.MustCompile(r.expr)
+	})
+
+	return r.re.MatchString(s)
+}
+
+func (r *lazyRegexp) FindStringSubmatch(s string) []string {
+	r.once.Do(func() {
+		r.re = regexp.MustCompile(r.expr)
+	})
+
+	return r.re.FindStringSubmatch(s)
+}
+
+func (r *lazyRegexp) FindAllStringSubmatch(s string, n int) [][]string {
+	r.once.Do(func() {
+		r.re = regexp.MustCompile(r.expr)
+	})
+
+	return r.re.FindAllStringSubmatch(s, n)
+}
+
+func (r *lazyRegexp) SubexpNames() []string {
+	r.once.Do(func() {
+		r.re = regexp.MustCompile(r.expr)
+	})
+
+	return r.re.SubexpNames()
+}
+
+func (r *lazyRegexp) Match(b []byte) bool {
+	r.once.Do(func() {
+		r.re = regexp.MustCompile(r.expr)
+	})
+
+	return r.re.Match(b)
+}
+
+func (r *lazyRegexp) String() string {
+	return r.expr
+}
+
+func Compile(expr string) (Regexp, error) {
+	_, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lazyRegexp{expr: expr}, nil
+}
+
+var _ Regexp = (*regexp.Regexp)(nil)

--- a/internal/regexp/regex.go
+++ b/internal/regexp/regex.go
@@ -1,32 +1,31 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package regexp
 
 import (
 	"regexp"
+
+	"github.com/corazawaf/coraza/v3/experimental/regexp/regexptypes"
 )
 
-var RegexCompiler func(expr string) (Regexp, error)
+var RegexCompiler func(expr string) (regexptypes.Regexp, error)
 
 func init() {
-	RegexCompiler = func(expr string) (Regexp, error) {
+	RegexCompiler = func(expr string) (regexptypes.Regexp, error) {
 		return regexp.Compile(expr)
 	}
 }
 
+type Regexp = regexptypes.Regexp
+
+// MustCompile is like Compile but panics if the expression cannot be parsed.
+// It is not intented to use with user input e.g. rules because it panics and
+// bypasses whatever logic provided by the users for regex compilation.
 func MustCompile(str string) *regexp.Regexp {
 	return regexp.MustCompile(str)
 }
 
-type Regexp interface {
-	MatchString(s string) bool
-	FindStringSubmatch(s string) []string
-	FindAllStringSubmatch(s string, n int) [][]string
-	SubexpNames() []string
-	Match(s []byte) bool
-	String() string
-}
-
-func Compile(expr string) (Regexp, error) {
+func Compile(expr string) (regexptypes.Regexp, error) {
 	return RegexCompiler(expr)
 }
-
-var _ Regexp = (*regexp.Regexp)(nil)

--- a/internal/regexp/regex_test.go
+++ b/internal/regexp/regex_test.go
@@ -1,0 +1,44 @@
+package regexp
+
+import (
+	"testing"
+)
+
+func TestCompile(t *testing.T) {
+	_, err := Compile(`[]`)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	_, err = Compile("[a-z]+")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMustCompile(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("MustCompile panicked with error: %v", r)
+		}
+	}()
+	MustCompile("[a-z]+")
+}
+
+func TestCompileCompilesJustOnce(t *testing.T) {
+	re, _ := Compile("[a-z]+")
+	lre := re.(*lazyRegexp)
+
+	if lre.re != nil {
+		t.Fatalf("expected nil")
+	}
+
+	m := re.Match([]byte("abc"))
+	if !m {
+		t.Fatalf("expected match")
+	}
+
+	if lre.re == nil {
+		t.Fatalf("unexpected nil")
+	}
+}

--- a/internal/regexp/regex_test.go
+++ b/internal/regexp/regex_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package regexp
 
 import (

--- a/internal/regexp/regex_test.go
+++ b/internal/regexp/regex_test.go
@@ -24,21 +24,3 @@ func TestMustCompile(t *testing.T) {
 	}()
 	MustCompile("[a-z]+")
 }
-
-func TestCompileCompilesJustOnce(t *testing.T) {
-	re, _ := Compile("[a-z]+")
-	lre := re.(*lazyRegexp)
-
-	if lre.re != nil {
-		t.Fatalf("expected nil")
-	}
-
-	m := re.Match([]byte("abc"))
-	if !m {
-		t.Fatalf("expected match")
-	}
-
-	if lre.re == nil {
-		t.Fatalf("unexpected nil")
-	}
-}

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -9,9 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/internal/auditlog"
@@ -737,7 +738,7 @@ func directiveSecAuditLogRelevantStatus(options *DirectiveOptions) error {
 		return err
 	}
 
-	options.WAF.AuditLogRelevantStatus = re.(*regexp.Regexp)
+	options.WAF.AuditLogRelevantStatus = re.(regexp.Regexp)
 	return nil
 }
 

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -12,12 +12,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/internal/auditlog"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/internal/memoize"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/types"
 )

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/corazawaf/coraza/v3/internal/regexp"
-
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 	"github.com/corazawaf/coraza/v3/types"
 )
 

--- a/internal/seclang/rules_test.go
+++ b/internal/seclang/rules_test.go
@@ -4,9 +4,10 @@
 package seclang
 
 import (
-	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/types"

--- a/internal/variables/generator/main.go
+++ b/internal/variables/generator/main.go
@@ -14,9 +14,10 @@ import (
 	"go/types"
 	"log"
 	"os"
-	"regexp"
 	"strings"
 	"text/template"
+
+	"github.com/corazawaf/coraza/v3/internal/regexp"
 )
 
 //go:embed variablesmap.go.tmpl


### PR DESCRIPTION
This PR aims to lazyload regexes to make sure we don't load in memory regexes that are not used (e.g. beyond our paranoia level) and only load them if we need them.

Some numbers I got

## main
```
total alloc: 2532805824
mallocs: 31321308
frees: 30807310
heap alloc: 47062520
heap_objects: 513998
stack_inuse: 753664
stack_sys: 753664
other_sys: 599720
num_gc: 120
pause_total_ns: 7347291
```

## this branch
```
total alloc: 2573655400
mallocs: 31423240
frees: 30985895
heap alloc: 39720744
heap_objects: 437345
stack_inuse: 950272
stack_sys: 950272
other_sys: 945888
num_gc: 127
pause_total_ns: 7457540
```


Code was:

```
func TestFTWAllocations(t *testing.T) {
	var m1, m2 runtime.MemStats
	runtime.GC()
	runtime.ReadMemStats(&m1)
	TestFTW(t)
	runtime.ReadMemStats(&m2)

	f, err := os.Create("ftw.bench")
	if err != nil {
		t.Fatal(err)
	}

	f.WriteString(fmt.Sprintf("total alloc: %d\n", m2.TotalAlloc-m1.TotalAlloc))
	f.WriteString(fmt.Sprintf("mallocs: %d\n", m2.Mallocs-m1.Mallocs))
	f.WriteString(fmt.Sprintf("frees: %d\n", m2.Frees-m1.Frees))
	f.WriteString(fmt.Sprintf("heap alloc: %d\n", m2.HeapAlloc-m1.HeapAlloc))
	f.WriteString(fmt.Sprintf("heap_objects: %d\n", m2.HeapObjects-m1.HeapObjects))
	f.WriteString(fmt.Sprintf("stack_inuse: %d\n", m2.StackInuse-m1.StackInuse))
	f.WriteString(fmt.Sprintf("stack_sys: %d\n", m2.StackSys-m1.StackSys))
	f.WriteString(fmt.Sprintf("other_sys: %d\n", m2.OtherSys-m1.OtherSys))
	f.WriteString(fmt.Sprintf("num_gc: %d\n", m2.NumGC-m1.NumGC))
	f.WriteString(fmt.Sprintf("pause_total_ns: %d\n", m2.PauseTotalNs-m1.PauseTotalNs))
func TestFTWAllocations(t *testing.T) {
	var m1, m2 runtime.MemStats
	runtime.GC()
	runtime.ReadMemStats(&m1)
	TestFTW(t)
	runtime.ReadMemStats(&m2)

	f, err := os.Create("ftw.bench")
	if err != nil {
		t.Fatal(err)
	}

	f.WriteString(fmt.Sprintf("total alloc: %d\n", m2.TotalAlloc-m1.TotalAlloc))
	f.WriteString(fmt.Sprintf("mallocs: %d\n", m2.Mallocs-m1.Mallocs))
	f.WriteString(fmt.Sprintf("frees: %d\n", m2.Frees-m1.Frees))
	f.WriteString(fmt.Sprintf("heap alloc: %d\n", m2.HeapAlloc-m1.HeapAlloc))
	f.WriteString(fmt.Sprintf("heap_objects: %d\n", m2.HeapObjects-m1.HeapObjects))
	f.WriteString(fmt.Sprintf("stack_inuse: %d\n", m2.StackInuse-m1.StackInuse))
	f.WriteString(fmt.Sprintf("stack_sys: %d\n", m2.StackSys-m1.StackSys))
	f.WriteString(fmt.Sprintf("other_sys: %d\n", m2.OtherSys-m1.OtherSys))
	f.WriteString(fmt.Sprintf("num_gc: %d\n", m2.NumGC-m1.NumGC))
	f.WriteString(fmt.Sprintf("pause_total_ns: %d\n", m2.PauseTotalNs-m1.PauseTotalNs))
}
```
