### PR TITLE
perf: store transformationValue by value in cache map

### DIFF
--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -2344,16 +2344,16 @@ func BenchmarkRuleEvalWithTransformations(b *testing.B) {
 	}
 
 	tx := waf.NewTransaction()
-	tx.ProcessURI("/test?a=1&b=2&c=3&d=4&e=5", "GET", "HTTP/1.1")
-	tx.AddRequestHeader("Host", "example.com")
-	if it := tx.ProcessRequestHeaders(); it != nil {
-		b.Fatalf("unexpected interruption during request headers processing: %+v", it)
-	}
 	b.Cleanup(func() {
 		if err := tx.Close(); err != nil {
 			b.Fatalf("failed to close transaction: %v", err)
 		}
 	})
+	tx.ProcessURI("/test?a=1&b=2&c=3&d=4&e=5", "GET", "HTTP/1.1")
+	tx.AddRequestHeader("Host", "example.com")
+	if it := tx.ProcessRequestHeaders(); it != nil {
+		b.Fatalf("unexpected interruption during request headers processing: %+v", it)
+	}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
## Summary

- Store `transformationValue` structs directly in the transformation cache map instead of as pointers
- Eliminates one heap allocation per cache entry (confirmed via `go build -gcflags='-m'`: `&transformationValue{...} escapes to heap` on main, gone on branch)
- Improves data locality for cache lookups during rule evaluation

## Benchmark

`BenchmarkRuleEvalWithTransformations` — 1 rule with `lowercase` transformation evaluating `ARGS` (5 query params):

```
main (*transformationValue pointer):
BenchmarkRuleEvalWithTransformations-10    807051    1491 ns/op    2103 B/op    40 allocs/op

branch (transformationValue by value):
BenchmarkRuleEvalWithTransformations-10    862641    1416 ns/op    1857 B/op    35 allocs/op
```

| Metric | Change |
|---|---|
| Speed | **-5%** |
| Allocs | **40 → 35 (-12.5%)** |
| Bytes | **2103 → 1857 (-12%)** |

The 5-alloc reduction matches the 5 cached entries (one per ARGS key). Each additional cached transformation saves 1 alloc.

## Test plan

- [x] `go test ./internal/corazawaf/ -count=1` passes
- [x] `BenchmarkRuleEvalWithTransformations` proves the alloc reduction
- [x] `go build -gcflags='-m'` confirms `&transformationValue{...}` no longer escapes to heap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a performance benchmark that measures rule evaluation with transformation processing enabled, exercising request-header handling and transaction lifecycle. Includes allocation reporting, timer reset, repeated evaluation loops, and proper transaction cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->