### PR TITLE
perf: return nil instead of empty slice in GetField

### DIFF
--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -582,7 +582,7 @@ func (tx *Transaction) GetStopWatch() string {
 func (tx *Transaction) GetField(rv ruleVariableParams) []types.MatchData {
 	col := tx.Collection(rv.Variable)
 	if col == nil {
-		return []types.MatchData{}
+		return nil
 	}
 
 	var matches []types.MatchData


### PR DESCRIPTION
## Summary

- Return `nil` instead of `[]types.MatchData{}` when collection is nil in `GetField`
- Both behave identically for `len()` checks and `range` iteration
- `nil` avoids an unnecessary slice header allocation

## Benchmark

```
main:
BenchmarkTxGetField-10    5461011    215.3 ns/op    400 B/op    8 allocs/op

branch:
BenchmarkTxGetField-10    5312268    223.9 ns/op    400 B/op    8 allocs/op
```

No measurable change — the nil collection path isn't exercised in `BenchmarkTxGetField` since all collections are populated. This is a correctness/consistency improvement rather than a hot-path optimization.

## Test plan

- [x] `go test ./internal/corazawaf/ -count=1` passes