### PR TITLE
inspectFile: False-positive match fixed

### DIFF
--- a/internal/operators/inspect_file.go
+++ b/internal/operators/inspect_file.go
@@ -32,11 +32,11 @@ func (o *inspectFile) Evaluate(tx plugintypes.TransactionState, value string) bo
 	defer cancel()
 	// Add /bin/bash to context?
 	cmd := exec.CommandContext(ctx, o.path, value)
-	_, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded || err != nil {
 		return false
 	}
-	return true
+	return len(output) > 0 && output[0] != '1'
 }
 
 func init() {

--- a/internal/operators/inspect_file_test.go
+++ b/internal/operators/inspect_file_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 )
 
-func TestInspectFile(t *testing.T) {
+func TestInspectFileExitCode(t *testing.T) {
 	existCommand := "/bin/echo"
 	if runtime.GOOS == "windows" {
 		existCommand = "C:\\Windows\\system32\\tasklist.exe"
@@ -44,6 +44,41 @@ func TestInspectFile(t *testing.T) {
 			}
 			if want, have := tt.exists, ipf.Evaluate(nil, "/?"); want != have {
 				t.Errorf("inspectfile path %s: want %v, have %v", tt.path, want, have)
+			}
+		})
+	}
+}
+
+func TestInspectFileOutput(t *testing.T) {
+	existCommand := "/bin/echo"
+	if runtime.GOOS == "windows" {
+		// TODO: Add support for this platform.
+		t.Skip("Skipping test on Windows")
+	}
+
+	ipf, err := newInspectFile(plugintypes.OperatorOptions{Arguments: existCommand})
+	if err != nil {
+		t.Error("cannot init inspectfile operator")
+	}
+
+	tests := []struct {
+		output string
+		match  bool
+	}{
+		{
+			output: "1 clamscan: OK",
+			match:  false,
+		},
+		{
+			output: "0 clamscan: FOUND",
+			match:  true,
+		},
+	}
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.output, func(t *testing.T) {
+			if want, have := tt.match, ipf.Evaluate(nil, tt.output); want != have {
+				t.Errorf("inspectfile output '%s': want %t, have %t", tt.output, want, have)
 			}
 		})
 	}


### PR DESCRIPTION
According to [modsec docs](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#user-content-inspectFile), the operator should check script output as well as its exit code. Here is [the implementation](https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.13/src/operators/inspect_file.cc#L80). But Coraza is missing that and ignores script output completely. I prepared a patch, please review.

p.s.: Unfortunately I don't have windows platform, so if somebody can help me to implement unit test for it, I would very appretiate that.