### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 6 * * 6'
 
+permissions: {}
+
 concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -12,6 +14,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -6,10 +6,15 @@ on:
     - cron: "05 14 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   fuzz:
     name: Fuzz tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ on:
       - "**/*.md"
       - "LICENSE"
 
+permissions: {}
+
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -21,6 +23,8 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - name: Install Go

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,9 +8,13 @@ on:
       - "**/*.md"
       - "LICENSE"
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - "**/*.md"
       - "LICENSE"
+
+permissions: {}
 
 concurrency:
   group: regression-${{ github.ref }}
@@ -45,6 +49,8 @@ jobs:
             os: ubuntu-latest
             build-flag: "coraza.rule.multiphase_evaluation,coraza.rule.mandatory_rule_id_check,coraza.rule.case_sensitive_args_keys,coraza.rule.no_regex_multiline,memoize_builders,no_fs_access"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     env:
       GOLANG_BASE_VERSION: "1.25.x"
     steps:
@@ -56,9 +62,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: true
       - name: Tests and coverage
-        run: |
-          export BUILD_TAGS=${{ matrix.build-flag }}
-          go run mage.go coverage
+        env:
+          BUILD_TAGS: ${{ matrix.build-flag }}
+        run: go run mage.go coverage
       - name: "Codecov: General"
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         if: ${{ matrix.go-version == env.GOLANG_BASE_VERSION }}
@@ -92,6 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: read
+      contents: read
     steps:
       - name: GitHub Checks
         uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0

--- a/.github/workflows/tinygo.yml
+++ b/.github/workflows/tinygo.yml
@@ -14,6 +14,8 @@ on:
       - "**/*.md"
       - "LICENSE"
 
+permissions: {}
+
 concurrency:
   group: tinygo-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -27,6 +29,8 @@ jobs:
         tinygo-version: [0.40.1]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` (deny-all) to every workflow and scoped per-job permissions granting only what each job needs
- Fix expression injection in `regression.yml` by using `env:` block instead of inline shell interpolation for `BUILD_TAGS`
- Restrict `regression.yml` `pull_request` trigger to `main` branch only (consistent with other workflows)

## Motivation

Without explicit permissions, jobs get default token permissions which may be overly broad. Bots submitting malicious PRs could potentially abuse workflows that have more permissions than needed. These changes follow the [principle of least privilege](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) for GitHub Actions.

## Changes per workflow

| Workflow | Changes |
|---|---|
| `close-issues.yml` | Added top-level `permissions: {}` |
| `codeql-analysis.yml` | Added `permissions: {}` + job-level `security-events: write`, `contents: read` |
| `lint.yml` | Added `permissions: {}` + job-level `contents: read` |
| `regression.yml` | Added `permissions: {}` + job-level `contents: read`, `checks: read`; fixed expression injection; added `branches: [main]` filter |
| `tinygo.yml` | Added `permissions: {}` + job-level `contents: read` |
| `fuzz.yml` | Added `permissions: {}` + job-level `contents: read`, `issues: write` |

## Test plan

- [x] Verify all CI workflows still pass on this PR
- [x] Confirm CodeQL analysis can still write security events
- [x] Confirm fuzz workflow can still create issues on failure