### PR TITLE
fix: cutQuotedString - not working for `\""`

### DIFF
--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -469,6 +469,7 @@ func cutQuotedString(s string) (string, string, error) {
 		}
 		// if the number of backslashes is odd, it's an escape sequence
 		if previousEscapeCount%2 == 1 {
+			previousEscapeCount = 0
 			continue
 		}
 

--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -66,6 +66,11 @@ func TestVariables(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	p.FromString(`SecRule REQUEST_HEADERS "@contains \"" "id:8"`)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestVariableCases(t *testing.T) {

--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -67,7 +67,7 @@ func TestVariables(t *testing.T) {
 		t.Error(err)
 	}
 
-	p.FromString(`SecRule REQUEST_HEADERS "@contains \"" "id:8"`)
+	err = p.FromString(`SecRule REQUEST_HEADERS "@contains \"" "id:8"`)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

When a escaped double quotes (`\"`)  is followed by a non escaped double quotes (`"`), the non escaped double quotes (`"`) was not properly identified because there was a missing reset to escape count.


**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: