### PR TITLE
perf: GetField reduce allocations

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -587,9 +587,9 @@ func (tx *Transaction) GetField(rv ruleVariableParams) []types.MatchData {
 	}
 
 	// in the most common scenario filteredMatches length will be
-	// the same as matches length, so we avoid allocating per result
-	filteredMatches := make([]types.MatchData, 0, len(matches))
-
+	// the same as matches length, so we avoid allocating per result.
+	// We reuse the matches slice to store filtered results avoiding extra allocation.
+	filteredCount := 0
 	for _, c := range matches {
 		isException := false
 		lkey := strings.ToLower(c.Key())
@@ -600,10 +600,11 @@ func (tx *Transaction) GetField(rv ruleVariableParams) []types.MatchData {
 			}
 		}
 		if !isException {
-			filteredMatches = append(filteredMatches, c)
+			matches[filteredCount] = c
+			filteredCount++
 		}
 	}
-	matches = filteredMatches
+	matches = matches[:filteredCount]
 
 	if rv.Count {
 		count := len(matches)

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1291,6 +1291,20 @@ func TestTxGetField(t *testing.T) {
 	}
 }
 
+func BenchmarkTxGetField(b *testing.B) {
+	tx := makeTransaction(b)
+	rvp := ruleVariableParams{
+		Variable: variables.Args,
+	}
+	for i := 0; i < b.N; i++ {
+		tx.GetField(rvp)
+	}
+	if err := tx.Close(); err != nil {
+		b.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+	b.ReportAllocs()
+}
+
 func TestTxProcessURI(t *testing.T) {
 	waf := NewWAF()
 	tx := waf.NewTransaction()


### PR DESCRIPTION
One less alloc/op, but numbers can matter at scale.


Before:
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/corazawaf
cpu: Apple M1 Pro
BenchmarkTxGetField-10    	 2294287	       582.5 ns/op	     448 B/op	       9 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/internal/corazawaf	2.374s

BenchmarkCRSSimplePOST-10    	     902	   1276337 ns/op	  338771 B/op	    7220 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/testing/coreruleset	2.054s

```
After:
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/corazawaf
cpu: Apple M1 Pro
BenchmarkTxGetField-10    	 3306369	       355.6 ns/op	     400 B/op	       8 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/internal/corazawaf	2.051s

BenchmarkCRSSimplePOST-10    	     874	   1262635 ns/op	  320807 B/op	    6418 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/testing/coreruleset	2.034s
```