### PR TITLE
chore: update renovate config to use common

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
-  ],
-  "constraints": {
-    "go": "1.22"
-  }
+    "local>corazawaf/renovate-config"
+  ]
 }


### PR DESCRIPTION
## what

- use centralized renovatebot config

## why

- standarization
- easier maintenance