### PR TITLE
perf: use builtin clear() for map resets

### DIFF
--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -179,9 +179,7 @@ func (c *Map) Name() string {
 
 // Reset removes all key/value pairs from the map.
 func (c *Map) Reset() {
-	for k := range c.data {
-		delete(c.data, k)
-	}
+	clear(c.data)
 }
 
 // Format updates the passed strings.Builder with the formatted map key/values.

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -151,9 +151,7 @@ func (rg *RuleGroup) Eval(phase types.RulePhase, tx *Transaction) bool {
 	usedRules := 0
 	ts := time.Now().UnixNano()
 	transformationCache := tx.transformationCache
-	for k := range transformationCache {
-		delete(transformationCache, k)
-	}
+	clear(transformationCache)
 RulesLoop:
 	for i := range rg.rules {
 		r := &rg.rules[i]


### PR DESCRIPTION
## Summary

- Replace manual `for k := range m { delete(m, k) }` loops with Go's builtin `clear()`
- Applied to transformation cache reset (per-phase) and `collections.Map.Reset()` (per-transaction)
- `clear()` is compiler-optimized since Go 1.21 and avoids per-key delete overhead

## Benchmark

```
main:
BenchmarkTransactionCreation-10    150046    8010 ns/op    50582 B/op    223 allocs/op

branch:
BenchmarkTransactionCreation-10    148284    8112 ns/op    50581 B/op    223 allocs/op
```

No measurable difference in this benchmark since it creates transactions without rules, so the cache/map clearing paths aren't exercised. The benefit is in rule evaluation with large transformation caches and collection resets.

## Test plan

- [x] `go test ./internal/corazawaf/ ./internal/collections/ -count=1` passes