### PR TITLE
fix: FuzzB64Decode regexp match for fuzzing

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -182,7 +182,8 @@ func Fuzz() error {
 		{
 			pkg: "./internal/transformations",
 			tests: []string{
-				"FuzzB64Decode",
+				"FuzzB64Decode$",
+				"FuzzB64DecodeExt",
 				"FuzzCMDLine",
 			},
 		},


### PR DESCRIPTION
Fixes #1052 #1053.