### PR TITLE
docs: add RuiQi to integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Coraza Project maintains implementations and plugins for the following serve
 * [Proxy WASM extension](https://github.com/corazawaf/coraza-proxy-wasm) for proxies with proxy-wasm support (e.g. Envoy) - stable, still under development
 * [HAProxy SPOE Plugin](https://github.com/corazawaf/coraza-spoa) - experimental
 * [Coraza C Library (For nginx, etc)](https://github.com/corazawaf/libcoraza) - experimental
+* [RuiQi WAF](https://github.com/HUAHUAI23/RuiQi) - Web management panel and enhanced traffic control for Coraza SPOA - experimental
 
 ## Prerequisites
 


### PR DESCRIPTION
Hey folks!
While using Coraza, I discovered a pain point: although Coraza is an incredibly powerful WAF engine, it lacks an intuitive management panel and some practical traffic control strategies. As a practitioner, I felt these features are quite important for daily operations.
So I rolled up my sleeves and built some extensions based on coraza-spoa, creating the [RuiQi WAF](https://github.com/HUAHUAI23/RuiQi) project. Key features include:

🎛️ Web Management Panel - Provides intuitive rule management, log viewing, and configuration interface
🚦 Traffic Control Policies - Supports rate limiting, blacklists/whitelists, and other flow control features
🔧 Micro-engine Extensions - Enhances usability while maintaining Coraza's core capabilities
📊 Monitoring & Analytics - Real-time traffic analysis and attack statistics

Now that the project has a working initial version, I'm wondering if we could add it to Coraza's integrations list so more folks with similar needs can discover and use it.
Of course, the project is still being continuously improved, so I welcome everyone's feedback and suggestions! If you're interested, contributions are also very welcome.
Thanks to the Coraza team for providing such an excellent foundation!