### PR TITLE
chore(regression): improve coverage with testing tag matrix

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,11 +13,28 @@ on:
       - "LICENSE"
 
 jobs:
+  # Generate matrix of tags for all permutations of the tests
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.generate.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Generate tag combinations
+        id: generate
+        run: |
+          go run mage.go tags-matrix > tags.json
+          echo "::set-output name=tags::$(cat tags.json)"
+        shell: bash
   test:
+    needs: generate-matrix
     strategy:
       matrix:
         go-version: [1.22.x, 1.23.x]
         os: [ubuntu-latest]
+        build-flag: ${{ fromJson(needs.generate-matrix.outputs.tags) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -28,7 +45,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
       - name: Tests and coverage
-        run: go run mage.go coverage
+        run: |
+          mkdir build
+          go test -race -coverprofile=build/${{ matrix.build-flag }}.txt -covermode=atomic -coverpkg=./... ${{ matrix.build-flag }} ./...
+          go test -race -coverprofile=build/${{ matrix.build-flag }}-examples.txt -covermode=atomic -coverpkg=./... ${{ matrix.build-flag }} ./examples/http-server
+          go test -coverprofile=build/${{ matrix.build-flag }}-ftw.txt -covermode=atomic -coverpkg=./... ${{ matrix.build-flag }} ./testing/coreruleset
+          go tool cover -html=build/coverage.txt -o build/coverage.html"
       - name: "Codecov: General"
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         if: ${{ matrix.go-version == '1.22.x' }}


### PR DESCRIPTION
This PR addresses the lack of test permutations across all building tags. Future build tags should be added to magefile.go