### PR TITLE
feat: add WAF.Close() with per-owner memoize cache tracking

### DIFF
--- a/experimental/waf.go
+++ b/experimental/waf.go
@@ -4,6 +4,8 @@
 package experimental
 
 import (
+	"io"
+
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/types"
 )
@@ -22,4 +24,12 @@ type WAFWithOptions interface {
 type WAFWithRules interface {
 	// RulesCount returns the number of rules in this WAF.
 	RulesCount() int
+}
+
+// WAFCloser allows closing a WAF instance to release cached resources
+// such as compiled regex patterns. Transactions in-flight are unaffected
+// as they hold their own references to compiled objects.
+// This will be promoted to the public WAF interface in v4.
+type WAFCloser interface {
+	io.Closer
 }

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	gosync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/corazawaf/coraza/v3/debuglog"
@@ -23,6 +25,8 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/sync"
 	"github.com/corazawaf/coraza/v3/types"
 )
+
+var wafIDCounter atomic.Uint64
 
 // Default settings
 const (
@@ -146,7 +150,9 @@ type WAF struct {
 	// Configures the maximum number of ARGS that will be accepted for processing.
 	ArgumentLimit int
 
-	memoizer *memoize.Memoizer
+	memoizerID uint64
+	memoizer   *memoize.Memoizer
+	closeOnce  gosync.Once
 }
 
 // Options is used to pass options to the WAF instance
@@ -332,7 +338,9 @@ func NewWAF() *WAF {
 		waf.TmpDir = os.TempDir()
 	}
 
-	waf.memoizer = memoize.NewMemoizer()
+	id := wafIDCounter.Add(1)
+	waf.memoizerID = id
+	waf.memoizer = memoize.NewMemoizer(id)
 
 	waf.Logger.Debug().Msg("A new WAF instance was created")
 	return waf
@@ -443,4 +451,14 @@ func (w *WAF) Validate() error {
 // Memoizer returns the WAF's memoizer for caching compiled patterns.
 func (w *WAF) Memoizer() *memoize.Memoizer {
 	return w.memoizer
+}
+
+// Close releases cached resources owned by this WAF instance.
+// Cached entries shared with other WAF instances remain until all owners release them.
+// Transactions already in-flight are unaffected as they hold their own references.
+func (w *WAF) Close() error {
+	w.closeOnce.Do(func() {
+		memoize.Release(w.memoizerID)
+	})
+	return nil
 }

--- a/internal/memoize/noop.go
+++ b/internal/memoize/noop.go
@@ -9,7 +9,13 @@ package memoize
 type Memoizer struct{}
 
 // NewMemoizer returns a no-op Memoizer.
-func NewMemoizer() *Memoizer { return &Memoizer{} }
+func NewMemoizer(_ uint64) *Memoizer { return &Memoizer{} }
 
 // Do always calls fn directly without caching.
 func (m *Memoizer) Do(_ string, fn func() (any, error)) (any, error) { return fn() }
+
+// Release is a no-op when memoization is disabled.
+func Release(_ uint64) {}
+
+// Reset is a no-op when memoization is disabled.
+func Reset() {}

--- a/internal/memoize/noop_test.go
+++ b/internal/memoize/noop_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestNoopDo(t *testing.T) {
-	m := NewMemoizer()
+	m := NewMemoizer(1)
 	calls := 0
 
 	fn := func() (any, error) {
@@ -38,7 +38,7 @@ func TestNoopDo(t *testing.T) {
 }
 
 func TestNoopDoError(t *testing.T) {
-	m := NewMemoizer()
+	m := NewMemoizer(1)
 
 	_, err := m.Do("key1", func() (any, error) {
 		return nil, errors.New("fail")

--- a/internal/memoize/nosync.go
+++ b/internal/memoize/nosync.go
@@ -7,26 +7,69 @@ package memoize
 
 import "sync"
 
-var cache sync.Map
+type entry struct {
+	value   any
+	mu      sync.Mutex
+	owners  map[uint64]struct{}
+	deleted bool
+}
 
-// Memoizer caches expensive function calls on a global cache.
+var cache sync.Map // key -> *entry
+
+// Memoizer caches expensive function calls with per-owner tracking.
 // TinyGo variant without singleflight.
-type Memoizer struct{}
+type Memoizer struct {
+	ownerID uint64
+}
 
-// NewMemoizer creates a new Memoizer.
-func NewMemoizer() *Memoizer {
-	return &Memoizer{}
+// NewMemoizer creates a Memoizer that tracks cached entries under the given owner ID.
+func NewMemoizer(ownerID uint64) *Memoizer {
+	return &Memoizer{ownerID: ownerID}
 }
 
 // Do returns a cached value for key, or calls fn and caches the result.
 func (m *Memoizer) Do(key string, fn func() (any, error)) (any, error) {
-	if value, ok := cache.Load(key); ok {
-		return value, nil
+	if v, ok := cache.Load(key); ok {
+		e := v.(*entry)
+		e.mu.Lock()
+		if !e.deleted {
+			e.owners[m.ownerID] = struct{}{}
+			e.mu.Unlock()
+			return e.value, nil
+		}
+		e.mu.Unlock()
 	}
 
 	data, err := fn()
 	if err == nil {
-		cache.Store(key, data)
+		e := &entry{
+			value:  data,
+			owners: map[uint64]struct{}{m.ownerID: {}},
+		}
+		cache.Store(key, e)
 	}
 	return data, err
+}
+
+// Release removes ownerID from all cached entries, deleting entries with no remaining owners.
+func Release(ownerID uint64) {
+	cache.Range(func(key, value any) bool {
+		e := value.(*entry)
+		e.mu.Lock()
+		delete(e.owners, ownerID)
+		if len(e.owners) == 0 {
+			e.deleted = true
+			cache.Delete(key)
+		}
+		e.mu.Unlock()
+		return true
+	})
+}
+
+// Reset clears the entire cache. Intended for testing.
+func Reset() {
+	cache.Range(func(key, _ any) bool {
+		cache.Delete(key)
+		return true
+	})
 }

--- a/internal/memoize/nosync_test.go
+++ b/internal/memoize/nosync_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestDo(t *testing.T) {
-	m := NewMemoizer()
+	t.Cleanup(Reset)
+
+	m := NewMemoizer(1)
 	expensiveCalls := 0
 
 	expensive := func() (any, error) {
@@ -45,7 +47,9 @@ func TestDo(t *testing.T) {
 }
 
 func TestFailedCall(t *testing.T) {
-	m := NewMemoizer()
+	t.Cleanup(Reset)
+
+	m := NewMemoizer(1)
 	calls := 0
 
 	twoForTheMoney := func() (any, error) {
@@ -56,7 +60,7 @@ func TestFailedCall(t *testing.T) {
 		return calls, nil
 	}
 
-	result, err := m.Do("failkey1", twoForTheMoney)
+	result, err := m.Do("key1", twoForTheMoney)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -64,7 +68,7 @@ func TestFailedCall(t *testing.T) {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
 	}
 
-	result, err = m.Do("failkey1", twoForTheMoney)
+	result, err = m.Do("key1", twoForTheMoney)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
@@ -72,11 +76,57 @@ func TestFailedCall(t *testing.T) {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
 	}
 
-	result, err = m.Do("failkey1", twoForTheMoney)
+	result, err = m.Do("key1", twoForTheMoney)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	if want, have := 2, result.(int); want != have {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
+	}
+}
+
+func TestRelease(t *testing.T) {
+	t.Cleanup(Reset)
+
+	m1 := NewMemoizer(1)
+	m2 := NewMemoizer(2)
+
+	calls := 0
+	fn := func() (any, error) {
+		calls++
+		return calls, nil
+	}
+
+	_, _ = m1.Do("shared", fn)
+	_, _ = m2.Do("shared", fn)
+	_, _ = m1.Do("only-waf1", fn)
+
+	Release(1)
+
+	if _, ok := cache.Load("shared"); !ok {
+		t.Fatal("shared entry should still exist after releasing waf-1")
+	}
+	if _, ok := cache.Load("only-waf1"); ok {
+		t.Fatal("only-waf1 entry should be deleted after releasing its sole owner")
+	}
+
+	Release(2)
+	if _, ok := cache.Load("shared"); ok {
+		t.Fatal("shared entry should be deleted after releasing all owners")
+	}
+}
+
+func TestReset(t *testing.T) {
+	m := NewMemoizer(1)
+	_, _ = m.Do("k1", func() (any, error) { return 1, nil })
+	_, _ = m.Do("k2", func() (any, error) { return 2, nil })
+
+	Reset()
+
+	if _, ok := cache.Load("k1"); ok {
+		t.Fatal("cache should be empty after Reset")
+	}
+	if _, ok := cache.Load("k2"); ok {
+		t.Fatal("cache should be empty after Reset")
 	}
 }

--- a/internal/memoize/sync.go
+++ b/internal/memoize/sync.go
@@ -11,40 +11,104 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+type entry struct {
+	value   any
+	mu      sync.Mutex
+	owners  map[uint64]struct{}
+	deleted bool
+}
+
 var (
-	cache sync.Map
+	cache sync.Map // key -> *entry
 	group singleflight.Group
 )
 
-// Memoizer caches expensive function calls on a global cache.
-type Memoizer struct{}
+// Memoizer caches expensive function calls with per-owner tracking.
+type Memoizer struct {
+	ownerID uint64
+}
 
-// NewMemoizer creates a new Memoizer.
-func NewMemoizer() *Memoizer {
-	return &Memoizer{}
+// NewMemoizer creates a Memoizer that tracks cached entries under the given owner ID.
+func NewMemoizer(ownerID uint64) *Memoizer {
+	return &Memoizer{ownerID: ownerID}
+}
+
+// addOwner attempts to register the ownerID on the entry.
+// Returns false if the entry has been marked as deleted.
+func (m *Memoizer) addOwner(e *entry) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.deleted {
+		return false
+	}
+	e.owners[m.ownerID] = struct{}{}
+	return true
 }
 
 // Do returns a cached value for key, or calls fn and caches the result.
 // Only one execution is in-flight for a given key at a time.
 func (m *Memoizer) Do(key string, fn func() (any, error)) (any, error) {
 	// Fast path: check cache
-	if value, ok := cache.Load(key); ok {
-		return value, nil
+	if v, ok := cache.Load(key); ok {
+		e := v.(*entry)
+		if m.addOwner(e) {
+			return e.value, nil
+		}
+		// Entry was deleted concurrently; fall through to slow path.
 	}
 
 	// Slow path: singleflight ensures only one compilation per key
-	value, err, _ := group.Do(key, func() (any, error) {
+	val, err, _ := group.Do(key, func() (any, error) {
 		// Double-check after acquiring singleflight
-		if value, ok := cache.Load(key); ok {
-			return value, nil
+		if v, ok := cache.Load(key); ok {
+			e := v.(*entry)
+			if m.addOwner(e) {
+				return e.value, nil
+			}
 		}
 
 		data, innerErr := fn()
 		if innerErr == nil {
-			cache.Store(key, data)
+			e := &entry{
+				value:  data,
+				owners: map[uint64]struct{}{m.ownerID: {}},
+			}
+			cache.Store(key, e)
 		}
 		return data, innerErr
 	})
 
-	return value, err
+	// Ensure this caller is registered as an owner even if its execution
+	// was deduplicated by singleflight.
+	if err == nil {
+		if v, ok := cache.Load(key); ok {
+			e := v.(*entry)
+			m.addOwner(e)
+		}
+	}
+
+	return val, err
+}
+
+// Release removes ownerID from all cached entries, deleting entries with no remaining owners.
+func Release(ownerID uint64) {
+	cache.Range(func(key, value any) bool {
+		e := value.(*entry)
+		e.mu.Lock()
+		delete(e.owners, ownerID)
+		if len(e.owners) == 0 {
+			e.deleted = true
+			cache.Delete(key)
+		}
+		e.mu.Unlock()
+		return true
+	})
+}
+
+// Reset clears the entire cache. Intended for testing.
+func Reset() {
+	cache.Range(func(key, _ any) bool {
+		cache.Delete(key)
+		return true
+	})
 }

--- a/internal/memoize/sync_test.go
+++ b/internal/memoize/sync_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestDo(t *testing.T) {
-	m := NewMemoizer()
+	t.Cleanup(Reset)
+
+	m := NewMemoizer(1)
 	expensiveCalls := 0
 
 	expensive := func() (any, error) {
@@ -45,7 +47,9 @@ func TestDo(t *testing.T) {
 }
 
 func TestFailedCall(t *testing.T) {
-	m := NewMemoizer()
+	t.Cleanup(Reset)
+
+	m := NewMemoizer(1)
 	calls := 0
 
 	twoForTheMoney := func() (any, error) {
@@ -56,7 +60,7 @@ func TestFailedCall(t *testing.T) {
 		return calls, nil
 	}
 
-	result, err := m.Do("failkey1", twoForTheMoney)
+	result, err := m.Do("key1", twoForTheMoney)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -64,7 +68,7 @@ func TestFailedCall(t *testing.T) {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
 	}
 
-	result, err = m.Do("failkey1", twoForTheMoney)
+	result, err = m.Do("key1", twoForTheMoney)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
@@ -72,11 +76,57 @@ func TestFailedCall(t *testing.T) {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
 	}
 
-	result, err = m.Do("failkey1", twoForTheMoney)
+	result, err = m.Do("key1", twoForTheMoney)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 	if want, have := 2, result.(int); want != have {
 		t.Fatalf("unexpected value, want %d, have %d", want, have)
+	}
+}
+
+func TestRelease(t *testing.T) {
+	t.Cleanup(Reset)
+
+	m1 := NewMemoizer(1)
+	m2 := NewMemoizer(2)
+
+	calls := 0
+	fn := func() (any, error) {
+		calls++
+		return calls, nil
+	}
+
+	_, _ = m1.Do("shared", fn)
+	_, _ = m2.Do("shared", fn)
+	_, _ = m1.Do("only-waf1", fn)
+
+	Release(1)
+
+	if _, ok := cache.Load("shared"); !ok {
+		t.Fatal("shared entry should still exist after releasing waf-1")
+	}
+	if _, ok := cache.Load("only-waf1"); ok {
+		t.Fatal("only-waf1 entry should be deleted after releasing its sole owner")
+	}
+
+	Release(2)
+	if _, ok := cache.Load("shared"); ok {
+		t.Fatal("shared entry should be deleted after releasing all owners")
+	}
+}
+
+func TestReset(t *testing.T) {
+	m := NewMemoizer(1)
+	_, _ = m.Do("k1", func() (any, error) { return 1, nil })
+	_, _ = m.Do("k2", func() (any, error) { return 2, nil })
+
+	Reset()
+
+	if _, ok := cache.Load("k1"); ok {
+		t.Fatal("cache should be empty after Reset")
+	}
+	if _, ok := cache.Load("k2"); ok {
+		t.Fatal("cache should be empty after Reset")
 	}
 }

--- a/waf.go
+++ b/waf.go
@@ -159,3 +159,8 @@ func (w wafWrapper) NewTransactionWithOptions(opts corazawaf.Options) types.Tran
 func (w wafWrapper) RulesCount() int {
 	return w.waf.Rules.Count()
 }
+
+// Close releases cached resources owned by this WAF instance.
+func (w wafWrapper) Close() error {
+	return w.waf.Close()
+}


### PR DESCRIPTION
## Summary
- Add per-owner tracking to the memoize cache using `uint64` owner IDs for efficient WAF lifecycle management
- Implement `WAF.Close()` (via `experimental.WAFCloser`) to release cached regex/aho-corasick entries when a WAF instance is destroyed
- Add `Release()` and `Reset()` functions with tombstone-based cleanup to safely handle concurrent access

## Test plan
- [x] `TestRelease` — verifies shared entries persist until all owners release, sole-owner entries are deleted
- [x] `TestReset` — verifies full cache clear
- [x] `TestDo` / `TestFailedCall` — existing tests updated for `uint64` ownerID
- [x] `go test ./... -count=1` — full suite passes
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Important!!!
Not using waf.Close will create a memory leak, its imeprative to implement it for all connectors once this is enabled by default