### PR TITLE
ci: reduce regression matrix from 128 to 15 jobs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   schedule:
     - cron: '0 6 * * 6'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,10 @@ on:
       - "**/*.md"
       - "LICENSE"
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,30 +12,38 @@ on:
       - "**/*.md"
       - "LICENSE"
 
-jobs:
-  # Generate matrix of tags for all permutations of the tests
-  generate-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.generate.outputs.tags }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+concurrency:
+  group: regression-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-      - name: Generate tag combinations
-        id: generate
-        run: |
-          go run mage.go tagsmatrix > tags.json
-          echo "tags=$(cat tags.json)" >> "$GITHUB_OUTPUT"
-        shell: bash
+jobs:
   test:
-    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x, 1.26.x]
+        go-version: [1.25.x]
         os: [ubuntu-latest]
-        build-flag: ${{ fromJson(needs.generate-matrix.outputs.tags) }}
+        build-flag:
+          - ""
+          - "coraza.rule.mandatory_rule_id_check"
+          - "coraza.rule.case_sensitive_args_keys"
+          - "coraza.rule.no_regex_multiline"
+          - "memoize_builders"
+          - "coraza.rule.multiphase_evaluation"
+          - "no_fs_access"
+          - "coraza.rule.multiphase_evaluation,coraza.rule.mandatory_rule_id_check"
+          - "coraza.rule.multiphase_evaluation,coraza.rule.case_sensitive_args_keys"
+          - "coraza.rule.multiphase_evaluation,coraza.rule.no_regex_multiline"
+          - "no_fs_access,memoize_builders"
+          - "coraza.rule.mandatory_rule_id_check,coraza.rule.case_sensitive_args_keys,coraza.rule.no_regex_multiline"
+          - "coraza.rule.multiphase_evaluation,coraza.rule.mandatory_rule_id_check,coraza.rule.case_sensitive_args_keys,coraza.rule.no_regex_multiline,memoize_builders,no_fs_access"
+        include:
+          - go-version: 1.26.x
+            os: ubuntu-latest
+            build-flag: ""
+          - go-version: 1.26.x
+            os: ubuntu-latest
+            build-flag: "coraza.rule.multiphase_evaluation,coraza.rule.mandatory_rule_id_check,coraza.rule.case_sensitive_args_keys,coraza.rule.no_regex_multiline,memoize_builders,no_fs_access"
     runs-on: ${{ matrix.os }}
     env:
       GOLANG_BASE_VERSION: "1.25.x"
@@ -89,7 +97,7 @@ jobs:
         uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          delay: 120s # give some time to matrix jobs
+          delay: 30s
           interval: 10s # default value
           timeout: 3600s # default value
           ignore: "codecov/patch,codecov/project"

--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -14,6 +14,10 @@ on:
       - "**/*.md"
       - "LICENSE"
 
+concurrency:
+  group: tinygo-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Replace dynamic 64-permutation tag matrix with a curated static list of 13 build-flag combinations. Run all combos on Go 1.25.x and only baseline + kitchen-sink on Go 1.26.x.

Add concurrency groups to regression, lint, tinygo, and codeql workflows so stale PR runs are auto-cancelled on new pushes.

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: