### PR TITLE
fix: toolchain version in go.mod

### DIFF
--- a/examples/http-server/go.mod
+++ b/examples/http-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/corazawaf/coraza/v3/examples/http-server
 
-go 1.22
+go 1.22.0
 
 require github.com/corazawaf/coraza/v3 v3.2.1
 


### PR DESCRIPTION
## what

- fix toolchain version

## why

- As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).
