### PR TITLE
fix: variable parsing error 

### DIFF
--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -145,6 +145,9 @@ func (rp *RuleParser) ParseVariables(vars string) error {
 				isEscaped = !isEscaped
 			default:
 				curKey = append(curKey, c)
+				if isEscaped {
+					isEscaped = false
+				}
 			}
 		case 3:
 			// XPATH

--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -295,9 +295,6 @@ func TestParseRule(t *testing.T) {
 			if err := rp.ParseVariables(tt.vars); err != nil {
 				t.Error(err)
 			}
-			//for i := 0; i < reflect.ValueOf(rp.rule).Elem().FieldByName("variables").Len(); i++ {
-			//	fmt.Println(i, reflect.ValueOf(rp.rule).Elem().FieldByName("variables").Index(i).FieldByName("KeyStr").String())
-			//}
 			got := reflect.ValueOf(rp.rule).Elem().FieldByName("variables").Len()
 			if got != tt.want {
 				t.Error("variables parse error want", tt.want, "got", got)


### PR DESCRIPTION
Fixed the issue that the ParseVariables function would parse the regular expression with escape characters incorrectly

fix #1088
