### PR TITLE
fix `http.Flusher` and `io.ReaderFrom` implementation

### DIFF
--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -113,8 +113,9 @@ func (i *rwInterceptor) ReadFrom(r io.Reader) (n int64, err error) {
 }
 
 func (i *rwInterceptor) Flush() {
-	// coraza middleware always needs to buffer the entire request, response cycle
-	// we can not flush early
+	if !i.wroteHeader {
+		i.WriteHeader(i.statusCode)
+	}
 }
 
 type responseWriter interface {

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -114,7 +114,7 @@ func (i *rwInterceptor) ReadFrom(r io.Reader) (n int64, err error) {
 
 func (i *rwInterceptor) Flush() {
 	if !i.wroteHeader {
-		i.WriteHeader(i.statusCode)
+		i.WriteHeader(http.StatusOK)
 	}
 }
 

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -108,7 +108,22 @@ func (i *rwInterceptor) Header() http.Header {
 	return i.w.Header()
 }
 
-var _ http.ResponseWriter = (*rwInterceptor)(nil)
+func (i *rwInterceptor) ReadFrom(r io.Reader) (n int64, err error) {
+	return io.Copy(i, r)
+}
+
+func (i *rwInterceptor) Flush() {
+	// coraza middleware always needs to buffer the entire request, response cycle
+	// we can not flush early
+}
+
+type responseWriter interface {
+	http.ResponseWriter
+	io.ReaderFrom
+	http.Flusher
+}
+
+var _ responseWriter = (*rwInterceptor)(nil)
 
 // wrap wraps the interceptor into a response writer that also preserves
 // the http interfaces implemented by the original response writer to avoid
@@ -168,110 +183,32 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	var (
 		hijacker, isHijacker = i.w.(http.Hijacker)
 		pusher, isPusher     = i.w.(http.Pusher)
-		flusher, isFlusher   = i.w.(http.Flusher)
-		reader, isReader     = i.w.(io.ReaderFrom)
 	)
 
 	switch {
-	case !isHijacker && !isPusher && !isFlusher && !isReader:
+	case !isHijacker && !isPusher:
 		return struct {
-			http.ResponseWriter
+			responseWriter
 		}{i}, responseProcessor
-	case !isHijacker && !isPusher && !isFlusher && isReader:
+	case !isHijacker && isPusher:
 		return struct {
-			http.ResponseWriter
-			io.ReaderFrom
-		}{i, reader}, responseProcessor
-	case !isHijacker && !isPusher && isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-		}{i, flusher}, responseProcessor
-	case !isHijacker && !isPusher && isFlusher && isReader:
-		return struct {
-			http.ResponseWriter
-			http.Flusher
-			io.ReaderFrom
-		}{i, flusher, reader}, responseProcessor
-	case !isHijacker && isPusher && !isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
+			responseWriter
 			http.Pusher
 		}{i, pusher}, responseProcessor
-	case !isHijacker && isPusher && !isFlusher && isReader:
+	case isHijacker && !isPusher:
 		return struct {
-			http.ResponseWriter
-			http.Pusher
-			io.ReaderFrom
-		}{i, pusher, reader}, responseProcessor
-	case !isHijacker && isPusher && isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
-			http.Pusher
-			http.Flusher
-		}{i, pusher, flusher}, responseProcessor
-	case !isHijacker && isPusher && isFlusher && isReader:
-		return struct {
-			http.ResponseWriter
-			http.Pusher
-			http.Flusher
-			io.ReaderFrom
-		}{i, pusher, flusher, reader}, responseProcessor
-	case isHijacker && !isPusher && !isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
+			responseWriter
 			http.Hijacker
 		}{i, hijacker}, responseProcessor
-	case isHijacker && !isPusher && !isFlusher && isReader:
+	case isHijacker && isPusher:
 		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			io.ReaderFrom
-		}{i, hijacker, reader}, responseProcessor
-	case isHijacker && !isPusher && isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Flusher
-		}{i, hijacker, flusher}, responseProcessor
-	case isHijacker && !isPusher && isFlusher && isReader:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Flusher
-			io.ReaderFrom
-		}{i, hijacker, flusher, reader}, responseProcessor
-	case isHijacker && isPusher && !isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
+			responseWriter
 			http.Hijacker
 			http.Pusher
 		}{i, hijacker, pusher}, responseProcessor
-	case isHijacker && isPusher && !isFlusher && isReader:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Pusher
-			io.ReaderFrom
-		}{i, hijacker, pusher, reader}, responseProcessor
-	case isHijacker && isPusher && isFlusher && !isReader:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Pusher
-			http.Flusher
-		}{i, hijacker, pusher, flusher}, responseProcessor
-	case isHijacker && isPusher && isFlusher && isReader:
-		return struct {
-			http.ResponseWriter
-			http.Hijacker
-			http.Pusher
-			http.Flusher
-			io.ReaderFrom
-		}{i, hijacker, pusher, flusher, reader}, responseProcessor
 	default:
 		return struct {
-			http.ResponseWriter
+			responseWriter
 		}{i}, responseProcessor
 	}
 }

--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -186,10 +186,6 @@ func wrap(w http.ResponseWriter, r *http.Request, tx types.Transaction) (
 	)
 
 	switch {
-	case !isHijacker && !isPusher:
-		return struct {
-			responseWriter
-		}{i}, responseProcessor
 	case !isHijacker && isPusher:
 		return struct {
 			responseWriter

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -47,6 +47,75 @@ func TestWriteHeader(t *testing.T) {
 	}
 }
 
+func TestWrite(t *testing.T) {
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := waf.NewTransaction()
+	req, _ := http.NewRequest("GET", "", nil)
+	res := httptest.NewRecorder()
+
+	rw, responseProcessor := wrap(res, req, tx)
+	_, err = rw.Write([]byte("hello"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = rw.Write([]byte("world"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = responseProcessor(tx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if want, have := 200, res.Code; want != have {
+		t.Errorf("unexpected status code, want %d, have %d", want, have)
+	}
+}
+
+func TestWriteWithWriteHeader(t *testing.T) {
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := waf.NewTransaction()
+	req, _ := http.NewRequest("GET", "", nil)
+	res := httptest.NewRecorder()
+
+	rw, responseProcessor := wrap(res, req, tx)
+	rw.WriteHeader(204)
+	// although we called WriteHeader, status code should be applied until
+	// responseProcessor is called.
+	if unwanted, have := 204, res.Code; unwanted == have {
+		t.Errorf("unexpected status code %d", have)
+	}
+
+	_, err = rw.Write([]byte("hello"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = rw.Write([]byte("world"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = responseProcessor(tx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if want, have := 204, res.Code; want != have {
+		t.Errorf("unexpected status code, want %d, have %d", want, have)
+	}
+}
+
 func TestFlush(t *testing.T) {
 	waf, err := coraza.NewWAF(coraza.NewWAFConfig())
 	if err != nil {
@@ -75,6 +144,14 @@ func TestFlush(t *testing.T) {
 	}
 }
 
+type testReaderFrom struct {
+	io.Writer
+}
+
+func (x *testReaderFrom) ReadFrom(r io.Reader) (n int64, err error) {
+	return io.Copy(x, r)
+}
+
 func TestReadFrom(t *testing.T) {
 	waf, err := coraza.NewWAF(coraza.NewWAFConfig())
 	if err != nil {
@@ -84,9 +161,82 @@ func TestReadFrom(t *testing.T) {
 	tx := waf.NewTransaction()
 	req, _ := http.NewRequest("GET", "", nil)
 	res := httptest.NewRecorder()
-	rw, _ := wrap(res, req, tx)
+
+	type responseWriter interface {
+		http.ResponseWriter
+		http.Flusher
+	}
+
+	resWithReaderFrom := struct {
+		responseWriter
+		io.ReaderFrom
+	}{
+		res,
+		&testReaderFrom{res},
+	}
+
+	rw, responseProcessor := wrap(resWithReaderFrom, req, tx)
 	rw.WriteHeader(204)
+	// although we called WriteHeader, status code should be applied until
+	// responseProcessor is called.
+	if unwanted, have := 204, res.Code; unwanted == have {
+		t.Errorf("unexpected status code %d", have)
+	}
+
 	_, err = rw.(io.ReaderFrom).ReadFrom(bytes.NewBuffer([]byte("hello world")))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	err = responseProcessor(tx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if want, have := 204, res.Code; want != have {
+		t.Errorf("unexpected status code, want %d, have %d", want, have)
+	}
+}
+
+type testPusher struct{}
+
+func (x *testPusher) Push(target string, opts *http.PushOptions) error {
+	return nil
+}
+
+func TestPusher(t *testing.T) {
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := waf.NewTransaction()
+	req, _ := http.NewRequest("GET", "", nil)
+	res := httptest.NewRecorder()
+
+	type responseWriter interface {
+		http.ResponseWriter
+		http.Flusher
+	}
+
+	resWithPush := struct {
+		responseWriter
+		http.Pusher
+	}{
+		res,
+		&testPusher{},
+	}
+
+	rw, responseProcessor := wrap(resWithPush, req, tx)
+	rw.WriteHeader(204)
+	rw.(http.Pusher).Push("http://example.com", nil)
+	// although we called WriteHeader, status code should be applied until
+	// responseProcessor is called.
+	if unwanted, have := 204, res.Code; unwanted == have {
+		t.Errorf("unexpected status code %d", have)
+	}
+
+	err = responseProcessor(tx, req)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -307,11 +307,9 @@ func TestInterface(t *testing.T) {
 	t.Run("http.Hijacker and http.Pusher", func(t *testing.T) {
 		rw, _ := wrap(struct {
 			http.ResponseWriter
-			http.Flusher
 			http.Hijacker
 			http.Pusher
 		}{
-			res,
 			res,
 			&testHijacker{},
 			&testPusher{},

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -229,7 +229,11 @@ func TestPusher(t *testing.T) {
 
 	rw, responseProcessor := wrap(resWithPush, req, tx)
 	rw.WriteHeader(204)
-	rw.(http.Pusher).Push("http://example.com", nil)
+	err = rw.(http.Pusher).Push("http://example.com", nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	// although we called WriteHeader, status code should be applied until
 	// responseProcessor is called.
 	if unwanted, have := 204, res.Code; unwanted == have {

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -86,7 +86,10 @@ func TestReadFrom(t *testing.T) {
 	res := httptest.NewRecorder()
 	rw, _ := wrap(res, req, tx)
 	rw.WriteHeader(204)
-	rw.(io.ReaderFrom).ReadFrom(bytes.NewBuffer([]byte("hello world")))
+	_, err = rw.(io.ReaderFrom).ReadFrom(bytes.NewBuffer([]byte("hello world")))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	if want, have := 204, res.Code; want != have {
 		t.Errorf("unexpected status code, want %d, have %d", want, have)


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

--------

Before this change `http.Flusher` and `io.ReaderFrom` essentially acted like a bypass for the coraza middleware because they directly called the underlying writer.

`http.Flusher` is unimplementable because it doesn't make sense to flush early to the client. It does have one observable effect. A call to `Flush` before a call to `Write` (or `WriteHeader`) also implies a call to `WriteHeader`.

`io.ReaderFrom` can be implemented by linking it with `Write` through `io.Copy`