### PR TITLE
fix(go1.24): bump linter

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -23,7 +23,7 @@ import (
 
 var addLicenseVersion = "v1.1.1" // https://github.com/google/addlicense/releases
 var gosImportsVer = "v0.3.7"     // https://github.com/rinchsan/gosimports/releases
-var golangCILintVer = "v1.60.3"  // https://github.com/golangci/golangci-lint/releases
+var golangCILintVer = "v1.64.8"  // https://github.com/golangci/golangci-lint/releases
 var errNoGitDir = errors.New("no .git directory found")
 var errUpdateGeneratedFiles = errors.New("generated files need to be updated")
 


### PR DESCRIPTION
Fixes https://github.com/corazawaf/coraza/issues/1329.
Bumps the linter to a version (latest) that supports Go `1.24`.