### PR TITLE
fix: broken TestDirectives SecUploadDir on windows

### DIFF
--- a/internal/seclang/directives_test.go
+++ b/internal/seclang/directives_test.go
@@ -4,6 +4,7 @@
 package seclang
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -142,7 +143,7 @@ func TestDirectives(t *testing.T) {
 		"SecUploadDir": {
 			{"", expectErrorOnDirective},
 			{"/tmp-non-existing", expectErrorOnDirective},
-			{"/tmp", func(w *corazawaf.WAF) bool { return w.UploadDir == "/tmp" }},
+			{os.TempDir(), func(w *corazawaf.WAF) bool { return w.UploadDir == os.TempDir() }},
 		},
 		"SecSensorId": {
 			{"", expectErrorOnDirective},


### PR DESCRIPTION
This is a small fix for the SecUploadDir directive test. On windows /tmp does not exist, so I choose a platform independent approach. This test now passes OK on windows and *nix.
