### PR TITLE
chore: ignore generated files in codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 ignore:
   - "**/generator/main.go" # generator tools usually involves writing files
+  - "**/*.gen.go" # generated files from go generate
 fixes:
   # Apparently using build/ as prefix is not enough to ignore the directory
   # Reference: https://community.codecov.com/t/codecov-website-can-not-show-line-by-line-coverage/3809


### PR DESCRIPTION
## Summary
- Add `**/*.gen.go` glob pattern to codecov ignore list so go generate output (e.g. `variablesmap.gen.go`, `directivesmap.gen.go`) is excluded from coverage reports.

## Test plan
- [ ] Verify codecov config is valid by checking the PR's coverage report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to exclude automatically generated source files from coverage reports, ensuring coverage metrics reflect only hand-written code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->