### PR TITLE
fix: deny action with default status 403

### DIFF
--- a/internal/actions/deny.go
+++ b/internal/actions/deny.go
@@ -4,8 +4,6 @@
 package actions
 
 import (
-	"net/http"
-
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -39,7 +37,8 @@ func (a *denyFn) Evaluate(r plugintypes.RuleMetadata, tx plugintypes.Transaction
 	status := r.Status()
 	// deny action defaults to status 403
 	if status == noStatus {
-		status = http.StatusForbidden
+		// TODO(M4tteop): use http.StatusForbidden once we drop Go 1.20 support. http pkg unsupported with TinyGo and Go <1.20
+		status = 403
 	}
 	tx.Interrupt(&types.Interruption{
 		Status: status,

--- a/internal/actions/deny.go
+++ b/internal/actions/deny.go
@@ -4,6 +4,8 @@
 package actions
 
 import (
+	"net/http"
+
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -27,14 +29,20 @@ func (a *denyFn) Init(_ plugintypes.RuleMetadata, data string) error {
 }
 
 const noID = 0
+const noStatus = 0
 
 func (a *denyFn) Evaluate(r plugintypes.RuleMetadata, tx plugintypes.TransactionState) {
 	rid := r.ID()
 	if rid == noID {
 		rid = r.ParentID()
 	}
+	status := r.Status()
+	// deny action defaults to status 403
+	if status == noStatus {
+		status = http.StatusForbidden
+	}
 	tx.Interrupt(&types.Interruption{
-		Status: r.Status(),
+		Status: status,
 		RuleID: rid,
 		Action: "deny",
 	})

--- a/testing/engine/disruptive_actions.go
+++ b/testing/engine/disruptive_actions.go
@@ -43,7 +43,7 @@ var _ = profile.RegisterProfile(profile.Profile{
 						Output: profile.ExpectedOutput{
 							TriggeredRules: []int{2},
 							Interruption: &profile.ExpectedInterruption{
-								Status: 500,
+								Status: 403,
 								Data:   "",
 								RuleID: 2,
 								Action: "deny",
@@ -285,7 +285,8 @@ var _ = profile.RegisterProfile(profile.Profile{
 	},
 	Rules: `
 SecRule REQUEST_URI "/redirect1$" "phase:1,id:1,log,status:302,redirect:https://www.example.com"
-SecRule REQUEST_URI "/deny1$" "phase:1,id:2,log,status:500,deny"
+# deny action defaults to status 403
+SecRule REQUEST_URI "/deny1$" "phase:1,id:2,log,deny"
 SecRule REQUEST_URI "/drop1$" "phase:1,id:3,log,drop"
 
 SecRule REQUEST_URI "/redirect2$" "phase:2,id:21,log,status:302,redirect:https://www.example.com"


### PR DESCRIPTION
This PR proposes to set `403` as default deny status code instead of delegating it to the connectors. 

### Why?

If the rule `status` field is not set, `Deny` action is currently setting the status code of the interruption equal to `0`. Only at the connector level, there is some logic to convert the `0` into a `403`. Example in [coraza-proxy-wasm](https://github.com/corazawaf/coraza-proxy-wasm/blob/de6279b086d2cb3f1e7df7a88d73b2837feeb2b4/wasmplugin/plugin.go#L699-L703):
```
	statusCode := interruption.Status
	if statusCode == 0 {
		statusCode = defaultInterruptionStatusCode
	}
	if err := proxywasm.SendHttpResponse(uint32(statusCode), nil, nil, noGRPCStream); err != nil {
```
Delegating it to the connector leads to `SecAuditLogRelevantStatus` not working properly. The regex `^(?:(5|4)(0|1)[0-9])$` tries to match `tx.interruption.Status` equal to `0` without succeeding.

This behaviour notably happens with [CRS blocking rules](https://github.com/coreruleset/coreruleset/blob/main/rules/REQUEST-949-BLOCKING-EVALUATION.conf#L212) that have the `deny` action not followed by an explicit `status`.

### Possible workaround:
```
SecAuditLogRelevantStatus "^(?:(5|4)(0|1)[0-9]|0)$"
```