### PR TITLE
Add raw body processor

### DIFF
--- a/internal/bodyprocessors/raw.go
+++ b/internal/bodyprocessors/raw.go
@@ -1,0 +1,40 @@
+package bodyprocessors
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/collections"
+)
+
+type rawBodyProcessor struct {
+}
+
+func (*rawBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
+	buf := new(strings.Builder)
+	if _, err := io.Copy(buf, reader); err != nil {
+		return err
+	}
+
+	b := buf.String()
+
+	v.RequestBody().(*collections.Single).Set(b)
+	v.RequestBodyLength().(*collections.Single).Set(strconv.Itoa(len(b)))
+	return nil
+}
+
+func (*rawBodyProcessor) ProcessResponse(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
+	return nil
+}
+
+var (
+	_ plugintypes.BodyProcessor = &rawBodyProcessor{}
+)
+
+func init() {
+	RegisterBodyProcessor("raw", func() plugintypes.BodyProcessor {
+		return &rawBodyProcessor{}
+	})
+}

--- a/internal/bodyprocessors/raw.go
+++ b/internal/bodyprocessors/raw.go
@@ -13,8 +13,8 @@ type rawBodyProcessor struct {
 }
 
 func (*rawBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.TransactionVariables, _ plugintypes.BodyProcessorOptions) error {
-	buf := new(strings.Builder)
-	if _, err := io.Copy(buf, reader); err != nil {
+	var buf strings.Builder
+	if _, err := io.Copy(&buf, reader); err != nil {
 		return err
 	}
 

--- a/internal/bodyprocessors/raw.go
+++ b/internal/bodyprocessors/raw.go
@@ -12,7 +12,7 @@ import (
 type rawBodyProcessor struct {
 }
 
-func (*rawBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
+func (*rawBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.TransactionVariables, _ plugintypes.BodyProcessorOptions) error {
 	buf := new(strings.Builder)
 	if _, err := io.Copy(buf, reader); err != nil {
 		return err
@@ -25,7 +25,7 @@ func (*rawBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.Transact
 	return nil
 }
 
-func (*rawBodyProcessor) ProcessResponse(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
+func (*rawBodyProcessor) ProcessResponse(io.Reader, plugintypes.TransactionVariables, plugintypes.BodyProcessorOptions) error {
 	return nil
 }
 

--- a/internal/bodyprocessors/raw_test.go
+++ b/internal/bodyprocessors/raw_test.go
@@ -1,0 +1,31 @@
+package bodyprocessors_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/bodyprocessors"
+	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+)
+
+func TestRAW(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables()
+
+	body := `this is a body
+without &any=meaning`
+	if err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{}); err != nil {
+		t.Error(err)
+	}
+	if v.RequestBody().Get() != body {
+		t.Errorf("Expected %s, got %s", body, v.RequestBody().Get())
+	}
+	if rbl, _ := strconv.Atoi(v.RequestBodyLength().Get()); rbl != len(body) {
+		t.Errorf("Expected %d, got %s", len(body), v.RequestBodyLength().Get())
+	}
+}


### PR DESCRIPTION
Adds the raw body processor discussed in #938.

Example configuration:
```
 Secrule REQUEST_HEADERS:Content-Type "@rx ^application/x-www-form-urlencoded" "id:100,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=URLENCODED"
 Secrule REQUEST_HEADERS:Content-Type "@rx ^multipart/form-data" "id:101,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=MULTIPART"
 Secrule REQUEST_HEADERS:Content-Type "@rx ^application/xml" "id:102,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=XML"
 Secrule REQUEST_HEADERS:Content-Type "@rx ^application/json" "id:103,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=JSON"
 Secrule REQUEST_HEADERS:Content-Type "@rx ^text/xml" "id:104,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=XML"
 SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" "id:105,phase:1,pass,nolog,noauditlog,ctl:requestBodyProcessor=RAW"
 ```