### PR TITLE
tests: adds logs for unexpected status code.

### DIFF
--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -254,7 +254,10 @@ func Run(cfg Config) error {
 			resp, err := client.Do(req)
 			fmt.Printf("[Wait] Waiting for %s. Timeout: %ds\n", healthCheck.url, timeout)
 			if err == nil {
-				io.Copy(io.Discard, resp.Body)
+				_, err = io.Copy(io.Discard, res.Body)
+				if err != nil {
+					return err
+				}
 				resp.Body.Close()
 
 				if resp.StatusCode == healthCheck.expectedCode {

--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -254,7 +254,7 @@ func Run(cfg Config) error {
 			resp, err := client.Do(req)
 			fmt.Printf("[Wait] Waiting for %s. Timeout: %ds\n", healthCheck.url, timeout)
 			if err == nil {
-				_, err = io.Copy(io.Discard, res.Body)
+				_, err = io.Copy(io.Discard, resp.Body)
 				if err != nil {
 					return err
 				}

--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -254,14 +254,19 @@ func Run(cfg Config) error {
 			resp, err := client.Do(req)
 			fmt.Printf("[Wait] Waiting for %s. Timeout: %ds\n", healthCheck.url, timeout)
 			if err == nil {
+				io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
+
 				if resp.StatusCode == healthCheck.expectedCode {
 					fmt.Printf("[Ok] Check successful, got status code %d\n", resp.StatusCode)
 					break
 				}
+
 				if healthCheck.expectedCode == configCheckStatusCode {
 					return fmt.Errorf("configs check failed, got status code %d, expected %d. Please check configs used", resp.StatusCode, healthCheck.expectedCode)
 				}
+
+				fmt.Printf("[Wait] Unexpected status code %d\n", resp.StatusCode)
 			}
 			timeout--
 			if timeout == 0 {

--- a/http/e2e/e2e.go
+++ b/http/e2e/e2e.go
@@ -270,7 +270,11 @@ func Run(cfg Config) error {
 			}
 			timeout--
 			if timeout == 0 {
-				return fmt.Errorf("timeout waiting for response from %s, make sure the server is running. Last request error: %v", healthCheck.url, err)
+				if err != nil {
+					return fmt.Errorf("timeout waiting for response from %s, make sure the server is running. Last request error: %v", healthCheck.url, err)
+				}
+
+				return fmt.Errorf("timeout waiting for response from %s, unexpected status code", healthCheck.url)
 			}
 		}
 	}


### PR DESCRIPTION
To give more context, when trying this e2e suite with traefik and traefik wasn't able to pull the wasm binary then every call would return 404 which I wasn't informed by logs.