### PR TITLE
experimental: UseRequest/ResponseBody methods

### DIFF
--- a/experimental/transaction.go
+++ b/experimental/transaction.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package experimental
+
+import (
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+type Transaction interface {
+	types.Transaction
+	// UseRequestBody directly sets the provided byte slice as the request body buffer.
+	// This is meant to be used when the entire request body is available, as it avoids
+	// the need for an extra copy into the request body buffer. Because of this, this method
+	// is expected to be called just once, further calls to UseRequestBody have to be avoided.
+	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
+	// The caller should not use b slice after this call.
+	//
+	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
+	UseRequestBody(b []byte) (*types.Interruption, int, error)
+
+	UseResponseBody(b []byte) (*types.Interruption, int, error)
+}

--- a/experimental/transaction.go
+++ b/experimental/transaction.go
@@ -9,6 +9,7 @@ import (
 
 type Transaction interface {
 	types.Transaction
+
 	// UseRequestBody directly sets the provided byte slice as the request body buffer.
 	// This is meant to be used when the entire request body is available, as it avoids
 	// the need for an extra copy into the request body buffer. Because of this, this method
@@ -19,5 +20,13 @@ type Transaction interface {
 	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
 	UseRequestBody(b []byte) (*types.Interruption, int, error)
 
+	// UseResponseBody directly sets the provided byte slice as the response body buffer.
+	// This is meant to be used when the entire response body is available, as it avoids
+	// the need for an extra copy into the response body buffer. Because of this, this method is expected to
+	// be called just once, further calls to UseResponseBody have to be avoided.
+	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
+	// The caller should not use b slice after this call.
+	//
+	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
 	UseResponseBody(b []byte) (*types.Interruption, int, error)
 }

--- a/experimental/transaction.go
+++ b/experimental/transaction.go
@@ -15,7 +15,9 @@ type Transaction interface {
 	// the need for an extra copy into the request body buffer. Because of this, this method
 	// is expected to be called just once, further calls to UseRequestBody have to be avoided.
 	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
-	// The caller should not use b slice after this call.
+	//
+	// Note: The new internal buffer takes ownership of the provided data, the caller should NOT use b slice
+	// after this call.
 	//
 	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
 	UseRequestBody(b []byte) (*types.Interruption, int, error)
@@ -25,7 +27,9 @@ type Transaction interface {
 	// the need for an extra copy into the response body buffer. Because of this, this method is expected to
 	// be called just once, further calls to UseResponseBody have to be avoided.
 	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
-	// The caller should not use b slice after this call.
+	//
+	// Note: The new internal buffer takes ownership of the provided data, the caller should NOT use b slice
+	// after this call.
 	//
 	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
 	UseResponseBody(b []byte) (*types.Interruption, int, error)

--- a/go.sum
+++ b/go.sum
@@ -100,7 +100,10 @@ golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
+<<<<<<< HEAD
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+=======
+>>>>>>> 2659bf19 (go mods)
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -100,10 +100,7 @@ golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
-<<<<<<< HEAD
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-=======
->>>>>>> 2659bf19 (go mods)
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -94,6 +94,24 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	return br.buffer.Write(data)
 }
 
+// SetBuffer sets the buffer to the provided slice of bytes.
+func (br *BodyBuffer) SetBuffer(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("provided data is empty")
+	}
+
+	// Check if the provided data exceeds the memory limit
+	if int64(len(data)) > br.options.MemoryLimit {
+		return errors.New("memoryLimit reached while writing")
+	}
+
+	// Set the buffer to the provided slice
+	br.buffer = bytes.NewBuffer(data)
+	br.length = int64(len(data))
+
+	return nil
+}
+
 type bodyBufferReader struct {
 	pos int
 	br  *BodyBuffer

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1272,11 +1272,6 @@ func (tx *Transaction) ReadResponseBodyFrom(r io.Reader) (*types.Interruption, i
 	return tx.interruption, int(w), err
 }
 
-// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
-// The caller should not use b slice after this call.
-//
-// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
-
 // UseResponseBody directly sets the provided byte slice as the response body buffer.
 // This is meant to be used when the entire response body is available, as it avoids
 // the need for an extra copy into the response body buffer. Because of this, this method is expected to

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -393,6 +393,32 @@ func TestUseRequestBodyMultipleCalls(t *testing.T) {
 	}
 }
 
+func BenchmarkUseRequestBody(b *testing.B) {
+	body := bytes.Repeat([]byte("A"), 10*1024*1024)
+
+	b.Run("WriteRequestBody", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tx := makeTransaction(b)
+			tx.lastPhase = 1
+			tx.RequestBodyAccess = true
+			tx.RequestBodyLimit = 11 * 1024 * 1024
+			_, _, _ = tx.WriteRequestBody(body)
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("UseRequestBody", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tx := makeTransaction(b)
+			tx.lastPhase = 1
+			tx.RequestBodyAccess = true
+			tx.RequestBodyLimit = 11 * 1024 * 1024
+			_, _, _ = tx.UseRequestBody(body)
+		}
+		b.ReportAllocs()
+	})
+}
+
 func TestResponseHeader(t *testing.T) {
 	tx := makeTransaction(t)
 	tx.AddResponseHeader("content-type", "test")
@@ -760,6 +786,32 @@ func TestUseResponseBodyMultipleCalls(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error calling UseRequestBody twice with phase 2 processed in between")
 	}
+}
+
+func BenchmarkUseResponseBody(b *testing.B) {
+	body := bytes.Repeat([]byte("A"), 10*1024*1024)
+
+	b.Run("WriteResponseBody", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tx := makeTransaction(b)
+			tx.lastPhase = 3
+			tx.ResponseBodyAccess = true
+			tx.ResponseBodyLimit = 11 * 1024 * 1024
+			_, _, _ = tx.WriteRequestBody(body)
+		}
+		b.ReportAllocs()
+	})
+
+	b.Run("UseResponseBody", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tx := makeTransaction(b)
+			tx.lastPhase = 3
+			tx.ResponseBodyAccess = true
+			tx.ResponseBodyLimit = 11 * 1024 * 1024
+			_, _, _ = tx.UseResponseBody(body)
+		}
+		b.ReportAllocs()
+	})
 }
 
 func TestAuditLogFields(t *testing.T) {

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/debuglog"
@@ -114,49 +115,18 @@ func TestTxMultipart(t *testing.T) {
 	}
 }
 
-func TestTxResponse(t *testing.T) {
-	/*
-		tx := NewWAF().NewTransaction()
-		ht := []string{
-			"HTTP/1.1 200 OK",
-			"Content-Type: text/html",
-			"Last-Modified: Mon, 14 Sep 2020 21:10:42 GMT",
-			"Accept-Ranges: bytes",
-			"ETag: \"0b5f480db8ad61:0\"",
-			"Vary: Accept-Encoding",
-			"Server: Microsoft-IIS/8.5",
-			"Content-Security-Policy: default-src: https:; frame-ancestors 'self' X-Frame-Options: SAMEORIGIN",
-			"Strict-Transport-Security: max-age=31536000; includeSubDomains; preload",
-			"Date: Wed, 16 Sep 2020 14:14:09 GMT",
-			"Connection: close",
-			"Content-Length: 10",
-			"",
-			"testcontent",
-		}
-		data := strings.Join(ht, "\r\n")
-		tx.ParseResponseString(nil, data)
-
-		exp := map[string]string{
-			"%{response_headers.content-length}": "10",
-			"%{response_headers.server}":         "Microsoft-IIS/8.5",
-		}
-
-		validateMacroExpansion(exp, tx, t)
-	*/
-}
-
 var requestBodyWriters = map[string]func(tx *Transaction, body string) (*types.Interruption, int, error){
-	// "WriteRequestBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
-	// 	return tx.WriteRequestBody([]byte(body))
-	// },
-	// "ReadRequestBodyFromKnownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
-	// 	return tx.ReadRequestBodyFrom(strings.NewReader(body))
-	// },
-	// "ReadRequestBodyFromUnknownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
-	// 	return tx.ReadRequestBodyFrom(struct{ io.Reader }{
-	// 		strings.NewReader(body),
-	// 	})
-	// },
+	"WriteRequestBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.WriteRequestBody([]byte(body))
+	},
+	"ReadRequestBodyFromKnownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.ReadRequestBodyFrom(strings.NewReader(body))
+	},
+	"ReadRequestBodyFromUnknownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.ReadRequestBodyFrom(struct{ io.Reader }{
+			strings.NewReader(body),
+		})
+	},
 	"UseRequestBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
 		return tx.UseRequestBody([]byte(body))
 	},
@@ -219,7 +189,7 @@ func TestWriteRequestBody(t *testing.T) {
 					for name, chunks := range bodyChunks {
 						t.Run(name, func(t *testing.T) {
 							if name != "BodyInOneShot" && writerName == "UseRequestBody" {
-								// UseRequestBody is intended to be used when the whole body is available
+								// UseRequestBody is intended to be used only when the whole body is available
 								return
 							}
 							waf := NewWAF()
@@ -306,7 +276,8 @@ func TestWriteRequestBodyOnLimitReached(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			for wName, writer := range requestBodyWriters {
 				if wName == "UseRequestBody" {
-					// Skip UseRequestBody test case. It is intended to be used when the whole body is available
+					// Skip UseRequestBody test case. It is intended to be used only when the whole body is available
+					// at once. This test gradually populates the body up to its limit.
 					continue
 				}
 				t.Run(wName, func(t *testing.T) {
@@ -388,31 +359,39 @@ func TestWriteRequestBodyIsNopWhenBodyIsNotAccesible(t *testing.T) {
 	}
 }
 
-// TODO: test TestUseRequestBodyMultipleCalls return an error
-// TODO: implement UseResponseBody
-// func TestUseRequestBodyMultipleCalls(t *testing.T) {
-// 	tx := makeTransaction(t)
-// 	tx.RequestBodyAccess = true
-// 	tx.RequestBodyLimit = 20
-// 	body := bytes.Repeat([]byte("a"), 100)
-// 	it, n, err := tx.UseRequestBody(body)
-// 	if err != nil {
-// 		t.Fatalf("unexpected error: %s", err.Error())
-// 	}
-// 	if it != nil {
-// 		t.Fatalf("unexpected interruption")
-// 	}
-// 	if n != int(tx.RequestBodyLimit) {
-// 		t.Fatalf("unexpected number of bytes written")
-// 	}
-// 	// UseRequestBody should not generate a copy of the data,
-// 	// body and tx.Buffer are expected to point to the same data
-// 	bodyPtr := unsafe.SliceData(body)
-// 	txBufferPtr := &tx.requestBodyBuffer.buffer.Bytes()[0]
-// 	if bodyPtr != txBufferPtr {
-// 		t.Fatalf("body and tx.Buffer are not pointing to the same data")
-// 	}
-// }
+// UseRequestBody has not to be called more then once, the first call
+// might already trigger the inspection and so a new buffer set might
+// not be inspected anymore. If that happens, an error has to be returned.
+func TestUseRequestBodyMultipleCalls(t *testing.T) {
+	tx := makeTransaction(t)
+	tx.lastPhase = 1
+	tx.RequestBodyAccess = true
+	tx.RequestBodyLimit = 10
+	tx.WAF.RequestBodyLimitAction = types.BodyLimitActionProcessPartial
+	body := bytes.Repeat([]byte("a"), 11)
+	it, n, err := tx.UseRequestBody(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	if it != nil {
+		t.Fatalf("unexpected interruption: %v", it)
+	}
+	if n != int(tx.RequestBodyLimit) {
+		t.Fatalf("unexpected number of bytes written. Expected %d, got %d", tx.RequestBodyLimit, n)
+	}
+	// UseRequestBody should not generate a copy of the data,
+	// body and tx.Buffer are expected to point to the same data
+	bodyPtr := unsafe.SliceData(body)
+	txBufferPtr := &tx.requestBodyBuffer.buffer.Bytes()[0]
+	if bodyPtr != txBufferPtr {
+		t.Fatalf("body and tx.Buffer are not pointing to the same data")
+	}
+	// Second call to UseRequestBody with phase 2 processed should trigger an error
+	_, _, err = tx.UseRequestBody(body)
+	if err == nil {
+		t.Fatalf("expected error calling UseRequestBody twice with phase 2 processed in between")
+	}
+}
 
 func TestResponseHeader(t *testing.T) {
 	tx := makeTransaction(t)
@@ -516,6 +495,9 @@ var responseBodyWriters = map[string]func(tx *Transaction, body string) (*types.
 			strings.NewReader(body),
 		})
 	},
+	"UseResponseBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+		return tx.UseResponseBody([]byte(body))
+	},
 }
 
 func TestWriteResponseBody(t *testing.T) {
@@ -567,10 +549,14 @@ func TestWriteResponseBody(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			for name, writeResponseBody := range responseBodyWriters {
-				t.Run(name, func(t *testing.T) {
+			for writerName, writeResponseBody := range responseBodyWriters {
+				t.Run(writerName, func(t *testing.T) {
 					for name, chunks := range bodyChunks {
 						t.Run(name, func(t *testing.T) {
+							if name != "BodyInOneShot" && writerName == "UseResponseBody" {
+								// UseResponseBody is intended to be used only when the whole body is available
+								return
+							}
 							waf := NewWAF()
 							waf.RuleEngine = types.RuleEngineOn
 							waf.ResponseBodyMimeTypes = []string{"text/plain"}
@@ -658,6 +644,11 @@ func TestWriteResponseBodyOnLimitReached(t *testing.T) {
 
 		t.Run(tName, func(t *testing.T) {
 			for wName, writer := range responseBodyWriters {
+				if wName == "UseResponseBody" {
+					// Skip UseResponseBody test case. It is intended to be used only when the whole body is available
+					// at once. This test gradually populates the body up to its limit.
+					continue
+				}
 				t.Run(wName, func(t *testing.T) {
 					tx := waf.NewTransaction()
 					_, err := tx.responseBodyBuffer.Write([]byte("ab"))
@@ -734,6 +725,40 @@ func TestWriteResponseBodyIsNopWhenBodyIsNotAccesible(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+// UseResponseBody has not to be called more then once, the first call
+// might already trigger the inspection and so a new buffer set might
+// not be inspected anymore. If that happens, an error has to be returned.
+func TestUseResponseBodyMultipleCalls(t *testing.T) {
+	tx := makeTransaction(t)
+	tx.lastPhase = 3
+	tx.ResponseBodyAccess = true
+	tx.ResponseBodyLimit = 10
+	tx.WAF.ResponseBodyLimitAction = types.BodyLimitActionProcessPartial
+	body := bytes.Repeat([]byte("a"), 11)
+	it, n, err := tx.UseResponseBody(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	if it != nil {
+		t.Fatalf("unexpected interruption: %v", it)
+	}
+	if n != int(tx.ResponseBodyLimit) {
+		t.Fatalf("unexpected number of bytes written. Expected %d, got %d", tx.ResponseBodyLimit, n)
+	}
+	// UseResponseBody should not generate a copy of the data,
+	// body and tx.Buffer are expected to point to the same data
+	bodyPtr := unsafe.SliceData(body)
+	txBufferPtr := &tx.responseBodyBuffer.buffer.Bytes()[0]
+	if bodyPtr != txBufferPtr {
+		t.Fatalf("body and tx.Buffer are not pointing to the same data")
+	}
+	// Second call to UseResponseBody with phase 4 processed should trigger an error
+	_, _, err = tx.UseResponseBody(body)
+	if err == nil {
+		t.Fatalf("expected error calling UseRequestBody twice with phase 2 processed in between")
 	}
 }
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -104,15 +104,8 @@ type Transaction interface {
 	// It returns the corresponding interruption, the number of bytes written an error if any.
 	ReadRequestBodyFrom(io.Reader) (*Interruption, int, error)
 
-	// UseRequestBody directly sets the provided byte slice as the request body buffer.
-	// This is meant to be used when the entire request body is available, as it avoids
-	// the need for an extra copy into the request body buffer. Because of this, this method is expected to
-	// be called just once. Further calls to UseRequestBody will overwrite the previous body set.
-	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
-	// The caller should not use b slice after this call.
-	//
-	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
-	UseRequestBody(b []byte) (*Interruption, int, error)
+	// Corrently exposed only as experimental
+	// UseRequestBody(b []byte) (*Interruption, int, error)
 
 	// AddResponseHeader Adds a response header variable
 	//
@@ -156,6 +149,9 @@ type Transaction interface {
 	//
 	// It returns the corresponding interruption, the number of bytes written an error if any.
 	ReadResponseBodyFrom(io.Reader) (*Interruption, int, error)
+
+	// Corrently exposed only as experimental
+	// UseResponseBody(b []byte) (*Interruption, int, error)
 
 	// ProcessLogging Logging all information relative to this transaction.
 	// At this point there is not need to hold the connection, the response can be

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -104,6 +104,16 @@ type Transaction interface {
 	// It returns the corresponding interruption, the number of bytes written an error if any.
 	ReadRequestBodyFrom(io.Reader) (*Interruption, int, error)
 
+	// UseRequestBody directly sets the provided byte slice as the request body buffer.
+	// This is meant to be used when the entire request body is available, as it avoids
+	// the need for an extra copy into the request body buffer. Because of this, this method is expected to
+	// be called just once. Further calls to UseRequestBody will overwrite the previous body set.
+	// If the body size exceeds the limit and the action is to reject, an interruption will be returned.
+	// The caller should not use b slice after this call.
+	//
+	// It returns the relevant interruption, the final internal body buffer length and any error that occurs.
+	UseRequestBody(b []byte) (*Interruption, int, error)
+
 	// AddResponseHeader Adds a response header variable
 	//
 	// With this method it is possible to feed Coraza with a response header.


### PR DESCRIPTION
Exposing as experimental two new methods to provide the bodies to Coraza. They are meant to be used when the entire request body is available, as it avoids the need for an extra copy into the body buffers.

Benchmark:
```
goos: darwin
goarch: arm64
pkg: github.com/corazawaf/coraza/v3/internal/corazawaf
BenchmarkUseRequestBody/WriteRequestBody-10         	    1383	    912582 ns/op	10544513 B/op	     214 allocs/op
BenchmarkUseRequestBody/UseRequestBody-10           	   63420	     17178 ns/op	   50075 B/op	     212 allocs/op
PASS
ok  	github.com/corazawaf/coraza/v3/internal/corazawaf	3.559s
```
Usage:
```
tx := waf.NewTransaction().(corazaexperimental.Transaction)
body := []byte("body") // Retrieved from the connector or somewhere
tx.UseResponseBody(body)
```
Usage:
- Go-ftw within its new quantitative testing phase: https://github.com/coreruleset/go-ftw/compare/main...use_body
- Experimenting with new connectors (no code available, yet)