### PR TITLE
fix: broken embedio on windows

### DIFF
--- a/internal/io/embedio.go
+++ b/internal/io/embedio.go
@@ -1,0 +1,15 @@
+package io
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// FSReadFile wraps fs.ReadFile supporting embedio on windows
+func FSReadFile(fsys fs.FS, name string) ([]byte, error) {
+	if filepath.Separator != '/' {
+		name = strings.ReplaceAll(name, string(filepath.Separator), "/")
+	}
+	return fs.ReadFile(fsys, name)
+}

--- a/internal/operators/from_file.go
+++ b/internal/operators/from_file.go
@@ -7,14 +7,16 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"path"
+	"path/filepath"
+
+	"github.com/corazawaf/coraza/v3/internal/io"
 )
 
 var errEmptyDirs = errors.New("empty dirs")
 
-func loadFromFile(filepath string, dirs []string, root fs.FS) ([]byte, error) {
-	if path.IsAbs(filepath) {
-		return fs.ReadFile(root, filepath)
+func loadFromFile(filename string, dirs []string, root fs.FS) ([]byte, error) {
+	if filepath.IsAbs(filename) {
+		return io.FSReadFile(root, filename)
 	}
 
 	if len(dirs) == 0 {
@@ -30,8 +32,8 @@ func loadFromFile(filepath string, dirs []string, root fs.FS) ([]byte, error) {
 	)
 
 	for _, p := range dirs {
-		absFilepath := path.Join(p, filepath)
-		content, err = fs.ReadFile(root, absFilepath)
+		absFilepath := filepath.Join(p, filename)
+		content, err = io.FSReadFile(root, absFilepath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -56,7 +56,7 @@ func (p *Parser) FromFile(profilePath string) error {
 		p.currentFile = profilePath
 		lastDir := p.currentDir
 		p.currentDir = filepath.Dir(profilePath)
-		file, err := fs.ReadFile(p.root, profilePath)
+		file, err := io.FSReadFile(p.root, profilePath)
 		if err != nil {
 			// we don't use defer for this as tinygo does not seem to like it
 			p.currentDir = originalDir


### PR DESCRIPTION
At the moment loadFromFile and parser.FromFile fail on windows if fs.Sub filesystem is used. This is due to the different behaviour related to  filepath.Seperator and absolute paths. 

This patch fixes TestEmbedFS, TestLoadFromFileAbsolutePath and TestLoadFromCustomFS on windows.

As loadFromFile and Parser.FromFile are not related to each other, it made more sense to me, to put the common code into the io package.