### PR TITLE
chore: change renovatebot config source from local to GitHub

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>corazawaf/renovate-config"
+    "github>corazawaf/renovate-config"
   ]
 }


### PR DESCRIPTION
## what

- update renovatebot config to use shared config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to reference the GitHub-hosted preset for dependency management settings, ensuring the preset is resolved from the official GitHub source rather than a local namespace. This adjusts where Renovate fetches its configuration without changing any exported APIs or application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->