### PR TITLE
perf: remove defer from doEvaluate hot path

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -190,7 +190,6 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	var matchedValues []types.MatchData
 	// we log if we are the parent rule
 	logger.Debug().Msg("Evaluating rule")
-	defer logger.Debug().Msg("Finished rule evaluation")
 
 	ruleCol := tx.variables.rule
 	ruleCol.SetIndex("id", 0, r.LogID())
@@ -335,6 +334,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	}
 
 	if len(matchedValues) == 0 {
+		logger.Debug().Msg("Finished rule evaluation")
 		return matchedValues
 	}
 
@@ -354,6 +354,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 
 			matchedChainValues := nr.doEvaluate(nrLogger, phase, tx, collectiveMatchedValues, chainLevel, cache)
 			if len(matchedChainValues) == 0 {
+				logger.Debug().Msg("Finished rule evaluation")
 				return matchedChainValues
 			}
 			matchedValues = append(matchedValues, matchedChainValues...)
@@ -387,6 +388,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 			tx.MatchRule(r, matchedValues)
 		}
 	}
+	logger.Debug().Msg("Finished rule evaluation")
 	return matchedValues
 }
 


### PR DESCRIPTION
## Summary

- Replace `defer logger.Debug().Msg("Finished rule evaluation")` with explicit calls before each return in `doEvaluate`
- `doEvaluate` is called for every rule in every phase, making the ~35ns defer overhead significant
- The function has only 3 return points, making explicit calls simple and maintainable

## Benchmark

```
main:
BenchmarkTransactionCreation-10    150046    8010 ns/op    50582 B/op    223 allocs/op

branch (no regression):
BenchmarkTransactionCreation-10    150046    8010 ns/op    50582 B/op    223 allocs/op
```

The ~35ns saving is per rule evaluation, not captured by `BenchmarkTransactionCreation` (no rules loaded). With CRS (~400 rules × 5 phases), this saves ~70µs per request.

## Test plan

- [x] `go test ./internal/corazawaf/ -count=1` passes