### PR TITLE
fix: RemoveTargetById Args in multiphase mode

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -620,6 +620,23 @@ func (tx *Transaction) RemoveRuleTargetByID(id int, variable variables.RuleVaria
 		Variable: variable,
 		KeyStr:   key,
 	}
+
+	if multiphaseEvaluation && (variable == variables.Args || variable == variables.ArgsNames) {
+		// ARGS and ARGS_NAMES have to be splitted into _GET and _POST
+		switch variable {
+		case variables.Args:
+			c.Variable = variables.ArgsGet
+			tx.ruleRemoveTargetByID[id] = append(tx.ruleRemoveTargetByID[id], c)
+			c.Variable = variables.ArgsPost
+			tx.ruleRemoveTargetByID[id] = append(tx.ruleRemoveTargetByID[id], c)
+		case variables.ArgsNames:
+			c.Variable = variables.ArgsGetNames
+			tx.ruleRemoveTargetByID[id] = append(tx.ruleRemoveTargetByID[id], c)
+			c.Variable = variables.ArgsPostNames
+			tx.ruleRemoveTargetByID[id] = append(tx.ruleRemoveTargetByID[id], c)
+		}
+		return
+	}
 	tx.ruleRemoveTargetByID[id] = append(tx.ruleRemoveTargetByID[id], c)
 }
 


### PR DESCRIPTION
In Multiphase, `ARGS` are split into `ARGS_POST` and `ARGS_GET`. Because of that, a `ruleRemoveTargetById` targeting ARGS, is not working because it adds an exception to a variable that is not checked.
This PR proposes to split ARGS also inside the `ruleRemoveTargetById` adding effectively the two specialized exceptions (one for `ARGS_POST` and one for `ARGS_GET`).

### Why?
- Fixes an expected behaviour.
- CRS rules [942440, 942441, 942442](https://github.com/coreruleset/coreruleset/blob/4fb2625c37d63428bccc20ebdac6601201b500f8/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf#L1322-L1345) are based on this logic.