### PR TITLE
fix: broken TestInspectFile on windows

### DIFF
--- a/internal/operators/inspect_file_test.go
+++ b/internal/operators/inspect_file_test.go
@@ -9,19 +9,24 @@ package operators
 import (
 	_ "fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 )
 
 func TestInspectFile(t *testing.T) {
+	existCommand := "/bin/echo"
+	if runtime.GOOS == "windows" {
+		existCommand = "C:\\Windows\\system32\\tasklist.exe"
+	}
+
 	tests := []struct {
 		path   string
 		exists bool
 	}{
 		{
-			// TODO(anuraaga): Don't have this rely on OS details.
-			path:   "/bin/echo",
+			path:   existCommand,
 			exists: true,
 		},
 		{
@@ -37,7 +42,7 @@ func TestInspectFile(t *testing.T) {
 			if err != nil {
 				t.Error("cannot init inspectfile operator")
 			}
-			if want, have := tt.exists, ipf.Evaluate(nil, ""); want != have {
+			if want, have := tt.exists, ipf.Evaluate(nil, "/?"); want != have {
 				t.Errorf("inspectfile path %s: want %v, have %v", tt.path, want, have)
 			}
 		})


### PR DESCRIPTION
This is a small for TestInspectFile on windows. As windows is not able to run /bin/echo I choose an alternative for this platform.

Why tasklist.exe?
- it is available on all windows versions
- it is available on wine
- it does not require elevated privileges

I also changed the argument from "" to "/?" to ensure that tasklist.exe does not do anything. On *nix this does not have any impact.

Why not XYZ?
I was unable to find a suitable platform independent alternative, as "finding" an available binary (e.g. go) at runtime would make the test more complex than the actual code.