### PR TITLE
fix: stackoverflow in `ReadFrom`

### DIFF
--- a/http/interceptor.go
+++ b/http/interceptor.go
@@ -109,7 +109,7 @@ func (i *rwInterceptor) Header() http.Header {
 }
 
 func (i *rwInterceptor) ReadFrom(r io.Reader) (n int64, err error) {
-	return io.Copy(i, r)
+	return io.Copy(struct{ io.Writer }{i}, r)
 }
 
 func (i *rwInterceptor) Flush() {

--- a/http/interceptor_test.go
+++ b/http/interceptor_test.go
@@ -214,6 +214,11 @@ func TestReadFrom(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
+	_, err = rw.(io.ReaderFrom).ReadFrom(struct{ io.Reader }{bytes.NewBuffer([]byte("hello world"))})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
 	err = responseProcessor(tx, req)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

------------

https://github.com/corazawaf/coraza/pull/923 introduced a stackoverflow when the value passed to `ReadFrom` does not implement the `io.WriterTo` interface.

From the `go` stdlib source :

```go
// copyBuffer is the actual implementation of Copy and CopyBuffer.
// if buf is nil, one is allocated.
func copyBuffer(dst Writer, src Reader, buf []byte) (written int64, err error) {
	// If the reader has a WriteTo method, use it to do the copy.
	// Avoids an allocation and a copy.
	if wt, ok := src.(WriterTo); ok {
		return wt.WriteTo(dst)
	}
	// Similarly, if the writer has a ReadFrom method, use it to do the copy.
	if rt, ok := dst.(ReaderFrom); ok {
		return rt.ReadFrom(src)
	}
```

If the first optimization can run no stackoverflow will happen.
But if the `src` does not implement `io.WriterTo` it will go to a second optimization.

In our use case it triggers a stackoverflow by calling itself.

There might be other ways to fix this and any suggestions are welcome!
I chose to erase all interfaces from the `ResponseWriter` except `io.Writer`.

This forces `io.Copy` to use `Write()`, which was the intended behavior.