### PR TITLE
Revert "chore: add tx to context"

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -8,7 +8,6 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -116,10 +115,6 @@ func WrapHandler(waf coraza.WAF, h http.Handler) http.Handler {
 
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		tx := newTX(r)
-
-		ctx := NewContext(r.Context(), &tx)
-		r = r.WithContext(ctx)
-
 		defer func() {
 			// We run phase 5 rules and create audit logs (if enabled)
 			tx.ProcessLogging()
@@ -174,16 +169,4 @@ func obtainStatusCodeFromInterruptionOrDefault(it *types.Interruption, defaultSt
 		return statusCode
 	}
 	return defaultStatusCode
-}
-
-type corazaWafContextKeyType string
-
-const contextTransactionKey = corazaWafContextKeyType("tx")
-
-func TxFromContext(ctx context.Context) *types.Transaction {
-	return ctx.Value(contextTransactionKey).(*types.Transaction)
-}
-
-func NewContext(ctx context.Context, tx *types.Transaction) context.Context {
-	return context.WithValue(ctx, contextTransactionKey, tx)
 }

--- a/http/middleware_test.go
+++ b/http/middleware_test.go
@@ -621,16 +621,6 @@ func TestHandlerAPI(t *testing.T) {
 			},
 			expectedStatusCode: 201,
 		},
-		"tx is set in context": {
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				tx := TxFromContext(r.Context())
-				if tx == nil {
-					t.Fatal("tx is not set in context")
-				}
-				w.WriteHeader(204)
-			},
-			expectedStatusCode: 204,
-		},
 	}
 
 	waf, err := coraza.NewWAF(coraza.NewWAFConfig().WithRequestBodyLimit(3))


### PR DESCRIPTION
Reverts corazawaf/coraza#1345

After deeper consideration, this approach only allows to have tx access up to phase 2 if it isn't interrupted which is nothing useful. I am convinced now the right approach is to provide hooks that users can implement and get more useful access without compromising the tx lifecycle.