### PR TITLE
ci: add wait-for-status check

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -86,4 +86,4 @@ jobs:
           uses: poseidon/wait-for-status-checks@v0.6.0
           with:
             token: ${{ secrets.GITHUB_TOKEN }}
-  
+ 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -76,3 +76,14 @@ jobs:
           files: build/coverage-tinygo.txt
           flags: tinygo,${{ matrix.build-flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
+  enforce-all-checks:
+      runs-on: ubuntu-latest
+      needs: test
+      permissions:
+        checks: read
+      steps:
+        - name: GitHub Checks
+          uses: poseidon/wait-for-status-checks@v0.6.0
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+  

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate
         run: |
           go run mage.go tagsmatrix > tags.json
-          echo "::set-output name=tags::$(cat tags.json)"
+          echo "tags=$(cat tags.json)" >> $GITHUB_OUTPUT
         shell: bash
   test:
     needs: generate-matrix


### PR DESCRIPTION
## what

- adds a new job in regression tests to prevent PRs to be merged unless everything has been a `success` in the pipeline
- fix deprecation in `set-output`

## why

- we must reassure that tests pass for all combinations