### PR TITLE
docs: add structured documentation comments to variables.go

### DIFF
--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -18,164 +18,534 @@ type RuleVariable byte
 const (
 	// Unknown is used as placeholder for errors
 	Unknown RuleVariable = iota
-	// ResponseContentType is the content type of the response
+	// Description: Response content type. Available only starting with phase 3. The value
+	// available in this variable is taken directly from the internal structures of Apache,
+	// which means that it may contain the information that is not yet available in response
+	// headers. In embedded deployments, you should always refer to this variable, rather than
+	// to RESPONSE_HEADERS:Content-Type.
 	ResponseContentType
-	// UniqueID is the unique id of the transaction
+	// Description: This variable holds the unique id for the transaction.
 	UniqueID
-	// ArgsCombinedSize is the combined size of the arguments
+	// Description: Contains the combined size of all request parameters. Files are excluded
+	// from the calculation. This variable can be useful, for example, to create a rule to
+	// ensure that the total size of the argument data is below a certain threshold. The
+	// following rule detects a request whose parameters are more than 2500 bytes long:
+	// ---
+	// ```modsecurity
+	// SecRule ARGS_COMBINED_SIZE "@gt 2500" "id:12"
+	// ````
 	ArgsCombinedSize
-	// FilesCombinedSize is the combined size of the uploaded files
+	// Description: Contains the total size of the files transported in request body. Available
+	// only on inspected multipart/form-data requests.
+	// ---
+	// ```modsecurity
+	// SecRule FILES_COMBINED_SIZE "@gt 100000" "id:18"
+	// ```
 	FilesCombinedSize
-	// FullRequestLength is the length of the full request
+	// Description: Represents the amount of bytes that FULL_REQUEST may use.
+	// ---
+	// ```modsecurity
+	// SecRule FULL_REQUEST_LENGTH "@eq 205" "id:21"
+	// ```
 	FullRequestLength
-	// InboundDataError will be set to 1 when the request body size
-	// is above the setting configured by SecRequesteBodyLimit
+	// Description: This variable will be set to 1 when the request body size is above the
+	// setting configured by **SecRequestBodyLimit** directive. Your policies should always
+	// contain a rule to check this variable. Depending on the rate of false positives and
+	// your default policy you should decide whether to block or just warn when the rule is
+	// triggered.
+	// ---
+	// The best way to use this variable is as in the example below:
+	//
+	// ```modsecurity
+	// SecRule INBOUND_DATA_ERROR "@eq 1" "phase:1,id:24,t:none,log,pass,msg:'Request Body Larger than SecRequestBodyLimit Setting'"
+	// ```
 	InboundDataError
-	// MatchedVar is the value of the matched variable
+	// Description: This variable holds the value of the most-recently matched variable. It is
+	// similar to the TX:0, but it is automatically supported by all operators and there is no
+	// need to specify the capture action.
+	// ---
+	// ```modsecurity
+	// SecRule ARGS pattern chain,deny,id:25
+	//   SecRule MATCHED_VAR "further scrutiny"
+	// ```
+	//
+	// **Note :** Be aware that this variable holds data for the last operator match. This means that if there are more than one matches, only the last one will be populated. Use MATCHED_VARS variable if you want all matches.
 	MatchedVar
-	// MatchedVarName is the name of the matched variable
+	// Description: This variable holds the full name of the variable that was matched against.
+	// ---
+	// ```modsecurity
+	// SecRule ARGS pattern "chain,deny,id:27"
+	//   SecRule MATCHED_VAR_NAME "@eq ARGS:param"
+	// ```
+	//
+	// **Note :** Be aware that this variable holds data for the last operator match. This means that if there are more than one matches, only the last one will be populated. Use MATCHED_VARS_NAMES variable if you want all matches.
 	MatchedVarName
 	// MultipartDataAfter kept for compatibility
 	MultipartDataAfter
-	// OutboundDataError will be set to 1 when the response body size
-	// is above the setting configured by SecResponseBodyLimit
+	// Description: This variable will be set to 1 when the response body size is above the
+	// setting configured by SecResponseBodyLimit directive. Your policies should always contain
+	// a rule to check this variable. Depending on the rate of false positives and your default
+	// policy you should decide whether to block or just warn when the rule is triggered.
+	// ---
+	// The best way to use this variable is as in the example below:
+	//
+	// ```modsecurity
+	// SecRule OUTBOUND_DATA_ERROR "@eq 1" "phase:1,id:32,t:none,log,pass,msg:'Response Body Larger than SecResponseBodyLimit Setting'"
+	// ```
 	OutboundDataError
-	// QueryString contains the raw query string part of a request URI
+	// Description: Contains the query string part of a request URI. The value in QUERY_STRING
+	// is always provided raw, without URL decoding taking place.
+	// ---
+	// ```modsecurity
+	// SecRule QUERY_STRING "attack" "id:34"
+	// ```
 	QueryString
-	// RemoteAddr is the remote address of the connection
+	// Description: This variable holds the IP address of the remote client.
+	// ---
+	// ```modsecurity
+	// SecRule REMOTE_ADDR "@ipMatch 192.168.1.101" "id:35"
+	// ```
 	RemoteAddr
-	// RemoteHost is the remote host of the connection, not implemented
+	// Description: If the Apache directive HostnameLookups is set to On, then this variable
+	// will hold the remote hostname resolved through DNS. If the directive is set to Off,
+	// this variable it will hold the remote IP address (same as REMOTE_ADDR). Possible uses
+	// for this variable would be to deny known bad client hosts or network blocks, or
+	// conversely, to allow in authorized hosts.
+	// ---
+	// ```modsecurity
+	// SecRule REMOTE_HOST "\.evil\.network\org$" "id:36"
+	// ```
 	RemoteHost
-	// RemotePort is the remote port of the connection
+	// Description: This variable holds information on the source port that the client used when
+	// initiating the connection to our web server.
+	// ---
+	// In the following example, we are evaluating to see whether the REMOTE_PORT is less than 1024, which would indicate that the user is a privileged user:
+	//
+	// ```modsecurity
+	// SecRule REMOTE_PORT "@lt 1024" "id:37"
+	// ```
 	RemotePort
-	// ReqbodyError contains the status of the request body processor used
-	// for request body parsing, 0 means no error, 1 means error
+	// Description: Contains the status of the request body processor used for request body
+	// parsing. The values can be 0 (no error) or 1 (error). This variable will be set by
+	// request body processors (typically the multipart/request-data parser, JSON or the XML
+	// parser) when they fail to do their work.
+	// ---
+	// ```modsecurity
+	// SecRule REQBODY_ERROR "@eq 1" deny,phase:2,id:39
+	// ```
+	//
+	// **Note :** Your policies must have a rule to check for request body processor errors at the very beginning of phase 2. Failure to do so will leave the door open for impedance mismatch attacks. It is possible, for example, that a payload that cannot be parsed by Coraza can be successfully parsed by more tolerant parser operating in the application. If your policy dictates blocking, then you should reject the request if error is detected. When operating in detection-only mode, your rule should alert with high severity when request body processing fails.
 	ReqbodyError
-	// ReqbodyErrorMsg contains the error message of the request body processor error
+	// Description: If there's been an error during request body parsing, the variable will
+	// contain the following error message:
+	// ---
+	// ```modsecurity
+	// SecRule REQBODY_ERROR_MSG "failed to parse" "id:40"
+	// ```
 	ReqbodyErrorMsg
-	// ReqbodyProcessorError is the same as ReqbodyErrr ?
+	// ReqbodyProcessorError is the same as ReqbodyError ?
 	ReqbodyProcessorError
 	// ReqbodyProcessorErrorMsg is the same as ReqbodyErrorMsg ?
 	ReqbodyProcessorErrorMsg
-	// ReqbodyProcessor contains the name of the request body processor used, default
-	// ones are: URLENCODED, MULTIPART, and XML. They can be extended using plugins.
+	// Description: Contains the name of the currently used request body processor. The possible
+	// values are URLENCODED, JSON, MULTIPART, and XML.
+	// ---
+	// ```modsecurity
+	// SecRule REQBODY_PROCESSOR "^XML$ chain,id:41
+	//   SecRule XML://* "something" "id:123"
+	// ```
 	ReqbodyProcessor
-	// RequestBasename contains the name after the last slash in the request URI
-	// It does not pass through any anti-evasion, use with transformations
+	// Description: This variable holds just the filename part of REQUEST_FILENAME (e.g.,
+	// index.php).
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_BASENAME "^login\.php$" phase:2,id:42,t:none,t:lowercase
+	// ```
+	//
+	// **Note :** Please note that anti-evasion transformations are not applied to this variable by default. REQUEST_BASENAME will recognize both / and \ as path separators. You should understand that the value of this variable depends on what was provided in request, and that it does not have to correspond to the resource (on disk) that will be used by the web server.
 	RequestBasename
-	// RequestBody contains the full request body, it will only be available
-	// For urlencoded requests. It is possible to force it's presence by using
-	// the ctl:forceRequestBodyVariable action
+	// Description: Holds the raw request body. This variable is available only if the
+	// URLENCODED request body processor was used, which will occur by default when the
+	// application/x-www-form-urlencoded content type is detected, or if the use of the
+	// URLENCODED request body parser was forced.
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_BODY "^username=\w{25,}\&password=\w{25,}\&Submit\=login$" "id:43"
+	// ```
+	//
+	// It is possible to force the presence of the REQUEST_BODY variable, but only when there is no request body processor defined using the ```ctl:forceRequestBodyVariable``` option in the REQUEST_HEADERS phase.
 	RequestBody
-	// RequestBodyLength contains the length of the request body in bytes calculated from
-	// the BodyBuffer, not from the content-type header
+	// Description: Contains the number of bytes read from a request body.
 	RequestBodyLength
-	// RequestFilename holds the relative request URL without the query string part.
-	// Anti-evasion transformations are not used by default
+	// Description: This variable holds the relative request URL without the query string part
+	// (e.g., /index.php).
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_FILENAME "^/cgi-bin/login\.php$" phase:2,id:46,t:none,t:normalizePath
+	// ```
+	//
+	// **Note :** Please note that anti-evasion transformations are not used on REQUEST_FILENAME, which means that you will have to specify them in the rules that use this variable.
 	RequestFilename
-	// RequestLine This variable holds the complete request line sent to the server
-	// (including the request method and HTTP version information).
+	// Description: This variable holds the complete request line sent to the server (including
+	// the request method and HTTP version information).
+	// ---
+	// ```modsecurity
+	// # Allow only POST, GET and HEAD request methods, as well as only
+	// # the valid protocol versions
+	// SecRule REQUEST_LINE "!(^((?:(?:POS|GE)T|HEAD))|HTTP/(0\.9|1\.0|1\.1)$)" "phase:1,id:49,log,block,t:none"
+	// ```
 	RequestLine
-	// RequestMethod is the request method
+	// Description: This variable holds the request method used in the transaction.
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_METHOD "^(?:CONNECT|TRACE)$" "id:50,t:none"
+	// ```
 	RequestMethod
-	// RequestProtocol is the protocol used in the request
+	// Description: This variable holds the request protocol version information.
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_PROTOCOL "!^HTTP/(0\.9|1\.0|1\.1)$" "id:51"
+	// ```
 	RequestProtocol
-	// RequestURI holds the full request URL including the query string data without
-	// the domain name
+	// Description: This variable holds the full request URL including the query string data
+	// (e.g., /index.php? p=X). However, it will never contain a domain name, even if it
+	// was provided on the request line.
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_URI "attack" "phase:1,id:52,t:none,t:urlDecode,t:lowercase,t:normalizePath"
+	// ```
+	//
+	// **Note :** Please note that anti-evasion transformations are not used on REQUEST_URI, which means that you will have to specify them in the rules that use this variable.
 	RequestURI
-	// RequestURIRaw is the same as RequestURI but with the domain name in case
-	// it was provided in the request line
+	// Description: Same as REQUEST_URI but will contain the domain name if it was provided on
+	// the request line (e.g., http://www.example.com/index.php?p=X).
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_URI_RAW "http:/" "phase:1,id:53,t:none,t:urlDecode,t:lowercase,t:normalizePath"
+	// ```
+	//
+	// **Note :** Please note that anti-evasion transformations are not used on REQUEST_URI_RAW, which means that you will have to specify them in the rules that use this variable.
 	RequestURIRaw
-	// ResponseBody contains the full response body, it will only be available if
-	// responseBodyAccess is set to on and the response mime matches the configured
-	// processable mime types
+	// Description: This variable holds the data for the response body, but only when response
+	// body buffering is enabled.
+	// ---
+	// ```modsecurity
+	// SecRule RESPONSE_BODY "ODBC Error Code" "phase:4,id:54,t:none"
+	// ```
 	ResponseBody
-	// ResponseContentLength contains the length of the response body in bytes calculated from
-	// the BodyBuffer, not from the content-type header
+	// Description: Response body length in bytes. Can be available starting with phase 3, but
+	// it does not have to be (as the length of response body is not always known in advance).
+	// If the size is not known, this variable will contain a zero. If RESPONSE_CONTENT_LENGTH
+	// contains a zero in phase 5 that means the actual size of the response body was 0. The
+	// value of this variable can change between phases if the body is modified. For example,
+	// in embedded mode, mod_deflate can compress the response body between phases 4 and 5.
 	ResponseContentLength
-	// ResponseProtocol is the protocol used in the response
+	// Description: This variable holds the HTTP response protocol information.
+	// ---
+	// ```modsecurity
+	// SecRule RESPONSE_PROTOCOL "^HTTP\/0\.9" "phase:3,id:57,t:none"
+	// ```
 	ResponseProtocol
-	// ResponseStatus is the status code of the response
+	// Description: This variable holds the HTTP response status code:
+	// ---
+	// ```modsecurity
+	// SecRule RESPONSE_STATUS "^[45]" "phase:3,id:58,t:none"
+	// ```
+	//
+	// This variable may not work as expected, as some implementations might change the status before releasing the output buffers.
 	ResponseStatus
-	// ServerAddr is the address of the server
+	// Description: This variable contains the IP address of the server.
+	// ---
+	// ```modsecurity
+	// SecRule SERVER_ADDR "@ipMatch 192.168.1.100" "id:67"
+	// ```
 	ServerAddr
-	// ServerName is the name of the server
+	// Description: This variable contains the transaction's hostname or IP address, taken from
+	// the request itself (which means that, in principle, it should not be trusted).
+	// ---
+	// ```modsecurity
+	// SecRule SERVER_NAME "hostname\.com$" "id:68"
+	// ```
 	ServerName
-	// ServerPort is the port of the server
+	// Description: This variable contains the local port that the web server (or reverse proxy)
+	// is listening on.
+	// ---
+	// ```modsecurity
+	// SecRule SERVER_PORT "^80$" "id:69"
+	// ```
 	ServerPort
-	// HighestSeverity is the highest severity from all matched rules
+	// Description: This variable holds the highest severity of any rules that have matched so
+	// far. Severities are numeric values and thus can be used with comparison operators such as
+	// @lt, and so on. A value of 255 indicates that no severity has been set.
+	// ---
+	// ```modsecurity
+	// SecRule HIGHEST_SEVERITY "@le 2" "phase:2,id:23,deny,status:500,msg:'severity %{HIGHEST_SEVERITY}'"
+	// ```
+	//
+	// **Note :** Higher severities have a lower numeric value.
 	HighestSeverity
-	// StatusLine is the status line of the response, including the request method
-	// and HTTP version information
+	// Description: This variable holds the full status line sent by the server (including the
+	// request method and HTTP version information).
+	// ---
+	// ```modsecurity
+	// # Generate an alert when the application generates 500 errors.
+	// SecRule STATUS_LINE "@contains 500" "phase:3,id:49,log,pass,logdata:'Application error detected!,t:none"
+	// ```
+	//
+	// **Supported on Coraza:** TBI
 	StatusLine
-	// Duration contains the time in miliseconds from
-	// the beginning of the transaction until this point
+	// Description: Contains the number of microseconds elapsed since the beginning of the
+	// current transaction.
+	//
+	// **Not Implemented yet**
 	Duration
-	// ResponseHeadersNames contains the names of the response headers
+	// Description: This variable is a collection of the response header names.
+	// ---
+	// ```modsecurity
+	// SecRule RESPONSE_HEADERS_NAMES "Set-Cookie" "phase:3,id:56,t:none"
+	// ```
+	//
+	// The same limitations apply as the ones discussed in RESPONSE_HEADERS.
 	ResponseHeadersNames // CanBeSelected
-	// RequestHeadersNames contains the names of the request headers
+	// Description: This variable is a collection of the names of all of the request headers.
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_HEADERS_NAMES "^x-forwarded-for" "log,deny,id:48,status:403,t:lowercase,msg:'Proxy Server Used'"
+	// ```
 	RequestHeadersNames // CanBeSelected
-	// Args contains copies of ArgsGet and ArgsPost
+	// Description: **ARGS** is a collection and can be used on its own (means all arguments
+	// including the POST Payload), with a static parameter (matches arguments with that name),
+	// or with a regular expression (matches all arguments with name that matches the regular
+	// expression). To look at only the query string or body arguments, see the ARGS_GET and
+	// ARGS_POST collections.
+	// ---
+	// Some variables are actually collections, which are expanded into more variables at runtime. The following example will examine all request arguments:
+	//
+	// ```modsecurity
+	// SecRule ARGS dirty "id:7"
+	// ```
+	//
+	// Sometimes, however, you will want to look only at parts of a collection. This can be achieved with the help of the selection operator(colon). The following example will only look at the arguments named p (do note that, in general, requests can contain multiple arguments with the same name):
+	//
+	// ```modsecurity
+	// SecRule ARGS:p dirty "id:8"
+	// ```
+	//
+	// It is also possible to specify exclusions. The following will examine all request arguments for the word dirty, except the ones named z (again, there can be zero or more arguments named z):
+	//
+	// ```modsecurity
+	// SecRule ARGS|!ARGS:z dirty "id:9"
+	// ```
+	//
+	// There is a special operator that allows you to count how many variables there are in a collection. The following rule will trigger if there is more than zero arguments in the request (ignore the second parameter for the time being):
+	//
+	// ```modsecurity
+	// SecRule &ARGS !^0$ "id:10"
+	// ```
+	//
+	// And sometimes you need to look at an array of parameters, each with a slightly different name. In this case you can specify a regular expression in the selection operator itself. The following rule will look into all arguments whose names begin with id_:
+	//
+	// ```modsecurity
+	// SecRule ARGS:/^id_/ dirty "id:11"
+	// ```
+	//
+	// **Note :** Using ```ARGS:p``` will not result in any invocations against the operator if argument p does not exist.
 	Args // CanBeSelected
-	// ArgsGet contains the GET (URL) arguments
+	// Description: **ARGS_GET** is similar to ARGS, but contains only query string parameters.
 	ArgsGet // CanBeSelected
-	// ArgsPost contains the POST (BODY) arguments
+	// Description: **ARGS_POST** is similar to **ARGS**, but only contains arguments from the
+	// POST body.
 	ArgsPost // CanBeSelected
 	// ArgsPath contains the url path parts
 	ArgsPath // CanBeSelected
-	// FilesSizes contains the sizes of the uploaded files
+	// Description: Contains a list of individual file sizes. Useful for implementing a size
+	// limitation on individual uploaded files. Available only on inspected multipart/form-data
+	// requests.
+	// ---
+	// ```modsecurity
+	// SecRule FILES_SIZES "@gt 100" "id:20"
+	// ```
 	FilesSizes // CanBeSelected
-	// FilesNames contains the names of the uploaded files
+	// Description: Contains a list of form fields that were used for file upload. Available only
+	// on inspected multipart/form-data requests.
+	// ---
+	// ```modsecurity
+	// SecRule FILES_NAMES "^upfile$" "id:19"
+	// ```
 	FilesNames // CanBeSelected
-	// FilesTmpContent is not supported
+	// Description: Contains a key-value set where value is the content of the file which was
+	// uploaded. Useful when used together with @fuzzyHash.
+	// ---
+	// ```modsecurity
+	// SecRule FILES_TMP_CONTENT "@fuzzyHash $ENV{CONF_DIR}/ssdeep.txt 1" "id:192372,log,deny"
+	// ```
+	//
+	// **Note :** SecUploadKeepFiles should be set to 'On' in order to have this collection filled.
 	FilesTmpContent // CanBeSelected
-	// MultipartFilename contains the multipart data from field FILENAME
+	// Description: This variable contains the multipart data from field FILENAME.
 	MultipartFilename // CanBeSelected
-	// MultipartName contains the multipart data from field NAME.
+	// Description: This variable contains the multipart data from field NAME.
 	MultipartName // CanBeSelected
-	// MatchedVarsNames is similar to MATCHED_VAR_NAME except that it is
-	// a collection of all matches for the current operator check.
+	// Description: Similar to MATCHED_VAR_NAME except that it is a collection of all matches
+	// for the current operator check.
+	// ---
+	// ```modsecurity
+	// SecRule ARGS pattern "chain,deny,id:28"
+	//   SecRule MATCHED_VARS_NAMES "@eq ARGS:param"
+	// ```
 	MatchedVarsNames // CanBeSelected
-	// MatchedVars is similar to MATCHED_VAR except that it is a collection
-	// of all matches for the current operator check
+	// Description: Similar to **MATCHED_VAR** except that it is a collection of all matches
+	// for the current operator check.
+	// ---
+	// ```modsecurity
+	// SecRule ARGS pattern "chain,deny,id:26"
+	//   SecRule MATCHED_VARS "@eq ARGS:param"
+	// ```
 	MatchedVars // CanBeSelected
-	// Files contains a collection of original file names
-	// (as they were called on the remote user’s filesys- tem).
-	// Available only on inspected multipart/form-data requests.
+	// Description: Contains a collection of original file names (as they were called on the
+	// remote user's filesystem). Available only on inspected multipart/form-data requests.
+	// ---
+	// ```modsecurity
+	// SecRule FILES "@rx \.conf$" "id:17"
+	// ```
+	//
+	// **Note :** Only available if files were extracted from the request body.
 	Files // CanBeSelected
-	// RequestCookies is a collection of all of request cookies (values only
+	// Description: This variable is a collection of all of request cookies (values only).
+	// ---
+	// Example: the following example is using the Ampersand special operator to count how many variables are in the collection. In this rule, it would trigger if the request does not include any Cookie headers.
+	//
+	// ```modsecurity
+	// SecRule &REQUEST_COOKIES "@eq 0" "id:44"
+	// ```
 	RequestCookies // CanBeSelected
-	// RequestHeaders can be used as either a collection of all of the request
-	// headers or can be used to inspect selected headers
+	// Description: This variable can be used as either a collection of all of the request
+	// headers or can be used to inspect selected headers (by using the
+	// REQUEST_HEADERS:Header-Name syntax).
+	// ---
+	// ```modsecurity
+	// SecRule REQUEST_HEADERS:Host "^[\d\.]+$" "deny,id:47,log,status:400,msg:'Host header is a numeric IP address'"
+	// ```
+	//
+	// **Note:** Coraza will treat multiple headers that have identical names as a "list", processing each single value.
 	RequestHeaders // CanBeSelected
-	// ResponseHeaders can be used as either a collection of all of the response
-	// headers or can be used to inspect selected headers
+	// Description: This variable refers to response headers, in the same way as
+	// REQUEST_HEADERS does to request headers.
+	// ---
+	// ```modsecurity
+	// SecRule RESPONSE_HEADERS:X-Cache "MISS" "id:55"
+	// ```
+	//
+	// This variable may not have access to some headers when running in embedded mode. Headers such as Server, Date, Connection, and Content-Type could be added just prior to sending the data to the client. This data should be available in phase 5 or when deployed in proxy mode.
 	ResponseHeaders // CanBeSelected
 	// ReseBodyProcessor contains the name of the response body processor used,
 	// no default
 	ResBodyProcessor
-	// Geo contains the location information of the client
+	// Description: GEO is a collection populated by the results of the last @geoLookup
+	// operator. The collection can be used to match geographical fields looked from an IP
+	// address or hostname.
+	// ---
+	// Fields:
+	//
+	// - **COUNTRY_CODE:** Two character country code. EX: US, CL, GB, etc.
+	// - **COUNTRY_CODE3:** Up to three character country code.
+	// - **COUNTRY_NAME:** The full country name.
+	// - **COUNTRY_CONTINENT:** The two character continent that the country is located. EX: EU
+	// - **REGION:** The two character region. For US, this is state. For Chile, region, etc.
+	// - **CITY:** The city name if supported by the database.
+	// - **POSTAL_CODE:** The postal code if supported by the database.
+	// - **LATITUDE:** The latitude if supported by the database.
+	// - **LONGITUDE:** The longitude if supported by the database.
+	//
+	// **Example:**
+	//
+	// ```modsecurity
+	// SecGeoLookupDb maxminddb file=/usr/local/geo/data/GeoLiteCity.dat
+	// ...
+	// SecRule REMOTE_ADDR "@geoLookup" "chain,id:22,drop,msg:'Non-GB IP address'"
+	// SecRule GEO:COUNTRY_CODE "!@streq GB"
+	// ```
 	Geo // CanBeSelected
-	// RequestCookiesNames contains the names of the request cookies
+	// Description: This variable is a collection of the names of all request cookies. For
+	// example, the following rule will trigger if the JSESSIONID cookie is not present:
+	// ---
+	// ```modsecurity
+	// SecRule &REQUEST_COOKIES_NAMES:JSESSIONID "@eq 0" "id:45"
+	// ```
 	RequestCookiesNames // CanBeSelected
-	// FilesTmpNames contains the names of the uploaded temporal files
+	// Description: Contains a list of temporary files' names on the disk. Useful when used
+	// together with @inspectFile. Available only on inspected multipart/form-data requests.
+	// ---
+	// ```modsecurity
+	// SecRule FILES_TMPNAMES "@inspectFile /path/to/inspect_script.pl" "id:21"
+	// ```
 	FilesTmpNames // CanBeSelected
-	// ArgsNames contains the names of the arguments (POST and GET)
+	// Description: Contains all request parameter names. You can search for specific parameter
+	// names that you want to inspect. In a positive policy scenario, you can also allowlist
+	// (using an inverted rule with the exclamation mark) only the authorized argument names.
+	// This example rule allows only two argument names: p and a:
+	// ---
+	// ```modsecurity
+	// SecRule ARGS_NAMES "!^(p|a)$" "id:13"
+	// ```
 	ArgsNames // CanBeSelected
-	// ArgsGetNames contains the names of the GET arguments
+	// Description: **ARGS_GET_NAMES** is similar to **ARGS_NAMES**, but contains only the
+	// names of query string parameters.
 	ArgsGetNames // CanBeSelected
-	// ArgsPostNames contains the names of the POST arguments
+	// Description: **ARGS_POST_NAMES** is similar to **ARGS_NAMES**, but contains only the
+	// names of request body parameters.
 	ArgsPostNames // CanBeSelected
-	// TX contains transaction specific variables created with setvar
+	// Description: This is the transient transaction collection, which is used to store pieces
+	// of data, create a transaction anomaly score, and so on. The variables placed into this
+	// collection are available only until the transaction is complete.
+	// ---
+	// ```modsecurity
+	// # Increment transaction attack score on attack
+	// SecRule ARGS attack "phase:2,id:82,nolog,pass,setvar:TX.score=+5"
+	//
+	// # Block the transactions whose scores are too high
+	// SecRule TX:SCORE "@gt 20" "phase:2,id:83,log,deny"
+	// ```
+	//
+	// Some variable names in the TX collection are reserved and cannot be used:
+	//
+	// - **TX:0:** the matching value when using the @rx or @pm operator with the capture action
+	// - **TX:1-TX:9:** the captured subexpression value when using the @rx operator with capturing parens and the capture action
 	TX // CanBeSelected
-	// Rule contains rule metadata
+	// Description: This is a special collection that provides access to the id, rev, severity,
+	// logdata, and msg fields of the rule that triggered the action. It can be used to refer to
+	// only the same rule in which it resides.
+	// ---
+	// ```modsecurity
+	// SecRule &REQUEST_HEADERS:Host "@eq 0" "log,deny,id:59,setvar:tx.varname=%{RULE.id}"
+	// ```
 	Rule // CanBeSelected
 	// JSON does not provide any data, might be removed
 	JSON // CanBeSelected
-	// Env contains the process environment variables
+	// Description: Collection that provides access to environment variables set by Coraza or
+	// other server modules. Requires a single parameter to specify the name of the desired
+	// variable.
+	// ---
+	// ```modsecurity
+	// # Set environment variable
+	// SecRule REQUEST_FILENAME "printenv" \
+	// "phase:2,id:15,pass,setenv:tag=suspicious"
+	//
+	// # Inspect environment variable
+	// SecRule ENV:tag "suspicious" "id:16"
+	//
+	// # Reading an environment variable from other Apache module (mod_ssl)
+	// SecRule TX:ANOMALY_SCORE "@gt 0" "phase:5,id:16,msg:'%{env.ssl_cipher}'"
+	// ```
+	//
+	// **Note :** Use setenv to set environment variables to be accessed by Apache.
+	//
+	// **Not Implemented yet**
 	Env // CanBeSelected
-	// UrlencodedError equals 1 if we failed to parse de URL
-	// It applies for URL query part and urlencoded post body
+	// Description: This variable is created when an invalid URL encoding is encountered during
+	// the parsing of a query string (on every request) or during the parsing of an
+	// application/x-www-form-urlencoded request body (only on the requests that use the
+	// URLENCODED request body processor).
 	UrlencodedError
 	// ResponseArgs contains the response parsed arguments
 	ResponseArgs // CanBeSelected
@@ -183,14 +553,56 @@ const (
 	ResponseXML // CanBeSelected
 	// RequestXML contains the request parsed XML
 	RequestXML // CanBeSelected
-	// XML is a pointer to ResponseXML
+	// Description: Special collection used to interact with the XML parser. It must contain a
+	// valid XPath expression, which will then be evaluated against a previously parsed XML DOM
+	// tree.
+	// ---
+	// ```modsecurity
+	// SecDefaultAction log,deny,status:403,phase:2,id:90
+	// SecRule REQUEST_HEADERS:Content-Type ^text/xml$ "phase:1,id:87,t:lowercase,nolog,pass,ctl:requestBodyProcessor=XML"
+	// SecRule REQBODY_PROCESSOR "!^XML$" skipAfter:12345,id:88
+	// ```
+	//
+	// It would match against payload such as this one:
+	//
+	// ```xml
+	// <employees>
+	//     <employee>
+	//         <name>Fred Jones</name>
+	//         <address location="home">
+	//             <street>900 Aurora Ave.</street>
+	//             <city>Seattle</city>
+	//             <state>WA</state>
+	//             <zip>98115</zip>
+	//         </address>
+	//         <address location="work">
+	//             <street>2011 152nd Avenue NE</street>
+	//             <city>Redmond</city>
+	//             <state>WA</state>
+	//             <zip>98052</zip>
+	//         </address>
+	//         <phone location="work">(425)555-5665</phone>
+	//         <phone location="home">(206)555-5555</phone>
+	//         <phone location="mobile">(206)555-4321</phone>
+	//     </employee>
+	// </employees>
+	// ```
 	XML // CanBeSelected
 	// MultipartPartHeaders contains the multipart headers
 	MultipartPartHeaders // CanBeSelected
 
 	// Unsupported variables
 
-	// AuthType is the authentication type
+	// Description: This variable holds the authentication method used to validate a user, if
+	// any of the methods built into HTTP are used. In a reverse-proxy deployment, this
+	// information will not be available if the authentication is handled in the backend web
+	// server.
+	// ---
+	// ```modsecurity
+	// SecRule AUTH_TYPE "Basic" "id:14"
+	// ```
+	//
+	// **Not Implemented yet**
 	AuthType
 	// FullRequest is the full request
 	FullRequest
@@ -220,11 +632,30 @@ const (
 	MultipartStrictError
 	// MultipartUnmatchedBoundary kept for compatibility
 	MultipartUnmatchedBoundary
-	// PathInfo is kept for compatibility
+	// Description: Contains the extra request URI information, also known as path info. (For
+	// example, in the URI /index.php/123, /123 is the path info.) Available only in embedded
+	// deployments.
+	// ---
+	// ```modsecurity
+	// SecRule PATH_INFO "^/(bin|etc|sbin|opt|usr)" "id:33"
+	// ```
 	PathInfo
-	// Sessionid is not supported
+	// Description: This variable contains the value set with setsid. See SESSION for a
+	// complete example.
+	//
+	// **Not Implemented yet**
 	Sessionid
-	// Userid is not supported
+	// Description: This variable contains the value set with setuid.
+	// ---
+	// ```modsecurity
+	// # Initialize user tracking
+	// SecAction "nolog,id:84,pass,setuid:%{REMOTE_USER}"
+	//
+	// # Is the current user the administrator?
+	// SecRule USERID "admin" "id:85"
+	// ```
+	//
+	// **Supported:** TBI
 	Userid
 	// IP is kept for compatibility
 	IP
@@ -236,22 +667,66 @@ const (
 	ResBodyProcessorError
 	// ResBodyProcessorErrorMsg
 	ResBodyProcessorErrorMsg
-	// Time holds a formatted string representing the time (hour:minute:second).
+	// Description: This variable holds a formatted string representing the time
+	// (hour:minute:second).
+	// ---
+	// ```modsecurity
+	// SecRule TIME "^(([1](8|9))|([2](0|1|2|3))):\d{2}:\d{2}$" "id:74"
+	// ```
 	Time
-	// TimeDay holds the current day of the month (1-31)
+	// Description: This variable holds the current date (1–31). The following rule triggers on
+	// a transaction that's happening anytime between the 10th and 20th in a month:
+	// ---
+	// ```modsecurity
+	// SecRule TIME_DAY "^(([1](0|1|2|3|4|5|6|7|8|9))|20)$" "id:75"
+	// ```
 	TimeDay
-	// TimeEpoch holds the time in seconds since 1970
+	// Description: This variable holds the time in seconds since 1970.
 	TimeEpoch
-	// TimeHour holds the current hour of the day (0-23)
+	// Description: This variable holds the current hour value (0–23). The following rule
+	// triggers when a request is made "off hours":
+	// ---
+	// ```modsecurity
+	// SecRule TIME_HOUR "^(0|1|2|3|4|5|6|[1](8|9)|[2](0|1|2|3))$" "id:76"
+	// ```
 	TimeHour
-	// TimeMin holds the current minute of the hour (0-59)
+	// Description: This variable holds the current minute value (0–59). The following rule
+	// triggers during the last half hour of every hour:
+	// ---
+	// ```modsecurity
+	// SecRule TIME_MIN "^(3|4|5)" "id:77"
+	// ```
 	TimeMin
-	// TimeMon holds the current month of the year (0-11)
+	// Description: This variable holds the current month value (0–11). The following rule
+	// matches if the month is either November (value 10) or December (value 11):
+	// ---
+	// ```modsecurity
+	// SecRule TIME_MON "^1" "id:78"
+	// ```
 	TimeMon
-	// TimeSec holds the current second of the minute (0-59)
+	// Description: This variable holds the current second value (0–59).
+	// ---
+	// **Supported:** TBI
+	//
+	// ```modsecurity
+	// SecRule TIME_SEC "@gt 30" "id:79"
+	// ```
 	TimeSec
-	// TimeWday holds the current weekday value (1–7), where Monday is 1
+	// Description: This variable holds the current weekday value (0–6). The following rule
+	// triggers only on Saturday and Sunday:
+	// ---
+	// **Supported:** TBI
+	//
+	// ```modsecurity
+	// SecRule TIME_WDAY "^(0|6)$" "id:80"
+	// ```
 	TimeWday
-	// TimeYear the current four-digit year value
+	// Description: This variable holds the current four-digit year value.
+	// ---
+	// **Supported:** TBI
+	//
+	// ```modsecurity
+	// SecRule TIME_YEAR "^2006$" "id:81"
+	// ```
 	TimeYear
 )


### PR DESCRIPTION
## Summary
- Updates variable comments in `internal/variables/variables.go` with structured `Description:` / `---` / content fields
- Each variable's comment now contains the full documentation matching the coraza.io website
- This enables the `variablesgen` tool in coraza.io to auto-generate the variables documentation page from source code, keeping docs and code in sync

## Motivation
The directives and operators documentation pages on coraza.io are already generated from structured Go comments. This PR extends the same pattern to variables, ensuring documentation stays in sync with the codebase.

## Test plan
- [x] Verify `go build ./...` passes (comments only, no logic changes)
- [x] Verify `go generate ./internal/variables/` still works
- [ ] Run `variablesgen` tool from coraza.io against this branch to confirm proper markdown generation