### PR TITLE
Auditlog Syslog writer

### DIFF
--- a/internal/auditlog/init_tinygo.go
+++ b/internal/auditlog/init_tinygo.go
@@ -18,6 +18,9 @@ func init() {
 	RegisterWriter("https", func() plugintypes.AuditLogWriter {
 		return noopWriter{}
 	})
+	RegisterWriter("syslog", func() plugintypes.AuditLogWriter {
+		return noopWriter{}
+	})
 
 	RegisterFormatter("json", &jsonFormatter{})
 	RegisterFormatter("jsonlegacy", &legacyJSONFormatter{})

--- a/internal/auditlog/init_windows.go
+++ b/internal/auditlog/init_windows.go
@@ -1,8 +1,9 @@
-// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// Copyright 2022 the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !tinygo && !windows && !plan9
-// +build !tinygo,!windows,!plan9
+//go:build (windows || plan9) && !tinygo
+// +build windows plan9
+// +build !tinygo
 
 package auditlog
 
@@ -19,7 +20,7 @@ func init() {
 		return &httpsWriter{}
 	})
 	RegisterWriter("syslog", func() plugintypes.AuditLogWriter {
-		return NewSyslogWriter()
+		return &noopWriter{}
 	})
 
 	RegisterFormatter("json", &jsonFormatter{})

--- a/internal/auditlog/logger_test.go
+++ b/internal/auditlog/logger_test.go
@@ -56,12 +56,6 @@ func TestGetFormatters(t *testing.T) {
 	})
 }
 
-type noopWriter struct{}
-
-func (noopWriter) Init(plugintypes.AuditLogConfig) error { return nil }
-func (noopWriter) Write(plugintypes.AuditLog) error      { return nil }
-func (noopWriter) Close() error                          { return nil }
-
 func TestRegisterAndGetWriter(t *testing.T) {
 
 	testCases := []struct {

--- a/internal/auditlog/noop_writer.go
+++ b/internal/auditlog/noop_writer.go
@@ -1,10 +1,6 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Currently only used with TinyGo
-//go:build tinygo
-// +build tinygo
-
 package auditlog
 
 import "github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"

--- a/internal/auditlog/syslog_writer.go
+++ b/internal/auditlog/syslog_writer.go
@@ -1,0 +1,82 @@
+// Copyright 2023 the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !tinygo && !windows && !plan9
+// +build !tinygo,!windows,!plan9
+
+package auditlog
+
+import (
+	"fmt"
+	"log/syslog"
+	"net/url"
+	"path"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+)
+
+type Syslog interface {
+	Err(string) error
+	Info(string) error
+	Close() error
+}
+
+// syslogWriter is used to write logs into syslog.
+type syslogWriter struct {
+	Syslog
+	formatter plugintypes.AuditLogFormatter
+	dialer    func(network, raddr string, p syslog.Priority, tag string) (Syslog, error)
+}
+
+func NewSyslogWriter() *syslogWriter {
+	s := new(syslogWriter)
+	s.dialer = s.dial
+
+	return s
+}
+
+func (s *syslogWriter) Init(c plugintypes.AuditLogConfig) error {
+	var network, raddr string
+	if c.Target != "" {
+		network, raddr = "tcp", c.Target
+		if u, err := url.Parse(c.Target); err == nil {
+			network, raddr = u.Scheme, path.Join(u.Host, u.Path)
+		}
+	}
+	w, err := s.dialer(network, raddr, syslog.LOG_LOCAL0, "com.coraza.waf")
+	if err != nil {
+		return fmt.Errorf("syslog dial failure: %w", err)
+	}
+	s.Syslog = w
+
+	s.formatter = c.Formatter
+
+	return nil
+}
+
+func (s *syslogWriter) dial(network, raddr string, p syslog.Priority, tag string) (Syslog, error) {
+	return syslog.Dial(network, raddr, p, tag)
+}
+
+func (s *syslogWriter) Write(al plugintypes.AuditLog) error {
+	payload, err := s.formatter.Format(al)
+	if err != nil {
+		return fmt.Errorf("auditlog format failure: %w", err)
+	}
+
+	if al.Transaction().IsInterrupted() {
+		if err := s.Syslog.Err(string(payload)); err != nil {
+			return fmt.Errorf("error write failure: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := s.Syslog.Info(string(payload)); err != nil {
+		return fmt.Errorf("info write failure: %w", err)
+	}
+
+	return nil
+}
+
+var _ plugintypes.AuditLogWriter = (*syslogWriter)(nil)

--- a/internal/auditlog/syslog_writer_test.go
+++ b/internal/auditlog/syslog_writer_test.go
@@ -1,0 +1,244 @@
+// Copyright 2023 the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !tinygo && !windows && !plan9
+// +build !tinygo,!windows,!plan9
+
+package auditlog
+
+import (
+	"log/syslog"
+	"net"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+)
+
+func Test_syslogWriter_Init(t *testing.T) {
+	type args struct {
+		c plugintypes.AuditLogConfig
+	}
+	type want struct {
+		network string
+		raddr   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    want
+		wantErr bool
+	}{
+		{
+			name: "Default",
+			args: args{
+				c: plugintypes.AuditLogConfig{
+					Target: "",
+				},
+			},
+			want: want{
+				network: "",
+				raddr:   "",
+			},
+		},
+		{
+			name: "AddrOnly",
+			args: args{
+				c: plugintypes.AuditLogConfig{
+					Target: "127.0.0.1:514",
+				},
+			},
+			want: want{
+				network: "tcp",
+				raddr:   "127.0.0.1:514",
+			},
+		},
+		{
+			name: "UDP",
+			args: args{
+				c: plugintypes.AuditLogConfig{
+					Target: "udp://127.0.0.1:514",
+				},
+			},
+			want: want{
+				network: "udp",
+				raddr:   "127.0.0.1:514",
+			},
+		},
+		{
+			name: "Socket",
+			args: args{
+				c: plugintypes.AuditLogConfig{
+					Target: "unixgram:///var/run/syslog",
+				},
+			},
+			want: want{
+				network: "unixgram",
+				raddr:   "/var/run/syslog",
+			},
+		},
+		{
+			name: "Formatter",
+			args: args{
+				c: plugintypes.AuditLogConfig{
+					Formatter: new(noopFormatter),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := GetWriter("syslog")
+			if err != nil {
+				t.FailNow()
+			}
+			syslogW := w.(*syslogWriter)
+
+			var (
+				dialed  bool
+				network string
+				raddr   string
+			)
+			syslogW.dialer = func(net, addr string, _ syslog.Priority, _ string) (Syslog, error) {
+				dialed = true
+				network = net
+				raddr = addr
+
+				return nil, nil
+			}
+
+			if err := w.Init(tt.args.c); (err != nil) != tt.wantErr {
+				t.Errorf("syslogWriter.Init() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if syslogW.formatter != tt.args.c.Formatter {
+				t.Errorf("syslogWriter.formatter want = %#v, got %#v", tt.args.c.Formatter, syslogW.formatter)
+			}
+
+			if !dialed {
+				t.Errorf("syslogWriter.dialer not called")
+			}
+			if network != tt.want.network {
+				t.Errorf("syslogWriter.Syslog.network want = %v, got %v", tt.want.network, network)
+			}
+			if raddr != tt.want.raddr {
+				t.Errorf("syslogWriter.Syslog.raddr want = %v, got %v", tt.want.raddr, raddr)
+			}
+		})
+	}
+}
+
+func Test_syslogWriter_Write(t *testing.T) {
+	type fields struct {
+		formatter plugintypes.AuditLogFormatter
+	}
+	type args struct {
+		al plugintypes.AuditLog
+	}
+	type want struct {
+		priority syslog.Priority
+		message  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    want
+		wantErr bool
+	}{
+		{
+			name: "Default",
+			fields: fields{
+				formatter: new(jsonFormatter),
+			},
+			args: args{
+				al: &Log{
+					Transaction_: Transaction{
+						ID_:            "42",
+						IsInterrupted_: false,
+					},
+				},
+			},
+			want: want{
+				priority: syslog.LOG_INFO,
+				message:  `{"transaction":{"timestamp":"","unix_timestamp":0,"id":"42","client_ip":"","client_port":0,"host_ip":"","host_port":0,"server_id":"","highest_severity":"","is_interrupted":false}}`,
+			},
+		},
+		{
+			name: "Interrupted",
+			fields: fields{
+				formatter: new(noopFormatter),
+			},
+			args: args{
+				al: &Log{
+					Transaction_: Transaction{
+						IsInterrupted_: true,
+					},
+				},
+			},
+			want: want{
+				priority: syslog.LOG_ERR,
+			},
+		},
+		{
+			name: "Failure",
+			fields: fields{
+				formatter: new(noopFormatter),
+			},
+			args: args{
+				al: &Log{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := GetWriter("syslog")
+			if err != nil {
+				t.FailNow()
+			}
+			syslogW := w.(*syslogWriter)
+			syslogW.formatter = tt.fields.formatter
+
+			var (
+				priority syslog.Priority
+				message  string
+			)
+			syslogW.Syslog = syslogMock(func(p syslog.Priority, m string) error {
+				if tt.wantErr {
+					return &net.OpError{Op: "write"}
+				}
+
+				priority = p
+				message = m
+
+				return nil
+			})
+
+			if err := w.Write(tt.args.al); (err != nil) != tt.wantErr {
+				t.Errorf("syslogWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if priority != tt.want.priority {
+				t.Errorf("priority want = %v, got %v", tt.want.priority, priority)
+			}
+			if message != tt.want.message {
+				t.Errorf("message want = %v, got %v", tt.want.message, message)
+			}
+		})
+	}
+}
+
+type syslogMock func(syslog.Priority, string) error
+
+func (s syslogMock) Err(m string) error {
+	return s(syslog.LOG_ERR, m)
+}
+
+func (s syslogMock) Info(m string) error {
+	return s(syslog.LOG_INFO, m)
+}
+
+func (syslogMock) Close() error {
+	return nil
+}


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Summary:
Implementation of `plugintypes.AuditLogWriter` to send audit logs into syslog. Stdlib `log/syslog` package has been used, so no extra dependencies needed.
Writes directed into `local0` syslog facility with LOG_INFO severity by default. Interrupted transactions will have LOG_ERR severity.

Changes:
`SecAuditLogType` directive now accept `syslog` value.
`SecAuditLog` directive now accept all supported by `log/syslog` values of `network` and `raddr` by pattern `network://raddr` (e.g. `udp://127.0.0.1:514`, `unixgram:///var/run/syslog`). Empty value will force `log/syslog` to select destination by it's internal logic.

Limitations:
Not available for tinygo because of not verified `log/syslog` [support](https://tinygo.org/docs/reference/lang-support/stdlib/#logsyslog).
Not available for windows and plan9 operating systems because of `log/syslog` limitations.

Thanks for your contribution :heart: