### PR TITLE
add `StringWriter` interface to `ResponseWriter`

### DIFF
--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -122,7 +122,7 @@ type responseWriter interface {
 	io.StringWriter
 }
 
-var _ stringResponseWriter = (*rwInterceptor)(nil)
+var _ responseWriter = (*rwInterceptor)(nil)
 
 // wrap wraps the interceptor into a response writer that also preserves
 // the http interfaces implemented by the original response writer to avoid
@@ -189,95 +189,95 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	switch {
 	case !isHijacker && !isPusher && !isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 		}{i}, responseProcessor
 	case !isHijacker && !isPusher && !isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			io.ReaderFrom
 		}{i, reader}, responseProcessor
 	case !isHijacker && !isPusher && isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Flusher
 		}{i, flusher}, responseProcessor
 	case !isHijacker && !isPusher && isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Flusher
 			io.ReaderFrom
 		}{i, flusher, reader}, responseProcessor
 	case !isHijacker && isPusher && !isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Pusher
 		}{i, pusher}, responseProcessor
 	case !isHijacker && isPusher && !isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Pusher
 			io.ReaderFrom
 		}{i, pusher, reader}, responseProcessor
 	case !isHijacker && isPusher && isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Pusher
 			http.Flusher
 		}{i, pusher, flusher}, responseProcessor
 	case !isHijacker && isPusher && isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Pusher
 			http.Flusher
 			io.ReaderFrom
 		}{i, pusher, flusher, reader}, responseProcessor
 	case isHijacker && !isPusher && !isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 		}{i, hijacker}, responseProcessor
 	case isHijacker && !isPusher && !isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			io.ReaderFrom
 		}{i, hijacker, reader}, responseProcessor
 	case isHijacker && !isPusher && isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Flusher
 		}{i, hijacker, flusher}, responseProcessor
 	case isHijacker && !isPusher && isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Flusher
 			io.ReaderFrom
 		}{i, hijacker, flusher, reader}, responseProcessor
 	case isHijacker && isPusher && !isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Pusher
 		}{i, hijacker, pusher}, responseProcessor
 	case isHijacker && isPusher && !isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Pusher
 			io.ReaderFrom
 		}{i, hijacker, pusher, reader}, responseProcessor
 	case isHijacker && isPusher && isFlusher && !isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Pusher
 			http.Flusher
 		}{i, hijacker, pusher, flusher}, responseProcessor
 	case isHijacker && isPusher && isFlusher && isReader:
 		return struct {
-			stringResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Pusher
 			http.Flusher
@@ -285,7 +285,7 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 		}{i, hijacker, pusher, flusher, reader}, responseProcessor
 	default:
 		return struct {
-			stringResponseWriter
+			responseWriter
 		}{i}, responseProcessor
 	}
 }

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -104,6 +104,11 @@ func (i *rwInterceptor) Write(b []byte) (int, error) {
 	return i.w.Write(b)
 }
 
+// WriteString buffers the response body until the request body limit is reach or an
+// interruption is triggered, this buffer is later used to analyse the body in
+// the response processor.
+// If the body isn't accessible or the mime type isn't processable, the response
+// body is being written to the delegate response writer directly.
 func (i *rwInterceptor) WriteString(s string) (n int, err error) {
 	return i.Write([]byte(s))
 }

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -117,7 +117,7 @@ func (i *rwInterceptor) Header() http.Header {
 	return i.w.Header()
 }
 
-type stringResponseWriter interface {
+type responseWriter interface {
 	http.ResponseWriter
 	io.StringWriter
 }


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

-----

This change adds the `io.StringWriter` interface to the `http.ResponseWriter` implementation in `interceptor.go`.

This is a fairly small addition because string values can be trivially converted to bytes.
It does not rely on the underlying `http.ResponseWriter` to also be a `io.StringWriter`.

Implementing `WriteString` is fairly common for http response writers.