### PR TITLE
cache Rule ID string version

### DIFF
--- a/internal/corazarules/rule.go
+++ b/internal/corazarules/rule.go
@@ -4,25 +4,33 @@
 package corazarules
 
 import (
+	"strconv"
+
 	"github.com/corazawaf/coraza/v3/types"
 )
+
+const noID = 0
 
 // RuleMetadata is used to store rule metadata
 // that can be used across packages
 type RuleMetadata struct {
-	ID_       int
-	File_     string
-	Line_     int
-	Rev_      string
-	Severity_ types.RuleSeverity
-	Version_  string
-	Tags_     []string
-	Maturity_ int
-	Accuracy_ int
-	Operator_ string
-	Phase_    types.RulePhase
-	Raw_      string
-	SecMark_  string
+	ID_          int
+	File_        string
+	Line_        int
+	Rev_         string
+	Severity_    types.RuleSeverity
+	Version_     string
+	Tags_        []string
+	Maturity_    int
+	Accuracy_    int
+	Operator_    string
+	Phase_       types.RulePhase
+	Raw_         string
+	SecMark_     string
+	cachedStrID_ string
+	// Contains the Id of the parent rule if you are inside
+	// a chain. Otherwise, it will be 0
+	ParentID_ int
 }
 
 func (r *RuleMetadata) ID() int {
@@ -75,4 +83,15 @@ func (r *RuleMetadata) Raw() string {
 
 func (r *RuleMetadata) SecMark() string {
 	return r.SecMark_
+}
+
+func (r *RuleMetadata) StrID() string {
+	if r.cachedStrID_ == "" {
+		rid := r.ID_
+		if rid == noID {
+			rid = r.ParentID_
+		}
+		r.cachedStrID_ = strconv.Itoa(rid)
+	}
+	return r.cachedStrID_
 }

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"unsafe"
@@ -104,10 +103,6 @@ type Rule struct {
 	// the rule evaluation process
 	actions []ruleActionParams
 
-	// Contains the Id of the parent rule if you are inside
-	// a chain. Otherwise, it will be 0
-	ParentID_ int
-
 	// Capture is used by the transaction to tell the operator
 	// to capture variables on TX:0-9
 	Capture bool
@@ -189,11 +184,6 @@ const noID = 0
 func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Transaction, collectiveMatchedValues *[]types.MatchData, chainLevel int, cache map[transformationKey]*transformationValue) []types.MatchData {
 	tx.Capture = r.Capture
 
-	rid := r.ID_
-	if rid == noID {
-		rid = r.ParentID_
-	}
-
 	if multiphaseEvaluation {
 		computeRuleChainMinPhase(r)
 	}
@@ -204,7 +194,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	defer logger.Debug().Msg("Finished rule evaluation")
 
 	ruleCol := tx.variables.rule
-	ruleCol.SetIndex("id", 0, strconv.Itoa(rid))
+	ruleCol.SetIndex("id", 0, r.StrID())
 	if r.Msg != nil {
 		ruleCol.SetIndex("msg", 0, r.Msg.String())
 	}


### PR DESCRIPTION
While testing the library at 1K RPS, `pprof` showed that this `strconv.Itoa` alone is adding a ~2.2% CPU usage.
Since this ID is per rule and does not change over time, we can compute it once, cache it and reuse.