### PR TITLE
fix tinygo tests for go 25

### DIFF
--- a/internal/actions/deny.go
+++ b/internal/actions/deny.go
@@ -4,6 +4,8 @@
 package actions
 
 import (
+	"net/http"
+
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -38,7 +40,7 @@ func (a *denyFn) Evaluate(r plugintypes.RuleMetadata, tx plugintypes.Transaction
 	status := r.Status()
 	// deny action defaults to status 403
 	if status == noStatus {
-		status = 403
+		status = http.StatusForbidden
 	}
 	tx.Interrupt(&types.Interruption{
 		Status: status,

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 	"regexp"
 	"runtime/debug"
 	"strconv"
@@ -1856,7 +1857,7 @@ func TestRequestFilename(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			waf := NewWAF()
 			tx := waf.NewTransaction()
-			tx.ProcessURI(test.uri, "GET", "HTTP/1.1")
+			tx.ProcessURI(test.uri, http.MethodGet, "HTTP/1.1")
 			if tx.variables.requestFilename.Get() != test.expected {
 				t.Fatalf("Expected REQUEST_FILENAME %q, got %q", test.expected, tx.variables.requestFilename.Get())
 			}

--- a/internal/seclang/rule_parser_test.go
+++ b/internal/seclang/rule_parser_test.go
@@ -1,8 +1,6 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !tinygo
-
 package seclang
 
 import (


### PR DESCRIPTION
The two main problems are that we are importing the whole http stack just for a few constants, and we are implementing the whole protobuf framework which is reflect-heavy.
I also think we should remove the ocsf library if possible and write a small in-house replacement, its too heavy for such a small purpose. 

This is meant to fix the build issues for https://github.com/corazawaf/coraza/pull/1462 

```
➜  coraza git:(fix-tinygo-tests) ✗ tinygo test ./...
testing: warning: no tests to run
ok      github.com/corazawaf/coraza/v3  0.004s
?       github.com/corazawaf/coraza/v3/collection       [no test files]
ok      github.com/corazawaf/coraza/v3/debuglog 0.008s
ok      github.com/corazawaf/coraza/v3/experimental     0.002s
ok      github.com/corazawaf/coraza/v3/experimental/plugins     0.003s
ok      github.com/corazawaf/coraza/v3/experimental/plugins/macro       0.003s
?       github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes [no test files]
?       github.com/corazawaf/coraza/v3/http     [no test files]
?       github.com/corazawaf/coraza/v3/http/e2e [no test files]
ok      github.com/corazawaf/coraza/v3/internal/actions 0.003s
ok      github.com/corazawaf/coraza/v3/internal/auditlog        0.001s
ok      github.com/corazawaf/coraza/v3/internal/bodyprocessors  0.002s
ok      github.com/corazawaf/coraza/v3/internal/collections     0.002s
ok      github.com/corazawaf/coraza/v3/internal/cookies 0.011s
ok      github.com/corazawaf/coraza/v3/internal/corazarules     0.007s
?       github.com/corazawaf/coraza/v3/internal/corazatypes     [no test files]
ok      github.com/corazawaf/coraza/v3/internal/corazawaf       0.021s
ok      github.com/corazawaf/coraza/v3/internal/environment     0.002s
?       github.com/corazawaf/coraza/v3/internal/io      [no test files]
?       github.com/corazawaf/coraza/v3/internal/memoize [no test files]
ok      github.com/corazawaf/coraza/v3/internal/operators       0.026s
ok      github.com/corazawaf/coraza/v3/internal/seclang 0.014s
?       github.com/corazawaf/coraza/v3/internal/seclang/generator       [no test files]
?       github.com/corazawaf/coraza/v3/internal/strings [no test files]
ok      github.com/corazawaf/coraza/v3/internal/sync    0.001s
ok      github.com/corazawaf/coraza/v3/internal/transformations 0.028s
ok      github.com/corazawaf/coraza/v3/internal/url     0.001s
ok      github.com/corazawaf/coraza/v3/internal/variables       0.001s
?       github.com/corazawaf/coraza/v3/internal/variables/generator     [no test files]
ok      github.com/corazawaf/coraza/v3/testing  0.035s
?       github.com/corazawaf/coraza/v3/testing/engine   [no test files]
?       github.com/corazawaf/coraza/v3/testing/profile  [no test files]
ok      github.com/corazawaf/coraza/v3/types    0.001s
?       github.com/corazawaf/coraza/v3/types/variables  [no test files]
➜  coraza git:(fix-tinygo-tests) go version
go version go1.25.5 linux/amd64
➜  coraza git:(fix-tinygo-tests) tinygo version
tinygo version 0.40.1 linux/amd64 (using go version go1.25.5 and LLVM version 20.1.1)
```