### PR TITLE
fix: typo in responseWriter name in TestWriteResponseBody

### DIFF
--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -488,7 +488,7 @@ func TestAuditLog(t *testing.T) {
 }
 
 var responseBodyWriters = map[string]func(tx *Transaction, body string) (*types.Interruption, int, error){
-	"WriteResponsequestBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
+	"WriteResponseBody": func(tx *Transaction, body string) (*types.Interruption, int, error) {
 		return tx.WriteResponseBody([]byte(body))
 	},
 	"ReadResponseBodyFromKnownLen": func(tx *Transaction, body string) (*types.Interruption, int, error) {


### PR DESCRIPTION
This pull request just fixes the name of a responseBodyWriter in TestWriteResponseBody.

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
  - This pull request just fixes the name of a responseBodyWriter in TestWriteResponseBody. It does not adds tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: