### PR TITLE
refactor: replace `reflect.StringHeader` with `unsafe.StringData`

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -5,7 +5,6 @@ package corazawaf
 
 import (
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -399,7 +398,7 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 		default:
 			// NOTE: See comment on transformationKey struct to understand this hacky code
 			argKey := arg.Key()
-			argKeyPtr := (*reflect.StringHeader)(unsafe.Pointer(&argKey)).Data // nolint:staticcheck
+			argKeyPtr := unsafe.StringData(argKey)
 			key := transformationKey{
 				argKey:            argKeyPtr,
 				argIndex:          argIdx,

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -253,7 +253,7 @@ type transformationKey struct {
 	// transaction phase and we would never have different string pointers with the same
 	// content, or more problematically same pointer for different content, as the strings
 	// will be alive throughout the phase.
-	argKey            uintptr
+	argKey            *byte
 	argIndex          int
 	argVariable       variables.RuleVariable
 	transformationsID int


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart:

---

Closes https://github.com/corazawaf/coraza/issues/1147.

The Godoc of `reflect.StringHeader` states [^1]:

> the Data field is not sufficient to guarantee the data it references will not be garbage collected, so programs must keep a separate, correctly typed pointer to the underlying data.

And the Godoc of `unsafe.Pointer` states [^2]:

> (2) Conversion of a Pointer to a uintptr (but not back to Pointer)
> ...
> A uintptr is an integer, not a reference. ... Even if a uintptr holds
the address of some object, the garbage collector will not update that uintptr's value if the object moves, nor will that uintptr keep the object from being reclaimed.

The replacement `unsafe.StringData` is a more correct way to get the pointer to the string data. The original proposal can be seen in https://github.com/golang/go/issues/53003#issuecomment-1140276077.

[^1]: https://pkg.go.dev/reflect#StringHeader
[^2]: https://pkg.go.dev/unsafe#Pointer