### PR TITLE
feat: add base64 encode transformation

### DIFF
--- a/internal/transformations/base64encode.go
+++ b/internal/transformations/base64encode.go
@@ -8,5 +8,7 @@ import (
 )
 
 func base64Encode(data string) (string, bool, error) {
-	return base64.StdEncoding.EncodeToString([]byte(data)), true, nil
+	src := []byte(data)
+
+	return base64.StdEncoding.EncodeToString(src), true, nil
 }

--- a/internal/transformations/base64encode.go
+++ b/internal/transformations/base64encode.go
@@ -1,0 +1,12 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import (
+	"encoding/base64"
+)
+
+func base64Encode(data string) (string, bool, error) {
+	return base64.StdEncoding.EncodeToString([]byte(data)), true, nil
+}

--- a/internal/transformations/base64encode.go
+++ b/internal/transformations/base64encode.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// Copyright 2024 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package transformations

--- a/internal/transformations/base64encode.go
+++ b/internal/transformations/base64encode.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 )
 
-func base64Encode(data string) (string, bool, error) {
+func base64encode(data string) (string, bool, error) {
 	src := []byte(data)
 
 	return base64.StdEncoding.EncodeToString(src), true, nil

--- a/internal/transformations/transformations.go
+++ b/internal/transformations/transformations.go
@@ -30,6 +30,7 @@ func GetTransformation(name string) (plugintypes.Transformation, error) {
 func init() {
 	Register("base64Decode", base64decode)
 	Register("base64DecodeExt", base64decodeext)
+	Register("base64Encode", base64encode)
 	Register("cmdLine", cmdLine)
 	Register("compressWhitespace", compressWhitespace)
 	Register("cssDecode", cssDecode)


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!


This PR brings [base64Encode](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#user-content-base64Encode) method.
[Issue 1252](https://github.com/corazawaf/coraza/issues/1252)

This changes rely on `encoding/base` std library  `base64.StdEncoding.EncodeToString`
I spent a little bit of time to investigate if it's necessary to implement custom base64Encode. If you have any doubts, real cases where std doesn't work or not appropriate for this project, please let me know here.


**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
As long as this implementation is technically a one liner that relies on std lib there is no real reason make unit test for it, otherwise we'll test std lib.
Plus as I can see there is a ready test data for `base64encode` in `transformation/testdata/base64encode.json` which is used in `TestTransformations`.
Plus I see there is no `test.go` files for the other one liners (ex. `hexEncode`), as I understood just to avoid bloating the codebase.
- [x] I have an appropriate description with correct grammar.
This code follows the code style in the project: has a specific signature with 3 returning parameters `(string, bool, error)` as I understand for the future flexibility and compatibility.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.
I ran `CGO_ENABLED=1 go run mage.go check` on my local machine and didn't get any fail.

Thanks for your contribution :heart: