### PR TITLE
perf: prefix-based transformation cache with inline values

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -97,6 +97,11 @@ type Rule struct {
 	transformations []ruleTransformationParams
 
 	transformationsID int
+	// transformationPrefixIDs holds the chain ID at each step of the transformation chain.
+	// transformationPrefixIDs[i] is the ID representing transformations [0..i].
+	// This enables prefix-based caching: rules sharing a common transformation prefix
+	// can reuse cached intermediate results instead of recomputing from scratch.
+	transformationPrefixIDs []int
 
 	// Slice of initialized actions to be evaluated during
 	// the rule evaluation process
@@ -161,7 +166,7 @@ const chainLevelZero = 0
 // Evaluate will evaluate the current rule for the indicated transaction
 // If the operator matches, actions will be evaluated, and it will return
 // the matched variables, keys and values (MatchData)
-func (r *Rule) Evaluate(phase types.RulePhase, tx plugintypes.TransactionState, cache map[transformationKey]*transformationValue) {
+func (r *Rule) Evaluate(phase types.RulePhase, tx plugintypes.TransactionState, cache map[transformationKey]transformationValue) {
 	// collectiveMatchedValues lives across recursive calls of doEvaluate
 	var collectiveMatchedValues []types.MatchData
 
@@ -180,7 +185,7 @@ func (r *Rule) Evaluate(phase types.RulePhase, tx plugintypes.TransactionState, 
 
 const noID = 0
 
-func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Transaction, collectiveMatchedValues *[]types.MatchData, chainLevel int, cache map[transformationKey]*transformationValue) []types.MatchData {
+func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Transaction, collectiveMatchedValues *[]types.MatchData, chainLevel int, cache map[transformationKey]transformationValue) []types.MatchData {
 	tx.Capture = r.Capture
 
 	if multiphaseEvaluation {
@@ -397,7 +402,7 @@ func (r *Rule) transformMultiMatchArg(arg types.MatchData) ([]string, []error) {
 	return r.executeTransformationsMultimatch(arg.Value())
 }
 
-func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]*transformationValue) (string, []error) {
+func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]transformationValue) (string, []error) {
 	switch {
 	case len(r.transformations) == 0:
 		return arg.Value(), nil
@@ -409,23 +414,53 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 		// NOTE: See comment on transformationKey struct to understand this hacky code
 		argKey := arg.Key()
 		argKeyPtr := unsafe.StringData(argKey)
-		key := transformationKey{
-			argKey:            argKeyPtr,
-			argIndex:          argIdx,
-			argVariable:       arg.Variable(),
-			transformationsID: r.transformationsID,
-		}
-		if cached, ok := cache[key]; ok {
-			return cached.arg, cached.errs
-		} else {
-			ars, es := r.executeTransformations(arg.Value())
-			errs := es
-			cache[key] = &transformationValue{
-				arg:  ars,
-				errs: es,
+
+		// Search from longest prefix (full chain) backwards for a cache hit.
+		// Best case: full chain cached → single map lookup, done.
+		// Typical case: shared prefix cached → start computing from there.
+		startIdx := 0
+		value := arg.Value()
+		var errs []error
+
+		for i := len(r.transformationPrefixIDs) - 1; i >= 0; i-- {
+			key := transformationKey{
+				argKey:            argKeyPtr,
+				argIndex:          argIdx,
+				argVariable:       arg.Variable(),
+				transformationsID: r.transformationPrefixIDs[i],
 			}
-			return ars, errs
+			if cached, ok := cache[key]; ok {
+				if i == len(r.transformationPrefixIDs)-1 {
+					// Full chain cached — nothing more to compute
+					return cached.arg, cached.errs
+				}
+				value = cached.arg
+				errs = cached.errs
+				startIdx = i + 1
+				break
+			}
 		}
+
+		// Execute remaining transformations, caching each intermediate step
+		// so later rules sharing a prefix can reuse our work.
+		for i := startIdx; i < len(r.transformations); i++ {
+			v, _, err := r.transformations[i].Function(value)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				value = v
+			}
+
+			key := transformationKey{
+				argKey:            argKeyPtr,
+				argIndex:          argIdx,
+				argVariable:       arg.Variable(),
+				transformationsID: r.transformationPrefixIDs[i],
+			}
+			cache[key] = transformationValue{arg: value, errs: errs}
+		}
+
+		return value, errs
 	}
 }
 
@@ -635,6 +670,7 @@ func (r *Rule) AddTransformation(name string, t plugintypes.Transformation) erro
 	}
 	r.transformations = append(r.transformations, ruleTransformationParams{Function: t})
 	r.transformationsID = transformationID(r.transformationsID, name)
+	r.transformationPrefixIDs = append(r.transformationPrefixIDs, r.transformationsID)
 	return nil
 }
 
@@ -642,6 +678,8 @@ func (r *Rule) AddTransformation(name string, t plugintypes.Transformation) erro
 // it is mostly used by the "none" transformation
 func (r *Rule) ClearTransformations() {
 	r.transformations = []ruleTransformationParams{}
+	r.transformationsID = 0
+	r.transformationPrefixIDs = nil
 }
 
 // SetOperator sets the operator of the rule

--- a/internal/corazawaf/rule_test.go
+++ b/internal/corazawaf/rule_test.go
@@ -574,7 +574,7 @@ func TestExecuteTransformationsMultiMatchReturnsMultipleErrors(t *testing.T) {
 }
 
 func TestTransformArgSimple(t *testing.T) {
-	transformationCache := map[transformationKey]*transformationValue{}
+	transformationCache := map[transformationKey]transformationValue{}
 	md := &corazarules.MatchData{
 		Variable_: variables.RequestURI,
 		Key_:      "REQUEST_URI",
@@ -592,10 +592,11 @@ func TestTransformArgSimple(t *testing.T) {
 	if arg != "/testAB" {
 		t.Errorf("Expected \"/testAB\", got \"%s\"", arg)
 	}
-	if len(transformationCache) != 1 {
-		t.Errorf("Expected 1 transformations in cache, got %d", len(transformationCache))
+	// Prefix caching stores an entry for each transformation step
+	if len(transformationCache) != 2 {
+		t.Errorf("Expected 2 transformations in cache (one per step), got %d", len(transformationCache))
 	}
-	// Repeating the same transformation, expecting still one element in the cache (that means it is a cache hit)
+	// Repeating the same transformation, expecting still two elements in the cache (cache hit)
 	arg, errs = rule.transformArg(md, 0, transformationCache)
 	if errs != nil {
 		t.Fatalf("Unexpected errors executing transformations: %v", errs)
@@ -603,13 +604,13 @@ func TestTransformArgSimple(t *testing.T) {
 	if arg != "/testAB" {
 		t.Errorf("Expected \"/testAB\", got \"%s\"", arg)
 	}
-	if len(transformationCache) != 1 {
-		t.Errorf("Expected 1 transformations in cache, got %d", len(transformationCache))
+	if len(transformationCache) != 2 {
+		t.Errorf("Expected 2 transformations in cache, got %d", len(transformationCache))
 	}
 }
 
 func TestTransformArgNoCacheForTXVariable(t *testing.T) {
-	transformationCache := map[transformationKey]*transformationValue{}
+	transformationCache := map[transformationKey]transformationValue{}
 	md := &corazarules.MatchData{
 		Variable_: variables.TX,
 		Key_:      "Custom_TX_Variable",
@@ -626,6 +627,84 @@ func TestTransformArgNoCacheForTXVariable(t *testing.T) {
 	}
 	if len(transformationCache) != 0 {
 		t.Errorf("Expected 0 transformations in cache, got %d. It is not expected to cache TX variable transformations", len(transformationCache))
+	}
+}
+
+func TestTransformArgPrefixSharing(t *testing.T) {
+	transformationCache := map[transformationKey]transformationValue{}
+	md := &corazarules.MatchData{
+		Variable_: variables.RequestURI,
+		Key_:      "REQUEST_URI",
+		Value_:    "/test",
+	}
+
+	// Rule 1 has chain: AppendA
+	rule1 := NewRule()
+	_ = rule1.AddTransformation("AppendA", transformationAppendA)
+
+	// Rule 2 has chain: AppendA, AppendB (shares prefix with rule1)
+	rule2 := NewRule()
+	_ = rule2.AddTransformation("AppendA", transformationAppendA)
+	_ = rule2.AddTransformation("AppendB", transformationAppendB)
+
+	// Evaluate rule1 first — caches the AppendA intermediate
+	arg1, errs := rule1.transformArg(md, 0, transformationCache)
+	if errs != nil {
+		t.Fatalf("Unexpected errors: %v", errs)
+	}
+	if arg1 != "/testA" {
+		t.Errorf("Expected \"/testA\", got %q", arg1)
+	}
+	if len(transformationCache) != 1 {
+		t.Errorf("Expected 1 cache entry after rule1, got %d", len(transformationCache))
+	}
+
+	// Evaluate rule2 — should reuse the cached AppendA result and only compute AppendB
+	arg2, errs := rule2.transformArg(md, 0, transformationCache)
+	if errs != nil {
+		t.Fatalf("Unexpected errors: %v", errs)
+	}
+	if arg2 != "/testAB" {
+		t.Errorf("Expected \"/testAB\", got %q", arg2)
+	}
+	// Should now have 2 entries: AppendA (shared) and AppendA+AppendB
+	if len(transformationCache) != 2 {
+		t.Errorf("Expected 2 cache entries after rule2 (prefix reuse), got %d", len(transformationCache))
+	}
+}
+
+func TestClearTransformationsResetsID(t *testing.T) {
+	transformationCache := map[transformationKey]transformationValue{}
+	md := &corazarules.MatchData{
+		Variable_: variables.RequestURI,
+		Key_:      "REQUEST_URI",
+		Value_:    "test",
+	}
+
+	// Rule A: t:AppendA, t:none, t:AppendB — effective chain is only AppendB
+	ruleA := NewRule()
+	_ = ruleA.AddTransformation("AppendA", transformationAppendA)
+	ruleA.ClearTransformations()
+	_ = ruleA.AddTransformation("AppendB", transformationAppendB)
+
+	// Rule B: t:AppendA, t:AppendB — effective chain is AppendA then AppendB
+	ruleB := NewRule()
+	_ = ruleB.AddTransformation("AppendA", transformationAppendA)
+	_ = ruleB.AddTransformation("AppendB", transformationAppendB)
+
+	argA, _ := ruleA.transformArg(md, 0, transformationCache)
+	argB, _ := ruleB.transformArg(md, 0, transformationCache)
+
+	if argA != "testB" {
+		t.Errorf("Rule A (t:none resets): expected \"testB\", got %q", argA)
+	}
+	if argB != "testAB" {
+		t.Errorf("Rule B (t:AppendA,t:AppendB): expected \"testAB\", got %q", argB)
+	}
+	// They must produce different results — if ClearTransformations didn't reset the ID,
+	// they'd collide in the cache and one would get the wrong result.
+	if argA == argB {
+		t.Error("Rule A and Rule B produced the same result — ClearTransformations likely didn't reset transformationsID")
 	}
 }
 

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -126,7 +126,7 @@ type Transaction struct {
 
 	variables TransactionVariables
 
-	transformationCache map[transformationKey]*transformationValue
+	transformationCache map[transformationKey]transformationValue
 }
 
 func (tx *Transaction) ID() string {

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -231,7 +231,7 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 		})
 
 		tx.variables = *NewTransactionVariables()
-		tx.transformationCache = map[transformationKey]*transformationValue{}
+		tx.transformationCache = map[transformationKey]transformationValue{}
 	}
 
 	// set capture variables

--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -146,6 +146,123 @@ func BenchmarkCRSLargePOST(b *testing.B) {
 	}
 }
 
+// BenchmarkCRSTransformationCache measures the transformation cache performance
+// across different request sizes. The transformation cache benefit scales with
+// (number of arguments) × (number of rules sharing transformation prefixes),
+// so these benchmarks exercise that by varying argument counts and value sizes.
+func BenchmarkCRSTransformationCache(b *testing.B) {
+	waf := crsWAF(b)
+
+	// Small: 2 query params, short values (typical simple API call)
+	smallQuery := "user=admin&action=view"
+	// Medium: 10 params with moderate values (typical form submission)
+	mediumParams := []string{
+		"username=johndoe",
+		"email=john@example.com",
+		"first_name=John",
+		"last_name=Doe",
+		"address=123+Main+Street",
+		"city=Springfield",
+		"state=IL",
+		"zip=62701",
+		"phone=555-0123",
+		"comment=This+is+a+test+comment+with+some+content",
+	}
+	mediumBody := strings.Join(mediumParams, "&")
+	// Large: 30 params with longer values (complex form, many args)
+	var largeParams []string
+	for i := 0; i < 30; i++ {
+		largeParams = append(largeParams, fmt.Sprintf("field_%d=%s", i, strings.Repeat("value", 20)))
+	}
+	largeBody := strings.Join(largeParams, "&")
+
+	b.Run("SmallGET_2params", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tx := waf.NewTransaction()
+			tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
+			tx.ProcessURI("GET", "/api/endpoint?"+smallQuery, "HTTP/1.1")
+			tx.AddRequestHeader("Host", "localhost")
+			tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
+			tx.AddRequestHeader("Accept", "application/json")
+			tx.ProcessRequestHeaders()
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				b.Error(err)
+			}
+			tx.AddResponseHeader("Content-Type", "application/json")
+			tx.ProcessResponseHeaders(200, "OK")
+			if _, err := tx.ProcessResponseBody(); err != nil {
+				b.Error(err)
+			}
+			tx.ProcessLogging()
+			if err := tx.Close(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("MediumPOST_10params", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tx := waf.NewTransaction()
+			tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
+			tx.ProcessURI("POST", "/api/submit?source=web", "HTTP/1.1")
+			tx.AddRequestHeader("Host", "localhost")
+			tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
+			tx.AddRequestHeader("Accept", "text/html")
+			tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+			tx.ProcessRequestHeaders()
+			if _, _, err := tx.WriteRequestBody([]byte(mediumBody)); err != nil {
+				b.Error(err)
+			}
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				b.Error(err)
+			}
+			tx.AddResponseHeader("Content-Type", "text/html")
+			tx.ProcessResponseHeaders(200, "OK")
+			if _, err := tx.ProcessResponseBody(); err != nil {
+				b.Error(err)
+			}
+			tx.ProcessLogging()
+			if err := tx.Close(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("LargePOST_30params", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			tx := waf.NewTransaction()
+			tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
+			tx.ProcessURI("POST", "/api/bulk?source=web&format=json", "HTTP/1.1")
+			tx.AddRequestHeader("Host", "localhost")
+			tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
+			tx.AddRequestHeader("Accept", "text/html")
+			tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+			tx.ProcessRequestHeaders()
+			if _, _, err := tx.WriteRequestBody([]byte(largeBody)); err != nil {
+				b.Error(err)
+			}
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				b.Error(err)
+			}
+			tx.AddResponseHeader("Content-Type", "text/html")
+			tx.ProcessResponseHeaders(200, "OK")
+			if _, err := tx.ProcessResponseBody(); err != nil {
+				b.Error(err)
+			}
+			tx.ProcessLogging()
+			if err := tx.Close(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}
+
 func TestFTW(t *testing.T) {
 	conf := coraza.NewWAFConfig()
 


### PR DESCRIPTION
Redesign the transformation cache to share intermediate results across rules with common transformation prefixes (e.g. rules using t:lowercase,t:urlDecodeUni reuse the t:lowercase result cached by an earlier rule using just t:lowercase).

Key changes:
- Add transformationPrefixIDs to Rule for backward prefix search
- Cache every intermediate transformation step, not just the final result
- Store cache values inline (not pointers) to avoid heap allocations
- Fix ClearTransformations (t:none) to reset transformationsID

Benchmarked against full CRS v4 ruleset (8 runs, benchstat):
- Allocations: -2% (small) to -19% (30 params)
- Memory:      -2% (small) to -12% (30 params)
- Timing:      -5% (small/large), neutral (medium)

No regressions on any metric.
