### PR TITLE
doc: fix phase in ctl action example

### DIFF
--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -92,7 +92,7 @@ const (
 // Example:
 // ```
 // # Parse requests with Content-Type "text/xml" as XML
-// SecRule REQUEST_CONTENT_TYPE ^text/xml "nolog,pass,id:106,ctl:requestBodyProcessor=XML"
+// SecRule REQUEST_CONTENT_TYPE ^text/xml "nolog,pass,id:106,phase:1,ctl:requestBodyProcessor=XML"
 //
 // # white-list the user parameter for rule #981260 when the REQUEST_URI is /index.php
 //


### PR DESCRIPTION
We must set `phase:1` since if we omit phase it defaults to `phase:2` and it causes a "Cannot change request body processor after request headers phase" error at below:
https://github.com/corazawaf/coraza/blob/4297ba0e02e94d424ce36fa8a0dfe6c426f17cbd/internal/actions/ctl.go#L230-L237


Checklist before submitting a PR:

- [ ] ~~My code includes positive and negative tests.~~ This pull request does not add tests since it only modifies a document.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.
