### PR TITLE
feat: set MULTIPART_STRICT_ERROR value when mutipart fails to parse

### DIFF
--- a/coraza.conf-recommended
+++ b/coraza.conf-recommended
@@ -28,12 +28,11 @@ SecRule REQUEST_HEADERS:Content-Type "^(?:application(?:/soap\+|/)|text/)xml" \
 SecRule REQUEST_HEADERS:Content-Type "^application/json" \
      "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
-# Sample rule to enable JSON request body parser for more subtypes.
-# Uncomment or adapt this rule if you want to engage the JSON
-# Processor for "+json" subtypes
+# Enable JSON request body parser for more subtypes.
+# Adapt this rule if you want to engage the JSON Processor for "+json" subtypes
 #
-#SecRule REQUEST_HEADERS:Content-Type "^application/[a-z0-9.-]+[+]json" \
-#     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+SecRule REQUEST_HEADERS:Content-Type "^application/[a-z0-9.-]+[+]json" \
+     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
 # Maximum request body size we will accept for buffering. If you support
 # file uploads then the value given on the first line has to be as large
@@ -61,84 +60,16 @@ SecRequestBodyLimitAction Reject
 # or log a high-severity alert (when deployed in detection-only mode).
 #
 SecRule REQBODY_ERROR "!@eq 0" \
-"id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
+    "id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
 
 # By default be strict with what we accept in the multipart/form-data
 # request body. If the rule below proves to be too strict for your
-# environment consider changing it to detection-only. You are encouraged
-# _not_ to remove it altogether.
+# environment consider changing it to detection-only.
+# Do NOT remove it, as it will catch many evasion attempts.
 #
 SecRule MULTIPART_STRICT_ERROR "!@eq 0" \
-"id:'200003',phase:2,t:none,log,deny,status:400, \
-msg:'Multipart request body failed strict validation: \
-PE %{REQBODY_PROCESSOR_ERROR}, \
-BQ %{MULTIPART_BOUNDARY_QUOTED}, \
-BW %{MULTIPART_BOUNDARY_WHITESPACE}, \
-DB %{MULTIPART_DATA_BEFORE}, \
-DA %{MULTIPART_DATA_AFTER}, \
-HF %{MULTIPART_HEADER_FOLDING}, \
-LF %{MULTIPART_LF_LINE}, \
-SM %{MULTIPART_MISSING_SEMICOLON}, \
-IQ %{MULTIPART_INVALID_QUOTING}, \
-IP %{MULTIPART_INVALID_PART}, \
-IH %{MULTIPART_INVALID_HEADER_FOLDING}, \
-FL %{MULTIPART_FILE_LIMIT_EXCEEDED}'"
-
-# Did we see anything that might be a boundary?
-#
-# Here is a short description about the Coraza Multipart parser: the
-# parser returns with value 0, if all "boundary-like" line matches with
-# the boundary string which given in MIME header. In any other cases it returns
-# with different value, eg. 1 or 2.
-#
-# The RFC 1341 descript the multipart content-type and its syntax must contains
-# only three mandatory lines (above the content):
-# * Content-Type: multipart/mixed; boundary=BOUNDARY_STRING
-# * --BOUNDARY_STRING
-# * --BOUNDARY_STRING--
-#
-# First line indicates, that this is a multipart content, second shows that
-# here starts a part of the multipart content, third shows the end of content.
-#
-# If there are any other lines, which starts with "--", then it should be
-# another boundary id - or not.
-#
-# After 3.0.3, there are two kinds of types of boundary errors: strict and permissive.
-#
-# If multipart content contains the three necessary lines with correct order, but
-# there are one or more lines with "--", then parser returns with value 2 (non-zero).
-#
-# If some of the necessary lines (usually the start or end) misses, or the order
-# is wrong, then parser returns with value 1 (also a non-zero).
-#
-# You can choose, which one is what you need. The example below contains the
-# 'strict' mode, which means if there are any lines with start of "--", then
-# Coraza blocked the content. But the next, commented example contains
-# the 'permissive' mode, then you check only if the necessary lines exists in
-# correct order. Whit this, you can enable to upload PEM files (eg "----BEGIN.."),
-# or other text files, which contains eg. HTTP headers.
-#
-# The difference is only the operator - in strict mode (first) the content blocked
-# in case of any non-zero value. In permissive mode (second, commented) the
-# content blocked only if the value is explicit 1. If it 0 or 2, the content will
-# allowed.
-#
-
-#
-# See #1747 and #1924 for further information on the possible values for
-# MULTIPART_UNMATCHED_BOUNDARY.
-#
-SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" \
-    "id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
-
-# Some internal errors will set flags in TX and we will need to look for these.
-# All of these are prefixed with "MSC_".  The following flags currently exist:
-#
-# COR_PCRE_LIMITS_EXCEEDED: PCRE match limits were exceeded.
-#
-SecRule TX:/^COR_/ "!@streq 0" \
-        "id:'200005',phase:2,t:none,deny,msg:'Coraza internal error flagged: %{MATCHED_VAR_NAME}'"
-
+    "id:'200003',phase:2,t:none,log,deny,status:400, \
+    msg:'Multipart request body failed strict validation."
 
 # -- Response body handling --------------------------------------------------
 
@@ -230,17 +161,11 @@ SecAuditLogParts ABIJDEFHZ
 #
 SecAuditLogType Serial
 
+# The following settings are not supported by Coraza
 
-# -- Miscellaneous -----------------------------------------------------------
-
-# Use the most commonly used application/x-www-form-urlencoded parameter
-# separator. There's probably only one application somewhere that uses
-# something else so don't expect to change this value.
-#
-SecArgumentSeparator &
-
-# Settle on version 0 (zero) cookies, as that is what most applications
-# use. Using an incorrect cookie version may open your installation to
-# evasion attacks (against the rules that examine named cookies).
-#
-SecCookieFormat 0
+# SecCookieFormat 0
+# SecArgumentSeparator &
+# SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" \
+#    "id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
+# SecRule TX:/^COR_/ "!@streq 0" \
+#       "id:'200005',phase:2,t:none,deny,msg:'Coraza internal error flagged: %{MATCHED_VAR_NAME}'"

--- a/experimental/plugins/plugintypes/transaction.go
+++ b/experimental/plugins/plugintypes/transaction.go
@@ -115,4 +115,5 @@ type TransactionVariables interface {
 	ArgsNames() collection.Collection
 	ArgsGetNames() collection.Collection
 	ArgsPostNames() collection.Collection
+	MultipartStrictError() collection.Single
 }

--- a/internal/bodyprocessors/multipart.go
+++ b/internal/bodyprocessors/multipart.go
@@ -24,6 +24,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 	storagePath := options.StoragePath
 	mediaType, params, err := mime.ParseMediaType(mimeType)
 	if err != nil {
+		v.MultipartStrictError().(*collections.Single).Set("1")
 		return err
 	}
 	if !strings.HasPrefix(mediaType, "multipart/") {
@@ -44,6 +45,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 			break
 		}
 		if err != nil {
+			v.MultipartStrictError().(*collections.Single).Set("1")
 			return err
 		}
 		partName := p.FormName()
@@ -60,10 +62,12 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 				// Only copy file to temp when not running in TinyGo
 				temp, err := os.CreateTemp(storagePath, "crzmp*")
 				if err != nil {
+					v.MultipartStrictError().(*collections.Single).Set("1")
 					return err
 				}
 				sz, err := io.Copy(temp, p)
 				if err != nil {
+					v.MultipartStrictError().(*collections.Single).Set("1")
 					return err
 				}
 				size = sz
@@ -71,6 +75,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 			} else {
 				sz, err := io.Copy(io.Discard, p)
 				if err != nil {
+					v.MultipartStrictError().(*collections.Single).Set("1")
 					return err
 				}
 				size = sz
@@ -83,6 +88,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 			// if is a field
 			data, err := io.ReadAll(p)
 			if err != nil {
+				v.MultipartStrictError().(*collections.Single).Set("1")
 				return err
 			}
 			totalSize += int64(len(data))

--- a/internal/bodyprocessors/multipart_test.go
+++ b/internal/bodyprocessors/multipart_test.go
@@ -94,3 +94,119 @@ text default
 		t.Error("multipart processor should fail for invalid content-type")
 	}
 }
+
+func TestMultipartErrorSetsMultipartStrictError(t *testing.T) {
+	payload := "--a\n" +
+		"\x0eContent-Disposition\x0e: form-data; name=\"file\";filename=\"1.jsp\"\n" +
+		"Content-Disposition: form-data; name=\"post\";\n" +
+		"\n" +
+		"<%out.print(123)%>\n" +
+		"--a--"
+	mp := multipartProcessor(t)
+	v := corazawaf.NewTransactionVariables()
+	strictError := v.MultipartStrictError()
+	if strictError.Get() != "" {
+		t.Errorf("expected strict error to be empty")
+	}
+	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
+		Mime: "multipart/form-data; boundary=a",
+	}); err != nil {
+		strictError = v.MultipartStrictError()
+		if strictError.Get() != "1" {
+			t.Error("expected strict error")
+		}
+	}
+}
+
+// TestMultipartCRLFAndLF tests a multipart payload with mixed CRLF and LF line endings.
+// Golang mime/multipart reader uses the first line ending after the boundary and wants to keep it consistent.
+// It will fail with NextPart: EOF if the line endings are mixed.
+func TestMultipartCRLFAndLF(t *testing.T) {
+	payload := "----------------------------756b6d74fa1a8ee2" +
+		"Content-Disposition: form-data; name=\"name\"" +
+		"" +
+		"test" +
+		"----------------------------756b6d74fa1a8ee2" +
+		"Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"" +
+		"Content-Type: text/plain" +
+		"" +
+		"This is a very small test file.." +
+		"----------------------------756b6d74fa1a8ee2" +
+		"Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"\r" +
+		"Content-Type: text/plain\r" +
+		"\r" +
+		"This is another very small test file..\r" +
+		"----------------------------756b6d74fa1a8ee2--\r"
+
+	mp := multipartProcessor(t)
+	v := corazawaf.NewTransactionVariables()
+	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
+		Mime: "multipart/form-data; boundary=756b6d74fa1a8ee2",
+	}); err != nil {
+		strictError := v.MultipartStrictError()
+		if strictError.Get() != "1" {
+			t.Error("expected strict error")
+		}
+		if !strings.Contains(err.Error(), "multipart: NextPart: EOF") {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestMultipartInvalidHeaderFolding tests a multipart payload where headers are folded badly (RFC 2047).
+// It will fail with NextPart: EOF.
+func TestMultipartInvalidHeaderFolding(t *testing.T) {
+	payload := "-------------------------------69343412719991675451336310646\n" +
+		"Content-Disposition: form-data;\n" +
+		" name=\"a\"\n" +
+		"\n" +
+		"\n" +
+		"-------------------------------69343412719991675451336310646\n" +
+		"Content-Disposition: form-data;\n" +
+		"    name=\"b\"\n" +
+		"\n" +
+		"2\n" +
+		"-------------------------------69343412719991675451336310646--\n"
+	mp := multipartProcessor(t)
+	v := corazawaf.NewTransactionVariables()
+	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
+		Mime: "multipart/form-data; boundary=69343412719991675451336310646",
+	}); err != nil {
+		strictError := v.MultipartStrictError()
+		if strictError.Get() != "1" {
+			t.Error("expected strict error")
+		}
+		if !strings.Contains(err.Error(), "multipart: NextPart: EOF") {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestMultipartUnmatchedBoundary tests a multipart payload where there is an unmatched boundary.
+func TestMultipartUnmatchedBoundary(t *testing.T) {
+	payload := "--------------------------756b6d74fa1a8ee2\n" +
+		"Content-Disposition: form-data; name=\"name\"\n" +
+		"\n" +
+		"test\n" +
+		"--------------------------756b6d74fa1a8ee2\n" +
+		"Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"\n" +
+		"Content-Type: text/plain\n" +
+		"\n" +
+		"This is a very small test file..\n" +
+		"--------------------------756b6d74fa1a8ee2\n" +
+		"Content-Disposition: form-data; name=\"filedata\"; filename=\"small_text_file.txt\"\n" +
+		"Content-Type: text/plain\n" +
+		"\n" +
+		"This is another very small test file..\n" +
+		"\n"
+	mp := multipartProcessor(t)
+	v := corazawaf.NewTransactionVariables()
+	if err := mp.ProcessRequest(strings.NewReader(payload), v, plugintypes.BodyProcessorOptions{
+		Mime: "multipart/form-data; boundary=756b6d74fa1a8ee2",
+	}); err != nil {
+		strictError := v.MultipartStrictError()
+		if strictError.Get() != "1" {
+			t.Error("expected strict error")
+		}
+	}
+}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1595,6 +1595,7 @@ type TransactionVariables struct {
 	multipartFilename        *collections.Map
 	multipartName            *collections.Map
 	multipartPartHeaders     *collections.Map
+	multipartStrictError     *collections.Single
 	outboundDataError        *collections.Single
 	queryString              *collections.Single
 	remoteAddr               *collections.Single
@@ -1713,6 +1714,7 @@ func NewTransactionVariables() *TransactionVariables {
 	v.responseXML = collections.NewMap(variables.ResponseXML)
 	v.requestXML = collections.NewMap(variables.RequestXML)
 	v.multipartPartHeaders = collections.NewMap(variables.MultipartPartHeaders)
+	v.multipartStrictError = collections.NewSingle(variables.MultipartStrictError)
 
 	// XML is a pointer to RequestXML
 	v.xml = v.requestXML
@@ -2046,6 +2048,10 @@ func (v *TransactionVariables) ResBodyProcessorErrorMsg() collection.Single {
 	return v.resBodyProcessorErrorMsg
 }
 
+func (v *TransactionVariables) MultipartStrictError() collection.Single {
+	return v.multipartStrictError
+}
+
 // All iterates over the variables. We return both variable and its collection, i.e. key/value, to follow
 // general range iteration in Go which always has a key and value (key is int index for slices). Notably,
 // this is consistent with discussions for custom iterable types in a future language version
@@ -2133,6 +2139,9 @@ func (v *TransactionVariables) All(f func(v variables.RuleVariable, col collecti
 		return
 	}
 	if !f(variables.MultipartPartHeaders, v.multipartPartHeaders) {
+		return
+	}
+	if !f(variables.MultipartStrictError, v.multipartStrictError) {
 		return
 	}
 	if !f(variables.OutboundDataError, v.outboundDataError) {

--- a/testing/coreruleset/go.mod
+++ b/testing/coreruleset/go.mod
@@ -2,8 +2,6 @@ module github.com/corazawaf/coraza/v3/testing/coreruleset
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/corazawaf/coraza-coreruleset/v4 v4.3.0

--- a/testing/coreruleset/go.mod
+++ b/testing/coreruleset/go.mod
@@ -1,6 +1,8 @@
 module github.com/corazawaf/coraza/v3/testing/coreruleset
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1

--- a/testing/coreruleset/go.sum
+++ b/testing/coreruleset/go.sum
@@ -18,14 +18,19 @@ github.com/coreruleset/ftw-tests-schema v1.1.0/go.mod h1:gRd9wBxjUI85HypWRDxJzbk
 github.com/coreruleset/go-ftw v0.6.4 h1:EdDNld38Jv4lxqHS+csGOJuHu1/8rpp4TlrFyoijTPk=
 github.com/coreruleset/go-ftw v0.6.4/go.mod h1:IayMjfOmmNNBcqTcZU92e6UZTy79/eFdmJEmRu8tLs4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=
+github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
+github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
 github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-yaml v1.11.3 h1:B3W9IdWbvrUu2OYQGwvU1nZtvMQJPBKgBUuweJjLj6I=
@@ -58,6 +63,7 @@ github.com/knadh/koanf/v2 v2.1.1/go.mod h1:4mnTRbZCK+ALuBXHZMjDfG9y714L7TykVnZkX
 github.com/kyokomi/emoji/v2 v2.2.13 h1:GhTfQa67venUUvmleTNFnb+bi7S3aocF7ZCXU9fSO7U=
 github.com/kyokomi/emoji/v2 v2.2.13/go.mod h1:JUcn42DTdsXJo1SWanHh4HKDEyPaR5CqkmoirZZP9qE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -67,6 +73,7 @@ github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
+github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -75,10 +82,12 @@ github.com/petar-dambovaliev/aho-corasick v0.0.0-20240411101913-e07a1f0e8eb4 h1:
 github.com/petar-dambovaliev/aho-corasick v0.0.0-20240411101913-e07a1f0e8eb4/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
 github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -91,6 +100,7 @@ github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGu
 golang.org/x/crypto v0.24.0 h1:mnl8DM0o513X8fdIkmyFE/5hTYxbwYOjDS/+rK6qpRI=
 golang.org/x/crypto v0.24.0/go.mod h1:Z1PMYSOR5nyMcyAVAIQSKCDwalqy85Aqn1x3Ws4L5DM=
 golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
 golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/types/variables/variables.go
+++ b/types/variables/variables.go
@@ -194,6 +194,8 @@ const (
 	ResBodyProcessorError = variables.ResBodyProcessorError
 	// ResBodyProcessorErrorMsg contains the error message if the response body processor failed
 	ResBodyProcessorErrorMsg = variables.ResBodyProcessorErrorMsg
+	// MultipartStrictError will be set to 1 when there is an error parsing multipart
+	MultipartStrictError = variables.MultipartStrictError
 )
 
 // Parse returns the byte interpretation


### PR DESCRIPTION
## what

- set MULTIPART_STRICT_ERROR as it is used in coraza.conf-recommended but never set
- as the parser doesn't implement all the sub-variables from modsecurity, at least a global failure must be propagated

## why

- to catch possible evasion attempts with multipart data