### PR TITLE
Allow square brackets in variables (macro expansion)

### DIFF
--- a/experimental/plugins/macro/macro.go
+++ b/experimental/plugins/macro/macro.go
@@ -166,7 +166,7 @@ func (m *macro) compile(input string) error {
 }
 
 func isValidMacroChar(c byte) bool {
-	return c == '.' || c == '_' || c == '-' || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+	return c == '[' || c == ']' || c == '.' || c == '_' || c == '-' || (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
 }
 
 // String returns the original string


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart:

**Summary**

This update allows square brackets (`[]`) in variable names, enabling compatibility with parameters like `ARGS.db-reset-tables[]`. Previously, these would result in errors, limiting Coraza's ability to handle some ModSecurity rule sets.

**Why This Matters?**

Square brackets are widely used in GET parameters and filenames. For example:

- PHP use them for array-like parameters (e.g., `fields[name]=value ` or `ARGS.fields[]`).
- jQuery serialize array inputs with square brackets in their names.

Without support for square brackets, users are forced to rewrite or bypass standard rules to handle these cases, reducing security coverage.

**What's Changed**:

- Updated the parser to accept `[]` in variable names.
- Added tests to confirm proper handling of variables with `[]`.

With this change, rules like the following are now supported:
```
SecRule ARGS.db-reset-tables[] "@contains sensitive" "id:1001,phase:2,deny"
```
This brings Coraza closer to full compatibility with ModSecurity configurations.