### PR TITLE
add windows-2022 to gh regression tests

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.21.x, 1.22.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
As discussed in other PRs a windows regression test would be helpful for the future.

For now the tests will fail, as several other PRs must be merged first and go-ftw must be updated to the latest version (my PR was just merged at go-ftw that fixed the windows issues there). I suggest to keep this PR open and retry it after other PRs are merged.