### PR TITLE
feat(experimental): adds transaction started and transaction closed hooks to the middleware.

### DIFF
--- a/experimental/plugins/plugintypes/transaction.go
+++ b/experimental/plugins/plugintypes/transaction.go
@@ -4,6 +4,8 @@
 package plugintypes
 
 import (
+	"context"
+
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/types"
@@ -34,7 +36,11 @@ type TransactionState interface {
 	// CaptureField captures a field.
 	CaptureField(idx int, value string)
 
+	// LastPhase that was evaluated
 	LastPhase() types.RulePhase
+
+	// Context returns the context of the transaction.
+	Context() context.Context
 }
 
 // TransactionVariables has pointers to all the variables of the transaction

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -126,6 +126,10 @@ func (tx *Transaction) ID() string {
 	return tx.id
 }
 
+func (tx *Transaction) Context() context.Context {
+	return tx.context
+}
+
 func (tx *Transaction) Variables() plugintypes.TransactionVariables {
 	return &tx.variables
 }


### PR DESCRIPTION
This is specially useful when you want to use transaction data to populate things like logs or spans in a trace enriching the experience and connecting the dots with observability.

This is still ongoing. I am not 100% sure the TransactionClose method has any utility besides e.g. adding a span event for start and close or do something with MatchedRules maybe? (request for comments @anuraaga @jptosso @M4tteoP @MrWako)