### PR TITLE
Fix audit RelevantOnly logs with DetectionOnly rule engine

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -376,7 +376,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 				// Flow actions are evaluated also if the rule engine is set to DetectionOnly
 				logger.Debug().Str("action", a.Name).Int("phase", int(phase)).Msg("Evaluating flow action for rule")
 				a.Function.Evaluate(r, tx)
-			} else if a.Function.Type() == plugintypes.ActionTypeDisruptive && tx.RuleEngine == types.RuleEngineOn {
+			} else if a.Function.Type() == plugintypes.ActionTypeDisruptive && tx.RuleEngine != types.RuleEngineOff {
 				// The parser enforces that the disruptive action is just one per rule (if more than one, only the last one is kept)
 				logger.Debug().Str("action", a.Name).Msg("Executing disruptive action for rule")
 				a.Function.Evaluate(r, tx)

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -54,6 +54,9 @@ type Transaction struct {
 	// True if the transaction has been disrupted by any rule
 	interruption *types.Interruption
 
+	// This is used to store detected interruptions that are not disruptive
+	detectedInterruption *types.Interruption
+
 	// This is used to store log messages
 	// Deprecated since Coraza 3.0.5: this variable is not used, logdata values are stored in the matched rules
 	Logdata string
@@ -308,6 +311,9 @@ func (tx *Transaction) Collection(idx variables.RuleVariable) collection.Collect
 func (tx *Transaction) Interrupt(interruption *types.Interruption) {
 	if tx.RuleEngine == types.RuleEngineOn {
 		tx.interruption = interruption
+	} else if tx.RuleEngine == types.RuleEngineDetectionOnly {
+		// Do not actually interrupt the transaction but still log it in the audit log
+		tx.detectedInterruption = interruption
 	}
 }
 
@@ -1340,6 +1346,8 @@ func (tx *Transaction) ProcessLogging() {
 		status := tx.variables.responseStatus.Get()
 		if tx.IsInterrupted() {
 			status = strconv.Itoa(tx.interruption.Status)
+		} else if tx.detectedInterruption != nil {
+			status = strconv.Itoa(tx.detectedInterruption.Status)
 		}
 		if re != nil && !re.Match([]byte(status)) {
 			// Not relevant status


### PR DESCRIPTION
Hello, this is a patch to fix corazawaf/coraza#1333 simply without touching at the interruption. The only downside is that we add a variable to the Transaction struct (If you have a better idea let me know). 

For now it is enough for my purpose, we have `RelevantOnly` audit logs when we are in `RuleEngineDetectionOnly` mode. 

The variable `detectedInterruption` is set to the `tx.interruption` when an interruption would have been triggered if we were in `RuleEngineOn`.

