### PR TITLE
chore:  config renovate to update up to our supported go version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ]
+    "config:best-practices"
+  ],
+  {
+  "constraints": {
+    "go": "1.21"
+  }
 }


### PR DESCRIPTION
## what

- prevent renovate to go beyond our golang supported version
- use best-practices instead of recommended

## why

- do not waste time reverting renovatebot changes in major release
- get best-practices