### PR TITLE
fix(testing): Correct use of ProcessURI in Benchmarks

### DIFF
--- a/testing/coreruleset/coreruleset_test.go
+++ b/testing/coreruleset/coreruleset_test.go
@@ -60,7 +60,7 @@ func BenchmarkCRSSimpleGET(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tx := waf.NewTransaction()
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
-		tx.ProcessURI("GET", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
+		tx.ProcessURI("/some_path/with?parameters=and&other=Stuff", "GET", "HTTP/1.1")
 		tx.AddRequestHeader("Host", "localhost")
 		tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
 		tx.AddRequestHeader("Accept", "application/json")
@@ -88,7 +88,7 @@ func BenchmarkCRSSimplePOST(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tx := waf.NewTransaction()
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
-		tx.ProcessURI("POST", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
+		tx.ProcessURI("/some_path/with?parameters=and&other=Stuff", "POST", "HTTP/1.1")
 		tx.AddRequestHeader("Host", "localhost")
 		tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
 		tx.AddRequestHeader("Accept", "application/json")
@@ -122,7 +122,7 @@ func BenchmarkCRSLargePOST(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tx := waf.NewTransaction()
 		tx.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 8080)
-		tx.ProcessURI("POST", "/some_path/with?parameters=and&other=Stuff", "HTTP/1.1")
+		tx.ProcessURI("/some_path/with?parameters=and&other=Stuff", "POST", "HTTP/1.1")
 		tx.AddRequestHeader("Host", "localhost")
 		tx.AddRequestHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Safari/537.36")
 		tx.AddRequestHeader("Accept", "application/json")


### PR DESCRIPTION
ProcessURI should be called like `ProcessURI(uri string, method string, httpVersion string)`. Maybe you should rerun some benchmarks :p 

**Make sure that you've checked the boxes below before you submit PR:**

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [x] My code is properly linted and passes pre-commit tests.

