### PR TITLE
chore: expose request timestamp

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1504,6 +1504,11 @@ func (tx *Transaction) AuditLog() *auditlog.Log {
 	return al
 }
 
+// UnixTimestamp returns the timestamp when the request was received.
+func (tx *Transaction) UnixTimestamp() int64 {
+	return tx.Timestamp
+}
+
 // Close closes the transaction after phase 5
 // This method helps the GC to clean up the transaction faster and release resources
 // It also allows caches the transaction back into the sync.Pool

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1719,7 +1719,6 @@ func TestForceRequestBodyOverride(t *testing.T) {
 func TestGetUnixTimestamp(t *testing.T) {
 	tx := makeTransaction(t)
 	stamp := tx.UnixTimestamp()
-	t.Logf("stamp: %d", stamp)
 	if stamp <= 0 {
 		t.Fatalf("no timestamp found")
 	}

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1716,6 +1716,15 @@ func TestForceRequestBodyOverride(t *testing.T) {
 	}
 }
 
+func TestGetUnixTimestamp(t *testing.T) {
+	tx := makeTransaction(t)
+	stamp := tx.UnixTimestamp()
+	t.Logf("stamp: %d", stamp)
+	if stamp <= 0 {
+		t.Fatalf("no timestamp found")
+	}
+}
+
 func TestCloseFails(t *testing.T) {
 	waf := NewWAF()
 	tx := waf.NewTransaction()

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -193,6 +193,8 @@ type Transaction interface {
 	// ID returns the transaction ID.
 	ID() string
 
+	// UnixTimestamp returns the transaction timestamp
+	UnixTimestamp() int64
 	// Closer closes the transaction and releases any resources associated with it such as request/response bodies.
 	io.Closer
 }


### PR DESCRIPTION
## what

- expose request timestamp
- we already used it for auditlog in ocsf as "Unix Timestamp"

## why

- #1144 

## TODO

- move to experimental