### PR TITLE
fix: broken multipart processor on windows

### DIFF
--- a/internal/bodyprocessors/multipart.go
+++ b/internal/bodyprocessors/multipart.go
@@ -65,6 +65,7 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 					v.MultipartStrictError().(*collections.Single).Set("1")
 					return err
 				}
+				defer temp.Close()
 				sz, err := io.Copy(temp, p)
 				if err != nil {
 					v.MultipartStrictError().(*collections.Single).Set("1")


### PR DESCRIPTION
The multipartBodyProcessor is broken on windows, because it creates a temporary file without closing it.

This would usually not be a problem, as the gc would take care of it, but the tests on windows fail, because go test tries to delete the files before gc cleaned the file descriptors.

Windows refuses to delete files as long as the file descriptor is open. Closing the temporary file fixes this issue and go test is able to cleanup the files.
