### PR TITLE
fix: makes max size log message CRS correlation rule friendly

### DIFF
--- a/internal/corazarules/rule_match.go
+++ b/internal/corazarules/rule_match.go
@@ -178,7 +178,7 @@ func (mr *MatchedRule) Context() context.Context {
 	return mr.Context_
 }
 
-const maxSizeLogMessage = 200
+const maxSizeLogMessage = 280
 
 func (mr MatchedRule) writeDetails(log *strings.Builder, matchData types.MatchData) {
 	msg := matchData.Message()


### PR DESCRIPTION
Logs generated by the [CRS correlation rule `980170`](https://github.com/coreruleset/coreruleset/blob/main/rules/RESPONSE-980-CORRELATION.conf#L77-L100) is quite lengthy and the current fixed max size of msg logs leads to don't print it fully.
Example of truncated log:
```
[msg "Anomaly Scores: (Inbound Scores: blocking=15, detection=15, per_pl=15-0-0-0, threshold=5) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=4) - (SQLI=0, XSS=15, RFI=0, LFI=0, RCE"] [data ""]
```
While a max value is advisable, it should still permit to fit the output of known rules. This PR proposes to increase the `maxSizeLogMessage` from `200` to `280` in order to print something like:
```
Anomaly Scores: (Inbound Scores: blocking=15, detection=15, per_pl=150-250-150-150, threshold=1000) - (Outbound Scores: blocking=0, detection=0, per_pl=0-0-0-0, threshold=4) - (SQLI=120, XSS=15, RFI=120, LFI=120, RCE=120, PHPI=120, HTTP=120, SESS=120, COMBINED_SCORE=1000)
```
The previous value was set in https://github.com/corazawaf/coraza/pull/478, I've not been able to find any rationale behind the specific value.

As a second step, it would be good to make it configurable. 