### PR TITLE
feat: add Context() getter in the TransactionState interface

### DIFF
--- a/experimental/plugins/plugintypes/transaction.go
+++ b/experimental/plugins/plugintypes/transaction.go
@@ -4,6 +4,8 @@
 package plugintypes
 
 import (
+	"context"
+
 	"github.com/corazawaf/coraza/v3/collection"
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/types"
@@ -35,6 +37,8 @@ type TransactionState interface {
 	CaptureField(idx int, value string)
 
 	LastPhase() types.RulePhase
+
+	Context() context.Context
 }
 
 // TransactionVariables has pointers to all the variables of the transaction

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1653,6 +1653,10 @@ func (tx *Transaction) setTimeVariables() {
 	tx.variables.timeWday.Set(strconv.Itoa(int(timestamp.Weekday())))
 }
 
+func (tx *Transaction) Context() context.Context {
+	return tx.context
+}
+
 // TransactionVariables has pointers to all the variables of the transaction
 type TransactionVariables struct {
 	args                     *collections.ConcatKeyed


### PR DESCRIPTION
> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

Add the getter Context() to the TransactionState interface. The context is stored in the Transaction type but is not available when writing custom actions or operators. This change enables the usage of the context object in these scenarios.

Use case:

* Share data between middleware when using http.WrapHandler. It can be a safer alternative to the previous approach using TransactionState (https://github.com/corazawaf/coraza/pull/1345).


NOTE: Let me know if we should add a unit test for this getter method. Since I can't find tests for other getters in the Transaction type, I assume that we don't write tests for simple getters.

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: