### PR TITLE
fix: broken normalisePath/normalisePathWin on windows

### DIFF
--- a/internal/transformations/normalise_path.go
+++ b/internal/transformations/normalise_path.go
@@ -5,6 +5,7 @@ package transformations
 
 import (
 	"path/filepath"
+	"strings"
 )
 
 func normalisePath(data string) (string, bool, error) {
@@ -13,10 +14,15 @@ func normalisePath(data string) (string, bool, error) {
 		return data, false, nil
 	}
 	clean := filepath.Clean(data)
+	if filepath.Separator != '/' {
+		// filepath.Clean uses filepath.Separator for the cleaned path
+		// on windows we need to replace the Separator with the expected forward slash
+		clean = strings.ReplaceAll(clean, string(filepath.Separator), "/")
+	}
 	if clean == "." {
 		return "", true, nil
 	}
-	if data[len(data)-1] == '/' {
+	if data[len(data)-1] == '/' || data[len(data)-1] == '\\' {
 		return clean + "/", true, nil
 	}
 	return clean, data != clean, nil


### PR DESCRIPTION
Currently the normalisePath transformation tests fail on windows. This is due to the behaviour difference of filepath.Clean on different platforms. filepath.Clean uses filepath.Separator for it's output, but a / seperated path is expected.

Furthermore, now there is also a check for \ as path directory ending.

This fixes the normalisePath and normalisePathWin transformation tests on windows.


