### PR TITLE
fix: add empty glob error when no files match

### DIFF
--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -34,7 +34,8 @@ type Parser struct {
 // It will return error if any directive fails to parse
 // or the file does not exist.
 // If the path contains a *, it will be expanded to all
-// files in the directory matching the pattern
+// files in the directory matching the pattern.
+// It will return an error if there are no files matching the pattern.
 func (p *Parser) FromFile(profilePath string) error {
 	originalDir := p.currentDir
 
@@ -44,6 +45,9 @@ func (p *Parser) FromFile(profilePath string) error {
 		files, err = fs.Glob(p.root, profilePath)
 		if err != nil {
 			return fmt.Errorf("failed to glob: %s", err.Error())
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("empty glob: %s does not match any file", profilePath)
 		}
 	} else {
 		files = append(files, profilePath)

--- a/internal/seclang/parser_test.go
+++ b/internal/seclang/parser_test.go
@@ -102,6 +102,11 @@ func TestLoadConfigurationFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
+
+	err = p.FromFile("./testdata/glob/*.comf")
+	if err == nil {
+		t.Errorf("expected an error as glob does not match any file")
+	}
 }
 
 // Connectors are supporting embedding github.com/corazawaf/coraza-coreruleset to ease CRS integration


### PR DESCRIPTION
Implements https://github.com/corazawaf/coraza/issues/1250.

## What

This PR adds an "empty glob" error when trying to include files using a glob pattern, but the pattern does not match any file.

## Why

If a user specifies a config file with `Include rules./*.conf`, the intent is that a number of files will be parsed (at least 1 :sweat_smile:). 
If for some reason the glob pattern does not match any file, we should return an error so that the user realizes there is a problem with the configuration. 
The user can then fix the glob pattern (or remove it if not needed), instead of assuming that the expected configuration files have been loaded. 



## Checklist
- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.
