### PR TITLE
fix: broken unclosed files on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 	}
+	// Close log files if any
+	defer waf.Close()
 
 	// Then we create a transaction and assign some variables
 	tx := waf.NewTransaction()

--- a/debuglog/logger.go
+++ b/debuglog/logger.go
@@ -97,4 +97,6 @@ type Logger interface {
 	// Error starts a new message with error level.
 	// You must call Msg on the returned event in order to send the event.
 	Error() Event
+
+	io.Closer
 }

--- a/internal/auditlog/https_writer.go
+++ b/internal/auditlog/https_writer.go
@@ -19,7 +19,6 @@ import (
 
 // httpsWriter is used to store logs in a single file
 type httpsWriter struct {
-	io.Closer
 	formatter plugintypes.AuditLogFormatter
 	url       string
 	client    *http.Client
@@ -65,6 +64,10 @@ func (h *httpsWriter) Write(al plugintypes.AuditLog) error {
 		// we cannot generate a log using the current api
 		return nil
 	}
+	return nil
+}
+
+func (h *httpsWriter) Close() error {
 	return nil
 }
 

--- a/internal/auditlog/serial_writer.go
+++ b/internal/auditlog/serial_writer.go
@@ -13,13 +13,13 @@ import (
 
 // serialWriter is used to store logs in a single file
 type serialWriter struct {
-	io.Closer
+	closer    io.Closer
 	logger    log.Logger
 	formatter plugintypes.AuditLogFormatter
 }
 
 func (sl *serialWriter) Init(c plugintypes.AuditLogConfig) error {
-	sl.Closer = NoopCloser
+	sl.closer = NoopCloser
 	if c.Target == "" {
 		return nil
 	}
@@ -36,7 +36,7 @@ func (sl *serialWriter) Init(c plugintypes.AuditLogConfig) error {
 			return err
 		}
 		f = ff
-		sl.Closer = ff
+		sl.closer = ff
 	}
 
 	sl.formatter = c.Formatter
@@ -60,6 +60,13 @@ func (sl *serialWriter) Write(al plugintypes.AuditLog) error {
 	}
 
 	sl.logger.Println(string(bts))
+	return nil
+}
+
+func (sl *serialWriter) Close() error {
+	if sl.closer != nil {
+		return sl.closer.Close()
+	}
 	return nil
 }
 

--- a/internal/auditlog/serial_writer_test.go
+++ b/internal/auditlog/serial_writer_test.go
@@ -44,7 +44,7 @@ func TestSerialLoggerSuccessOnInit(t *testing.T) {
 				t.Errorf("unexpected error: %s", err.Error())
 			}
 
-			if want, have := test.expectedCloser, w.Closer; want != have {
+			if want, have := test.expectedCloser, w.closer; want != have {
 				t.Errorf("unexpected closer, want %v, have %v", want, have)
 			}
 

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -414,3 +414,16 @@ func (w *WAF) Validate() error {
 
 	return nil
 }
+
+func (w *WAF) Close() error {
+	var err error = nil
+	auditLogWriter := w.auditLogWriter
+	if auditLogWriter != nil {
+		err = auditLogWriter.Close()
+	}
+	err1 := w.Logger.Close()
+	if err != nil {
+		return err
+	}
+	return err1
+}

--- a/internal/seclang/directives_log_test.go
+++ b/internal/seclang/directives_log_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := NewParser(waf)
 
 	auditpath := t.TempDir()
@@ -67,6 +68,7 @@ func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 
 func TestDebugDirectives(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	tmp := filepath.Join(t.TempDir(), "tmp.log")
 	p := NewParser(waf)
 	err := directiveSecDebugLog(&DirectiveOptions{

--- a/testing/auditlog_test.go
+++ b/testing/auditlog_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestAuditLogMessages(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	// generate a random tmp file
 	file, err := os.Create(filepath.Join(t.TempDir(), "tmp.log"))
@@ -42,7 +43,7 @@ func TestAuditLogMessages(t *testing.T) {
 	`); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 
 	tx := waf.NewTransaction()
 	tx.AddGetRequestArgument("test", "test")
@@ -73,6 +74,7 @@ func TestAuditLogMessages(t *testing.T) {
 
 func TestAuditLogRelevantOnly(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
@@ -89,7 +91,7 @@ func TestAuditLogRelevantOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}
@@ -110,13 +112,14 @@ func TestAuditLogRelevantOnly(t *testing.T) {
 
 func TestAuditLogRelevantOnlyOk(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	// generate a random tmp file
 	file, err := os.Create(filepath.Join(t.TempDir(), "tmp.log"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}
@@ -148,6 +151,7 @@ func TestAuditLogRelevantOnlyOk(t *testing.T) {
 
 func TestAuditLogRelevantOnlyNoAuditlog(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
@@ -164,7 +168,7 @@ func TestAuditLogRelevantOnlyNoAuditlog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}
@@ -185,6 +189,7 @@ func TestAuditLogRelevantOnlyNoAuditlog(t *testing.T) {
 
 func TestAuditLogOnNoLog(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
@@ -203,7 +208,7 @@ func TestAuditLogOnNoLog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}
@@ -228,6 +233,7 @@ func TestAuditLogOnNoLog(t *testing.T) {
 
 func TestAuditLogRequestMethodURIProtocol(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
@@ -242,7 +248,7 @@ func TestAuditLogRequestMethodURIProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}
@@ -283,6 +289,7 @@ func TestAuditLogRequestMethodURIProtocol(t *testing.T) {
 
 func TestAuditLogRequestBody(t *testing.T) {
 	waf := corazawaf.NewWAF()
+	defer waf.Close()
 	parser := seclang.NewParser(waf)
 	if err := parser.FromString(`
 		SecRuleEngine DetectionOnly
@@ -298,7 +305,7 @@ func TestAuditLogRequestBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer file.Close()
 	if err := parser.FromString(fmt.Sprintf("SecAuditLog %s", file.Name())); err != nil {
 		t.Fatal(err)
 	}

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -204,6 +204,7 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 	if err != nil {
 		t.Fatalf("failed to create error log: %v", err)
 	}
+	defer errorFile.Close()
 	errorWriter := bufio.NewWriter(errorFile)
 	conf = conf.WithErrorCallback(func(rule types.MatchedRule) {
 		msg := rule.ErrorLog() + "\n"
@@ -219,6 +220,7 @@ SecRule REQUEST_HEADERS:X-CRS-Test "@rx ^.*$" \
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer waf.Close()
 
 	s := httptest.NewServer(txhttp.WrapHandler(waf, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()

--- a/waf.go
+++ b/waf.go
@@ -6,6 +6,7 @@ package coraza
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/experimental"
@@ -26,6 +27,7 @@ type WAF interface {
 	// NewTransaction Creates a new initialized transaction for this WAF instance
 	NewTransaction() types.Transaction
 	NewTransactionWithID(id string) types.Transaction
+	io.Closer
 }
 
 // NewWAF creates a new WAF instance with the provided configuration.
@@ -150,4 +152,9 @@ func (w wafWrapper) NewTransactionWithID(id string) types.Transaction {
 // NewTransaction implements the same method on WAF.
 func (w wafWrapper) NewTransactionWithOptions(opts experimental.Options) types.Transaction {
 	return w.waf.NewTransactionWithOptions(opts)
+}
+
+// Close open log files
+func (w wafWrapper) Close() error {
+	return w.waf.Close()
 }


### PR DESCRIPTION
This patch fixes tests and log file behaviour on windows. The big problem here is, that windows does not allow to delete files with open file descriptors.

To solve this problem I had to implement the following changes:
- close temp files created during the tests
- close opened log files
- Add io.Closer to the WAF interface to allow closing log files

This was originally intended as a small fix, but now it requires an API change. Technically, it is not required to Close the log files on linux, but I think it is still a good best practice to not rely on GC alone.

I removed the os.Remove calls from testing/auditlog_test.go and replaced them with Close, as go test already cleans them up, but only if they are properly closed (on windows).