### PR TITLE
fix: headers leaked during interruptions at phase 3/4

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -185,6 +185,5 @@ func obtainStatusCodeFromInterruptionOrDefault(it *types.Interruption, defaultSt
 
 		return statusCode
 	}
-
 	return defaultStatusCode
 }


### PR DESCRIPTION
Initially reported in https://github.com/corazawaf/coraza-caddy/issues/147. We basically use the same Go middleware, therefore I first tried to reproduce and propose an initial patch here.

Port to coraza-caddy is required. 