### PR TITLE
fix: race condition on StrID

### DIFF
--- a/internal/actions/ctl_test.go
+++ b/internal/actions/ctl_test.go
@@ -336,7 +336,7 @@ func TestCtl(t *testing.T) {
 			waf.Logger = logger
 			r := corazawaf.NewRule()
 			r.ID_ = 1
-			r.StrRuleID_ = "1"
+			r.LogID_ = "1"
 			err := waf.Rules.Add(r)
 			if err != nil {
 				t.Fatalf("failed to add rule: %s", err.Error())

--- a/internal/actions/ctl_test.go
+++ b/internal/actions/ctl_test.go
@@ -335,6 +335,8 @@ func TestCtl(t *testing.T) {
 			waf := corazawaf.NewWAF()
 			waf.Logger = logger
 			r := corazawaf.NewRule()
+			r.ID_ = 1
+			r.StrRuleID_ = "1"
 			err := waf.Rules.Add(r)
 			if err != nil {
 				t.Fatalf("failed to add rule: %s", err.Error())

--- a/internal/actions/id.go
+++ b/internal/actions/id.go
@@ -38,7 +38,7 @@ func (a *idFn) Init(r plugintypes.RuleMetadata, data string) error {
 
 	cr := r.(*corazawaf.Rule)
 	cr.ID_ = int(i)
-	cr.StrRuleID_ = strconv.Itoa(i)
+	cr.LogID_ = strconv.Itoa(i)
 	return nil
 }
 

--- a/internal/actions/id.go
+++ b/internal/actions/id.go
@@ -38,6 +38,7 @@ func (a *idFn) Init(r plugintypes.RuleMetadata, data string) error {
 
 	cr := r.(*corazawaf.Rule)
 	cr.ID_ = int(i)
+	cr.StrRuleID_ = strconv.Itoa(i)
 	return nil
 }
 

--- a/internal/corazarules/rule.go
+++ b/internal/corazarules/rule.go
@@ -4,30 +4,29 @@
 package corazarules
 
 import (
-	"strconv"
-
 	"github.com/corazawaf/coraza/v3/types"
 )
-
-const noID = 0
 
 // RuleMetadata is used to store rule metadata
 // that can be used across packages
 type RuleMetadata struct {
-	ID_          int
-	File_        string
-	Line_        int
-	Rev_         string
-	Severity_    types.RuleSeverity
-	Version_     string
-	Tags_        []string
-	Maturity_    int
-	Accuracy_    int
-	Operator_    string
-	Phase_       types.RulePhase
-	Raw_         string
-	SecMark_     string
-	cachedStrID_ string
+	ID_ int
+	// String representation of the rule ID expected to be printed.
+	// If the rule is part of a chain, the rule ID will be the parent ID
+	// For performance reasons it is stored avoiding to perfrom the computation multiple times during the hot path
+	StrRuleID_ string
+	File_      string
+	Line_      int
+	Rev_       string
+	Severity_  types.RuleSeverity
+	Version_   string
+	Tags_      []string
+	Maturity_  int
+	Accuracy_  int
+	Operator_  string
+	Phase_     types.RulePhase
+	Raw_       string
+	SecMark_   string
 	// Contains the Id of the parent rule if you are inside
 	// a chain. Otherwise, it will be 0
 	ParentID_ int
@@ -85,13 +84,10 @@ func (r *RuleMetadata) SecMark() string {
 	return r.SecMark_
 }
 
-func (r *RuleMetadata) StrID() string {
-	if r.cachedStrID_ == "" {
-		rid := r.ID_
-		if rid == noID {
-			rid = r.ParentID_
-		}
-		r.cachedStrID_ = strconv.Itoa(rid)
+func (r *RuleMetadata) StrRuleID() string {
+	// TODO remove panic
+	if r.StrRuleID_ == "" {
+		panic("Rule ID not set")
 	}
-	return r.cachedStrID_
+	return r.StrRuleID_
 }

--- a/internal/corazarules/rule.go
+++ b/internal/corazarules/rule.go
@@ -11,22 +11,23 @@ import (
 // that can be used across packages
 type RuleMetadata struct {
 	ID_ int
-	// String representation of the rule ID expected to be printed.
-	// If the rule is part of a chain, the rule ID will be the parent ID
-	// For performance reasons it is stored avoiding to perfrom the computation multiple times during the hot path
-	StrRuleID_ string
-	File_      string
-	Line_      int
-	Rev_       string
-	Severity_  types.RuleSeverity
-	Version_   string
-	Tags_      []string
-	Maturity_  int
-	Accuracy_  int
-	Operator_  string
-	Phase_     types.RulePhase
-	Raw_       string
-	SecMark_   string
+	// Stores the string representation of the rule ID for logging purposes.
+	// If the rule is part of a chain, the parent ID is used as log ID.
+	// This approach prevents repeated computations in performance-critical sections, enhancing efficiency.
+	// It is stored for performance reasons, avoiding to perfrom the computation multiple times in the hot path
+	LogID_    string
+	File_     string
+	Line_     int
+	Rev_      string
+	Severity_ types.RuleSeverity
+	Version_  string
+	Tags_     []string
+	Maturity_ int
+	Accuracy_ int
+	Operator_ string
+	Phase_    types.RulePhase
+	Raw_      string
+	SecMark_  string
 	// Contains the Id of the parent rule if you are inside
 	// a chain. Otherwise, it will be 0
 	ParentID_ int
@@ -84,10 +85,6 @@ func (r *RuleMetadata) SecMark() string {
 	return r.SecMark_
 }
 
-func (r *RuleMetadata) StrRuleID() string {
-	// TODO remove panic
-	if r.StrRuleID_ == "" {
-		panic("Rule ID not set")
-	}
-	return r.StrRuleID_
+func (r *RuleMetadata) LogID() string {
+	return r.LogID_
 }

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -194,7 +194,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	defer logger.Debug().Msg("Finished rule evaluation")
 
 	ruleCol := tx.variables.rule
-	ruleCol.SetIndex("id", 0, r.StrID())
+	ruleCol.SetIndex("id", 0, r.StrRuleID())
 	if r.Msg != nil {
 		ruleCol.SetIndex("msg", 0, r.Msg.String())
 	}

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -194,7 +194,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	defer logger.Debug().Msg("Finished rule evaluation")
 
 	ruleCol := tx.variables.rule
-	ruleCol.SetIndex("id", 0, r.StrRuleID())
+	ruleCol.SetIndex("id", 0, r.LogID())
 	if r.Msg != nil {
 		ruleCol.SetIndex("msg", 0, r.Msg.String())
 	}

--- a/internal/corazawaf/rule_test.go
+++ b/internal/corazawaf/rule_test.go
@@ -21,6 +21,7 @@ func TestMatchEvaluate(t *testing.T) {
 	r.Msg, _ = macro.NewMacro("Message")
 	r.LogData, _ = macro.NewMacro("Data Message")
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	if err := r.AddVariable(variables.ArgsGet, "", false); err != nil {
 		t.Error(err)
 	}
@@ -44,6 +45,7 @@ func TestMatchEvaluate(t *testing.T) {
 func TestNoMatchEvaluate(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	if err := r.AddVariable(variables.ArgsGet, "", false); err != nil {
 		t.Error(err)
 	}
@@ -89,6 +91,7 @@ func TestNoMatchEvaluateBecauseOfException(t *testing.T) {
 			r.Msg, _ = macro.NewMacro("Message")
 			r.LogData, _ = macro.NewMacro("Data Message")
 			r.ID_ = 1
+			r.StrRuleID_ = "1"
 			if err := r.AddVariable(tc.variable, "", false); err != nil {
 				t.Error(err)
 			}
@@ -129,6 +132,7 @@ func (*dummyFlowAction) Type() plugintypes.ActionType {
 func TestFlowActionIfDetectionOnlyEngine(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	r.operator = nil
 	action := &dummyFlowAction{}
 	_ = r.AddAction("dummyFlowAction", action)
@@ -174,6 +178,7 @@ func TestMatchVariableRunsActionTypeNondisruptive(t *testing.T) {
 func TestDisruptiveActionFromChainNotEvaluated(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	action := &dummyNonDisruptiveAction{}
@@ -181,6 +186,7 @@ func TestDisruptiveActionFromChainNotEvaluated(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
+	chainedRule.StrRuleID_ = "1"
 	chainedRule.operator = nil
 	chainedAction := &dummyDenyAction{}
 	_ = chainedRule.AddAction("dummyDenyAction", chainedAction)
@@ -201,6 +207,7 @@ func TestRuleDetailsTransferredToTransaction(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 0
 	r.ParentID_ = 1
+	r.StrRuleID_ = "1"
 	r.Capture = true
 	r.operator = nil
 	tx := NewWAF().NewTransaction()
@@ -226,6 +233,7 @@ func TestSecActionMessagePropagationInMatchData(t *testing.T) {
 	r.Msg, _ = macro.NewMacro("Message")
 	r.LogData, _ = macro.NewMacro("Data Message")
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	// SecAction uses nil operator
 	r.operator = nil
 	tx := NewWAF().NewTransaction()
@@ -545,6 +553,7 @@ func TestTransformArgNoCacheForTXVariable(t *testing.T) {
 func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	r.Phase_ = 1
@@ -552,6 +561,7 @@ func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
+	chainedRule.StrRuleID_ = "1"
 	chainedRule.operator = nil
 	chainedRule.Capture = false
 	r.Chain = chainedRule
@@ -567,6 +577,7 @@ func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 func TestExpandMacroAfterWholeRuleEvaluation(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
+	r.StrRuleID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	r.Phase_ = 1
@@ -577,6 +588,7 @@ func TestExpandMacroAfterWholeRuleEvaluation(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
+	chainedRule.StrRuleID_ = "1"
 	chainedRule.operator = nil
 
 	_ = r.AddVariable(variables.RequestURI, "", false)

--- a/internal/corazawaf/rule_test.go
+++ b/internal/corazawaf/rule_test.go
@@ -21,7 +21,7 @@ func TestMatchEvaluate(t *testing.T) {
 	r.Msg, _ = macro.NewMacro("Message")
 	r.LogData, _ = macro.NewMacro("Data Message")
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	if err := r.AddVariable(variables.ArgsGet, "", false); err != nil {
 		t.Error(err)
 	}
@@ -45,7 +45,7 @@ func TestMatchEvaluate(t *testing.T) {
 func TestNoMatchEvaluate(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	if err := r.AddVariable(variables.ArgsGet, "", false); err != nil {
 		t.Error(err)
 	}
@@ -91,7 +91,7 @@ func TestNoMatchEvaluateBecauseOfException(t *testing.T) {
 			r.Msg, _ = macro.NewMacro("Message")
 			r.LogData, _ = macro.NewMacro("Data Message")
 			r.ID_ = 1
-			r.StrRuleID_ = "1"
+			r.LogID_ = "1"
 			if err := r.AddVariable(tc.variable, "", false); err != nil {
 				t.Error(err)
 			}
@@ -132,7 +132,7 @@ func (*dummyFlowAction) Type() plugintypes.ActionType {
 func TestFlowActionIfDetectionOnlyEngine(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	r.operator = nil
 	action := &dummyFlowAction{}
 	_ = r.AddAction("dummyFlowAction", action)
@@ -178,7 +178,7 @@ func TestMatchVariableRunsActionTypeNondisruptive(t *testing.T) {
 func TestDisruptiveActionFromChainNotEvaluated(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	action := &dummyNonDisruptiveAction{}
@@ -186,7 +186,7 @@ func TestDisruptiveActionFromChainNotEvaluated(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
-	chainedRule.StrRuleID_ = "1"
+	chainedRule.LogID_ = "1"
 	chainedRule.operator = nil
 	chainedAction := &dummyDenyAction{}
 	_ = chainedRule.AddAction("dummyDenyAction", chainedAction)
@@ -207,7 +207,7 @@ func TestRuleDetailsTransferredToTransaction(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 0
 	r.ParentID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	r.Capture = true
 	r.operator = nil
 	tx := NewWAF().NewTransaction()
@@ -233,7 +233,7 @@ func TestSecActionMessagePropagationInMatchData(t *testing.T) {
 	r.Msg, _ = macro.NewMacro("Message")
 	r.LogData, _ = macro.NewMacro("Data Message")
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	// SecAction uses nil operator
 	r.operator = nil
 	tx := NewWAF().NewTransaction()
@@ -553,7 +553,7 @@ func TestTransformArgNoCacheForTXVariable(t *testing.T) {
 func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	r.Phase_ = 1
@@ -561,7 +561,7 @@ func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
-	chainedRule.StrRuleID_ = "1"
+	chainedRule.LogID_ = "1"
 	chainedRule.operator = nil
 	chainedRule.Capture = false
 	r.Chain = chainedRule
@@ -577,7 +577,7 @@ func TestCaptureNotPropagatedToInnerChainRule(t *testing.T) {
 func TestExpandMacroAfterWholeRuleEvaluation(t *testing.T) {
 	r := NewRule()
 	r.ID_ = 1
-	r.StrRuleID_ = "1"
+	r.LogID_ = "1"
 	r.operator = nil
 	r.HasChain = true
 	r.Phase_ = 1
@@ -588,7 +588,7 @@ func TestExpandMacroAfterWholeRuleEvaluation(t *testing.T) {
 	chainedRule := NewRule()
 	chainedRule.ID_ = 0
 	chainedRule.ParentID_ = 1
-	chainedRule.StrRuleID_ = "1"
+	chainedRule.LogID_ = "1"
 	chainedRule.operator = nil
 
 	_ = r.AddVariable(variables.RequestURI, "", false)

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -845,7 +845,7 @@ func TestLogCallback(t *testing.T) {
 			tx := waf.NewTransaction()
 			rule := NewRule()
 			rule.ID_ = 1
-			rule.StrRuleID_ = "1"
+			rule.LogID_ = "1"
 			rule.Phase_ = 1
 			rule.Log = true
 			_ = rule.AddAction("deny", testCase.action)

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -845,6 +845,7 @@ func TestLogCallback(t *testing.T) {
 			tx := waf.NewTransaction()
 			rule := NewRule()
 			rule.ID_ = 1
+			rule.StrRuleID_ = "1"
 			rule.Phase_ = 1
 			rule.Log = true
 			_ = rule.AddAction("deny", testCase.action)

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -110,6 +110,7 @@ func directiveSecMarker(options *DirectiveOptions) error {
 	rule.Raw_ = fmt.Sprintf("SecMarker %s", options.Opts)
 	rule.SecMark_ = options.Opts
 	rule.ID_ = 0
+	rule.StrRuleID_ = "0"
 	rule.Phase_ = 0
 	rule.Line_ = options.Parser.LastLine
 	rule.File_ = options.Parser.ConfigFile

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -110,7 +110,7 @@ func directiveSecMarker(options *DirectiveOptions) error {
 	rule.Raw_ = fmt.Sprintf("SecMarker %s", options.Opts)
 	rule.SecMark_ = options.Opts
 	rule.ID_ = 0
-	rule.StrRuleID_ = "0"
+	rule.LogID_ = "0"
 	rule.Phase_ = 0
 	rule.Line_ = options.Parser.LastLine
 	rule.File_ = options.Parser.ConfigFile

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -384,6 +384,9 @@ func ParseRule(options RuleOptions) (*corazawaf.Rule, error) {
 
 	if parent := getLastRuleExpectingChain(options.WAF); parent != nil {
 		rule.ParentID_ = parent.ID_
+		// While the ID_ will be kept to 0 being a chain rule, the StrRuleID_ is meant to be
+		// the printable ID that represents the chain rule, therefore the parent's ID is inherited.
+		rule.StrRuleID_ = parent.StrRuleID_
 		lastChain := parent
 		for lastChain.Chain != nil {
 			lastChain = lastChain.Chain

--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -384,9 +384,9 @@ func ParseRule(options RuleOptions) (*corazawaf.Rule, error) {
 
 	if parent := getLastRuleExpectingChain(options.WAF); parent != nil {
 		rule.ParentID_ = parent.ID_
-		// While the ID_ will be kept to 0 being a chain rule, the StrRuleID_ is meant to be
+		// While the ID_ will be kept to 0 being a chain rule, the LogID_ is meant to be
 		// the printable ID that represents the chain rule, therefore the parent's ID is inherited.
-		rule.StrRuleID_ = parent.StrRuleID_
+		rule.LogID_ = parent.LogID_
 		lastChain := parent
 		for lastChain.Chain != nil {
 			lastChain = lastChain.Chain

--- a/magefile.go
+++ b/magefile.go
@@ -110,7 +110,7 @@ func Test() error {
 		return err
 	}
 
-	if err := sh.RunV("go", "test", "./examples/http-server"); err != nil {
+	if err := sh.RunV("go", "test", "./examples/http-server", "-race"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
WIP.
Implements `StrID` at rule parsing time in order to fix race conditions introduced by the lazy pattern. It basically creates the variable alongside the `ID` variable creation. 
I'm still unsure about the `StrRuleID_` name. The goal is to explain that it is not always just the string of `ID_`, but it is the "displayed" ID, so for chained rules, the displayed id is the parent id even if the inner rule (being an inner rule) has the `0` value ID.

Fixes https://github.com/corazawaf/coraza/issues/1083