### PR TITLE
feat: add WAFWithRules interface with RulesCount()

### DIFF
--- a/experimental/waf.go
+++ b/experimental/waf.go
@@ -15,3 +15,11 @@ type Options = corazawaf.Options
 type WAFWithOptions interface {
 	NewTransactionWithOptions(Options) types.Transaction
 }
+
+// WAFWithRules is an interface that allows to inspect the number of
+// rules loaded in a WAF instance. This is useful for connectors that
+// need to verify rule loading or implement configuration caching.
+type WAFWithRules interface {
+	// RulesCount returns the number of rules in this WAF.
+	RulesCount() int
+}

--- a/waf.go
+++ b/waf.go
@@ -154,3 +154,8 @@ func (w wafWrapper) NewTransactionWithID(id string) types.Transaction {
 func (w wafWrapper) NewTransactionWithOptions(opts corazawaf.Options) types.Transaction {
 	return w.waf.NewTransactionWithOptions(opts)
 }
+
+// RulesCount returns the number of rules in this WAF.
+func (w wafWrapper) RulesCount() int {
+	return w.waf.Rules.Count()
+}


### PR DESCRIPTION
## Summary
- Add a `WAFWithRules` experimental interface exposing `RulesCount()` 
- Allows connectors (nginx, Apache) to query the number of rules loaded in a WAF instance
- Used for configuration caching and rule loading verification

## Test plan
- Unit test for `RulesCount()` (0 rules, 2 rules)

Note: this is a dependency for corazawaf/libcoraza#50.

@fzipi