### PR TITLE
fix: more forgiving base64 transformation [custom implementation]

### DIFF
--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -25,6 +25,9 @@ var base64DecMap = []byte{
 // Padding is optional.
 // Partial decoding is returned up to the first invalid character (if any).
 // New line characters (\r and \n) are ignored.
+// Note: a custom base64 decoder is used in order to return partial decoding when an error arises. It
+// would be possible to use the standard library only relying on undocumented behaviors of the decoder.
+// For more context, see https://github.com/corazawaf/coraza/pull/940
 func base64decode(data string) (string, bool, error) {
 	res := doBase64decode(data)
 	return res, true, nil

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -3,32 +3,95 @@
 
 package transformations
 
-import (
-	"encoding/base64"
-	"strings"
+import "strings"
 
-	stringsutil "github.com/corazawaf/coraza/v3/internal/strings"
-)
+// // base64decode decodes a Base64-encoded string.
+// func base64decode(data string) (string, bool, error) {
+// 	// RawStdEncoding.DecodeString accepts and requires an unpadded string as input
+// 	// https://stackoverflow.com/questions/31971614/base64-encode-decode-without-padding-on-golang-appengine
+// 	dataNoPadding := strings.TrimRight(data, "=")
+// 	dec, err := base64.RawStdEncoding.DecodeString(dataNoPadding)
+// 	if err != nil {
+// 		// If the error is of type CorruptInputError, we can get the position of the illegal character
+// 		// and perform a partial decoding up to that point
+// 		if corrErr, ok := err.(base64.CorruptInputError); ok {
+// 			illegalCharPos := int(corrErr)
+// 			// Forgiving call (no error check) to DecodeString. Decoding is performed truncating
+// 			// the input string to the first error index. If a new decoding error occurs,
+// 			// it will not be about an illegal character but a malformed encoding of the trailing
+// 			// character because of the truncation. The dec will still contain a best effort decoded string
+// 			dec, _ = base64.RawStdEncoding.DecodeString(dataNoPadding[:illegalCharPos])
+// 		} else {
+// 			return data, false, nil
+// 		}
+// 	}
+// 	return stringsutil.WrapUnsafe(dec), true, nil
+// }
+
+var base64DecMap = []byte{
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 127, 127, 127, 127, 127, 127, 127,
+	127, 127, 127, 62, 127, 127, 127, 63, 52, 53,
+	54, 55, 56, 57, 58, 59, 60, 61, 127, 127,
+	127, 64, 127, 127, 127, 0, 1, 2, 3, 4,
+	5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+	15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+	25, 127, 127, 127, 127, 127, 127, 26, 27, 28,
+	29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+	39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+	49, 50, 51, 127, 127, 127, 127, 127,
+}
 
 // base64decode decodes a Base64-encoded string.
+// Important: We cannot use the golang base64 package because it does not
+// support mixed content like RAW+BASE64+RAW
+// This implementations supports base64 between non-base64 content
 func base64decode(data string) (string, bool, error) {
-	// RawStdEncoding.DecodeString accepts and requires an unpadded string as input
-	// https://stackoverflow.com/questions/31971614/base64-encode-decode-without-padding-on-golang-appengine
-	dataNoPadding := strings.TrimRight(data, "=")
-	dec, err := base64.RawStdEncoding.DecodeString(dataNoPadding)
-	if err != nil {
-		// If the error is of type CorruptInputError, we can get the position of the illegal character
-		// and perform a partial decoding up to that point
-		if corrErr, ok := err.(base64.CorruptInputError); ok {
-			illegalCharPos := int(corrErr)
-			// Forgiving call (no error check) to DecodeString. Decoding is performed truncating
-			// the input string to the first error index. If a new decoding error occurs,
-			// it will not be about an illegal character but a malformed encoding of the trailing
-			// character because of the truncation. The dec will still contain a best effort decoded string
-			dec, _ = base64.RawStdEncoding.DecodeString(dataNoPadding[:illegalCharPos])
-		} else {
-			return data, false, nil
+	res := doBase64decode(data)
+	return res, true, nil
+}
+
+func doBase64decode(src string) string {
+	slen := len(src)
+	if slen == 0 {
+		return src
+	}
+
+	var n, x, srcc int
+	var dst strings.Builder
+	dst.Grow(slen)
+
+	for ; srcc < slen; srcc++ {
+		// If invalid characther or padding reached, we stop decoding
+		if src[srcc] == '=' || src[srcc] == ' ' || src[srcc] > 127 || base64DecMap[src[srcc]] == 127 {
+			break
+		}
+		if src[srcc] == '\r' || src[srcc] == '\n' {
+			continue
+		}
+
+		x = (x << 6) | int(base64DecMap[src[srcc]]&0x3F)
+		n++
+		if n == 4 {
+			dst.WriteByte(byte(x >> 16))
+			dst.WriteByte(byte(x >> 8))
+			dst.WriteByte(byte(x))
+			n = 0
+			x = 0
 		}
 	}
-	return stringsutil.WrapUnsafe(dec), true, nil
+
+	// Handle any remaining characters
+	if n == 2 {
+		x <<= 12
+		dst.WriteByte(byte(x >> 16))
+	} else if n == 3 {
+		x <<= 6
+		dst.WriteByte(byte(x >> 16))
+		dst.WriteByte(byte(x >> 8))
+	}
+
+	return dst.String()
 }

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -21,8 +21,10 @@ func base64decode(data string) (string, bool, error) {
 		// and perform a partial decoding up to that point
 		if corrErr, ok := err.(base64.CorruptInputError); ok {
 			illegalCharPos := int(corrErr)
-			// Forgiving call to DecodeString, decoding is performed up to the illegal characther
-			// If an error occurs, dec will still contain the decoded string up to the error
+			// Forgiving call (no error check) to DecodeString. Decoding is performed truncating
+			// the input string to the first error index. If a new decoding error occurs,
+			// it will not be about an illegal character but a malformed encoding of the trailing
+			// character because of the truncation. The dec will still contain a best effort decoded string
 			dec, _ = base64.RawStdEncoding.DecodeString(dataNoPadding[:illegalCharPos])
 		} else {
 			return data, false, nil

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -5,16 +5,28 @@ package transformations
 
 import (
 	"encoding/base64"
+	"strings"
 
 	stringsutil "github.com/corazawaf/coraza/v3/internal/strings"
 )
 
 // base64decode decodes a Base64-encoded string.
 func base64decode(data string) (string, bool, error) {
-	dec, err := base64.StdEncoding.DecodeString(data)
+	// RawStdEncoding.DecodeString accepts and requires an unpadded string as input
+	// https://stackoverflow.com/questions/31971614/base64-encode-decode-without-padding-on-golang-appengine
+	dataNoPadding := strings.TrimRight(data, "=")
+	dec, err := base64.RawStdEncoding.DecodeString(dataNoPadding)
 	if err != nil {
-		// Forgiving implementation, which ignores invalid characters
-		return data, false, nil
+		// If the error is of type CorruptInputError, we can get the position of the illegal character
+		// and perform a partial decoding up to that point
+		if corrErr, ok := err.(base64.CorruptInputError); ok {
+			illegalCharPos := int(corrErr)
+			// Forgiving call to DecodeString, decoding is performed up to the illegal characther
+			// If an error occurs, dec will still contain the decoded string up to the error
+			dec, _ = base64.RawStdEncoding.DecodeString(dataNoPadding[:illegalCharPos])
+		} else {
+			return data, false, nil
+		}
 	}
 	return stringsutil.WrapUnsafe(dec), true, nil
 }

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -36,20 +36,26 @@ func doBase64decode(src string) string {
 		return src
 	}
 
-	var n, x, srcc int
+	var n, x int
 	var dst strings.Builder
 	dst.Grow(slen)
 
-	for ; srcc < slen; srcc++ {
+	for i := 0; i < slen; i++ {
+		currChar := src[i]
 		// If invalid character or padding reached, we stop decoding
-		if src[srcc] == '=' || src[srcc] == ' ' || src[srcc] > 127 || base64DecMap[src[srcc]] == 127 {
+		if currChar == '=' || currChar == ' ' || currChar > 127 {
 			break
 		}
-		if src[srcc] == '\r' || src[srcc] == '\n' {
+		decodedChar := base64DecMap[currChar]
+		// Another condition of invalid character
+		if decodedChar == 127 {
+			break
+		}
+		if currChar == '\r' || currChar == '\n' {
 			continue
 		}
 
-		x = (x << 6) | int(base64DecMap[src[srcc]]&0x3F)
+		x = (x << 6) | int(decodedChar&0x3F)
 		n++
 		if n == 4 {
 			dst.WriteByte(byte(x >> 16))

--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -42,6 +42,10 @@ func doBase64decode(src string) string {
 
 	for i := 0; i < slen; i++ {
 		currChar := src[i]
+		// new line characters are ignored.
+		if currChar == '\r' || currChar == '\n' {
+			continue
+		}
 		// If invalid character or padding reached, we stop decoding
 		if currChar == '=' || currChar == ' ' || currChar > 127 {
 			break
@@ -50,9 +54,6 @@ func doBase64decode(src string) string {
 		// Another condition of invalid character
 		if decodedChar == 127 {
 			break
-		}
-		if currChar == '\r' || currChar == '\n' {
-			continue
 		}
 
 		x = (x << 6) | int(decodedChar&0x3F)

--- a/internal/transformations/base64decode_test.go
+++ b/internal/transformations/base64decode_test.go
@@ -70,6 +70,93 @@ var b64DecodeTests = []struct {
 		input:    "PFRFU1Q-",
 		expected: "<TEST",
 	},
+	// The following tests are from the golang base64 decoder tests
+	// Source: https://github.com/golang/go/blob/master/src/encoding/base64/base64_test.go
+	{
+		name:     "golang test - RFC 3548 examples",
+		input:    "FPucA9l+",
+		expected: "\x14\xfb\x9c\x03\xd9\x7e",
+	},
+	{
+		name:     "golang test - RFC 3548 examples",
+		input:    "FPucA9k=",
+		expected: "\x14\xfb\x9c\x03\xd9",
+	},
+	{
+		name:     "golang test - RFC 3548 examples",
+		input:    "FPucAw==",
+		expected: "\x14\xfb\x9c\x03",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "",
+		expected: "",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zg==",
+		expected: "f",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zm8=",
+		expected: "fo",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zm9v",
+		expected: "foo",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zm9vYg==",
+		expected: "foob",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zm9vYmE=",
+		expected: "fooba",
+	},
+	{
+		name:     "golang test - RFC 4648 examples",
+		input:    "Zm9vYmFy",
+		expected: "foobar",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "c3VyZS4=",
+		expected: "sure.",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "c3VyZQ==",
+		expected: "sure",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "c3Vy",
+		expected: "sur",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "c3U=",
+		expected: "su",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "bGVhc3VyZS4=",
+		expected: "leasure.",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "ZWFzdXJlLg==",
+		expected: "easure.",
+	},
+	{
+		name:     "golang test - Wikipedia examples",
+		input:    "YXN1cmUu",
+		expected: "asure.",
+	},
 }
 
 func TestBase64Decode(t *testing.T) {

--- a/internal/transformations/base64decode_test.go
+++ b/internal/transformations/base64decode_test.go
@@ -71,7 +71,7 @@ var b64DecodeTests = []struct {
 		expected: "<TEST",
 	},
 	// The following tests are from the golang base64 decoder tests
-	// Source: https://github.com/golang/go/blob/master/src/encoding/base64/base64_test.go
+	// Source: https://github.com/golang/go/blob/c95fe91d0715dc0a8d55ac80a80f383c3635548b/src/encoding/base64/base64_test.go#L25C4-L49
 	{
 		name:     "golang test - RFC 3548 examples",
 		input:    "FPucA9l+",

--- a/internal/transformations/base64decode_test.go
+++ b/internal/transformations/base64decode_test.go
@@ -41,27 +41,32 @@ var b64DecodeTests = []struct {
 		expected: "<TEST>",
 	},
 	{
-		name:     "decoded up to the space (invalid caracter)",
+		name:     "Malformed base64 encoding",
+		input:    "PHNjcmlwd",
+		expected: "<scrip",
+	},
+	{
+		name:     "decoded up to the space (invalid character)",
 		input:    "PFR FU1Q+",
 		expected: "<T",
 	},
 	{
 		name:     "decoded up to the dot (invalid caracter)",
 		input:    "P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
-		expected: "",
+		expected: "", // Only the P character does not result in a printable character conversion.
 	},
 	{
-		name:     "decoded up to the dot (invalid caracter)",
+		name:     "decoded up to the dot (invalid character)",
 		input:    "PHNjcmlwd.D5hbGVydCgxKTwvc2NyaXB0Pg==",
 		expected: "<scrip",
 	},
 	{
-		name:     "decoded up to the dot (invalid caracter)",
+		name:     "decoded up to the dot (invalid character)",
 		input:    "PHNjcmlwdD.5hbGVydCgxKTwvc2NyaXB0Pg==",
 		expected: "<script",
 	},
 	{
-		name:     "decoded up to the dash (invalid caracter for base64.RawStdEncoding)",
+		name:     "decoded up to the dash (invalid character for base64.RawStdEncoding)",
 		input:    "PFRFU1Q-",
 		expected: "<TEST",
 	},

--- a/internal/transformations/base64decode_test.go
+++ b/internal/transformations/base64decode_test.go
@@ -51,7 +51,7 @@ var b64DecodeTests = []struct {
 		expected: "<T",
 	},
 	{
-		name:     "decoded up to the dot (invalid caracter)",
+		name:     "decoded up to the dot (invalid character)",
 		input:    "P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
 		expected: "", // Only the P character does not result in a printable character conversion.
 	},
@@ -66,7 +66,7 @@ var b64DecodeTests = []struct {
 		expected: "<script",
 	},
 	{
-		name:     "decoded up to the dash (invalid character for base64.RawStdEncoding)",
+		name:     "decoded up to the dash (invalid character for base64, only valid for Base64url)",
 		input:    "PFRFU1Q-",
 		expected: "<TEST",
 	},


### PR DESCRIPTION
Sibling of https://github.com/corazawaf/coraza/pull/940, providing a custom implementation of base64 decoding. The same tests are executed.

The implementation is a refactored version of https://github.com/corazawaf/coraza/pull/758 to allow missing padding and decode up to an illegal character.

We have to decide between:
- Rely (hacky) on a the std library transformation (definitely more confident about the implementation)
- Rely on and maintain our custom implementation (faster, less confident about the implementation, no unexpected changes not relying on undocumented std library functions behaviors) 

Benchmarks:

**PR: custom implementation (this PR)**
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/transformations
BenchmarkB64Decode/VGVzdENhc2U=-10         	27859436	        36.83 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/VGVzdABDYXNl-10         	30617679	        38.87 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/VGVzdENhc2U-10          	32812024	        36.56 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/PA==-10                 	69833588	        16.98 ns/op	       4 B/op	       1 allocs/op
BenchmarkB64Decode/PFRFU1Q+-10             	42157344	        28.29 ns/op	       8 B/op	       1 allocs/op
BenchmarkB64Decode/PHNjcmlwd-10            	36910915	        33.60 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/PFR_FU1Q+-10            	57075021	        22.50 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==-10         	58432546	        19.89 ns/op	      48 B/op	       1 allocs/op
BenchmarkB64Decode/PHNjcmlwd.D5hbGVydCgxKTwvc2NyaXB0Pg==-10         	33036349	        35.46 ns/op	      48 B/op	       1 allocs/op
BenchmarkB64Decode/PHNjcmlwdD.5hbGVydCgxKTwvc2NyaXB0Pg==-10         	31625136	        37.47 ns/op	      48 B/op	       1 allocs/op
BenchmarkB64Decode/PFRFU1Q--10                                      	43652700	        27.65 ns/op	       8 B/op	       1 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/internal/transformations	13.494s
```


**PR: Std library (https://github.com/corazawaf/coraza/pull/940)**
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/transformations
BenchmarkB64Decode/VGVzdENhc2U=-10         	48350179	        26.08 ns/op	       8 B/op	       1 allocs/op
BenchmarkB64Decode/VGVzdABDYXNl-10         	41106975	        27.79 ns/op	      16 B/op	       1 allocs/op
BenchmarkB64Decode/VGVzdENhc2U-10          	49100253	        24.27 ns/op	       8 B/op	       1 allocs/op
BenchmarkB64Decode/PA==-10                 	57690343	        20.77 ns/op	       1 B/op	       1 allocs/op
BenchmarkB64Decode/PFRFU1Q+-10             	46958845	        24.56 ns/op	       8 B/op	       1 allocs/op
BenchmarkB64Decode/PHNjcmlwd-10            	23393598	        51.72 ns/op	      16 B/op	       2 allocs/op
BenchmarkB64Decode/PFR_FU1Q+-10            	27806850	        43.29 ns/op	       8 B/op	       2 allocs/op
BenchmarkB64Decode/P.HNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==-10         	20983162	        55.50 ns/op	      80 B/op	       2 allocs/op
BenchmarkB64Decode/PHNjcmlwd.D5hbGVydCgxKTwvc2NyaXB0Pg==-10         	15266341	        78.58 ns/op	      88 B/op	       3 allocs/op
BenchmarkB64Decode/PHNjcmlwdD.5hbGVydCgxKTwvc2NyaXB0Pg==-10         	16138278	        74.43 ns/op	      88 B/op	       3 allocs/op
BenchmarkB64Decode/PFRFU1Q--10                                      	24491835	        48.89 ns/op	      16 B/op	       2 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/internal/transformations	14.896s
```

Tentatively closes https://github.com/corazawaf/coraza/issues/926, it should also fix 934131-5 and 934131-7 CRS 4.0.0-rc2 failing test (https://github.com/corazawaf/coraza/pull/899)