### PR TITLE
chore: update tinygo to 0.33.0

### DIFF
--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.22.x]
+        tinygo-version: [0.33.0]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,7 +35,7 @@ jobs:
       - name: setup tinygo
         uses: acifani/setup-tinygo@b2ba42b249c7d3efdfe94166ec0f48b3191404f7 # v2
         with:
-          tinygo-version: '0.31.2'
+          tinygo-version: ${{ matrix.tinygo-version }}
 
       - name: Cache TinyGo build
         uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3


### PR DESCRIPTION
## what

- updates tinygo to 0.33.0

## why

- compatible with go 1.23

## references

- https://github.com/tinygo-org/tinygo/releases/tag/v0.33.0