### PR TITLE
chore: optimizes time variables.

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1612,15 +1612,20 @@ func (tx *Transaction) generateResponseBodyError(err error) {
 // setTimeVariables sets all the time variables
 func (tx *Transaction) setTimeVariables() {
 	timestamp := time.Unix(0, tx.Timestamp)
-	tx.variables.time.Set(timestamp.Format(time.TimeOnly))
-	tx.variables.timeDay.Set(strconv.Itoa(timestamp.Day()))
 	tx.variables.timeEpoch.Set(strconv.FormatInt(timestamp.Unix(), 10))
-	tx.variables.timeHour.Set(strconv.Itoa(timestamp.Hour()))
-	tx.variables.timeMin.Set(strconv.Itoa(timestamp.Minute()))
-	tx.variables.timeSec.Set(strconv.Itoa(timestamp.Second()))
+
+	timeOnly := timestamp.Format(time.TimeOnly)
+	tx.variables.time.Set(timeOnly)
+	tx.variables.timeHour.Set(timeOnly[0:2])
+	tx.variables.timeMin.Set(timeOnly[3:5])
+	tx.variables.timeSec.Set(timeOnly)
+
+	y, m, d := timestamp.Date()
+	tx.variables.timeDay.Set(strconv.Itoa(d))
+	tx.variables.timeMon.Set(strconv.Itoa(int(m)))
+	tx.variables.timeYear.Set(strconv.Itoa(y))
+
 	tx.variables.timeWday.Set(strconv.Itoa(int(timestamp.Weekday())))
-	tx.variables.timeMon.Set(strconv.Itoa(int(timestamp.Month())))
-	tx.variables.timeYear.Set(strconv.Itoa(timestamp.Year()))
 }
 
 // TransactionVariables has pointers to all the variables of the transaction

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1618,7 +1618,7 @@ func (tx *Transaction) setTimeVariables() {
 	tx.variables.time.Set(timeOnly)
 	tx.variables.timeHour.Set(timeOnly[0:2])
 	tx.variables.timeMin.Set(timeOnly[3:5])
-	tx.variables.timeSec.Set(timeOnly)
+	tx.variables.timeSec.Set(timeOnly[6:8])
 
 	y, m, d := timestamp.Date()
 	tx.variables.timeDay.Set(strconv.Itoa(d))

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -1390,6 +1390,15 @@ func makeTransactionTimestamped(t testing.TB) *Transaction {
 	return tx
 }
 
+func BenchmarkTransactionTimestamped(b *testing.B) {
+	tx := NewWAF().NewTransaction()
+	tx.Timestamp = time.Now().Unix()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tx.setTimeVariables()
+	}
+}
+
 func makeTransactionMultipart(t *testing.T) *Transaction {
 	if t != nil {
 		t.Helper()


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/pull/1223

This PR adds a benchmark and also optimization for time variables

**Before**
```
BenchmarkTransactionTimestamped-12       6194395           165.1 ns/op        16 B/op          2 allocs/op
```
**After**
```
BenchmarkTransactionTimestamped-12      12029612            99.59 ns/op       16 B/op          2 allocs/op
```
cc @geoolekom

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: