### PR TITLE
feat(experimental): pluggable TelemetrySink interface for engine events

### DIFF
--- a/config.go
+++ b/config.go
@@ -95,6 +95,8 @@ type wafRule struct {
 // We still basically assume 64-bit usage where int are big sizes.
 type wafConfig struct {
 	ruleObserver             func(rule types.RuleMetadata)
+	telemetrySink            plugintypes.TelemetrySink
+	perRuleTiming            bool
 	rules                    []wafRule
 	auditLog                 *auditLogConfig
 	requestBodyAccess        bool
@@ -123,6 +125,31 @@ func (c *wafConfig) WithRules(rules ...*corazawaf.Rule) WAFConfig {
 func (c *wafConfig) WithRuleObserver(observer func(rule types.RuleMetadata)) WAFConfig {
 	ret := c.clone()
 	ret.ruleObserver = observer
+	return ret
+}
+
+// WithTelemetrySink attaches a TelemetrySink to the WAF configuration.
+// A nil sink is treated the same as no sink and disables event emission
+// with zero hot-path cost.
+//
+// This method is not part of the public WAFConfig interface; callers must
+// use experimental.WAFConfigWithTelemetrySink to set it. It may be promoted
+// to the stable API in Coraza v4.
+func (c *wafConfig) WithTelemetrySink(sink plugintypes.TelemetrySink) WAFConfig {
+	ret := c.clone()
+	ret.telemetrySink = sink
+	return ret
+}
+
+// WithPerRuleTiming enables per-rule timing emission at startup. The flag
+// can also be flipped at runtime on a live WAF via
+// experimental.WAFEnablePerRuleTiming.
+//
+// Not part of the public WAFConfig interface; access via
+// experimental.WAFConfigWithPerRuleTiming.
+func (c *wafConfig) WithPerRuleTiming(enabled bool) WAFConfig {
+	ret := c.clone()
+	ret.perRuleTiming = enabled
 	return ret
 }
 

--- a/experimental/plugins/plugintypes/telemetry.go
+++ b/experimental/plugins/plugintypes/telemetry.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package plugintypes
+
+import (
+	"context"
+	"time"
+
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+// TransactionEventKind classifies a TransactionEvent. The engine emits exactly
+// one Start event per transaction, one PhaseEnd event per phase actually
+// evaluated, and one Finish event when the transaction is closed.
+type TransactionEventKind uint8
+
+const (
+	// TransactionEventStart is emitted once, after the transaction struct is
+	// initialized and before any phase has been evaluated.
+	TransactionEventStart TransactionEventKind = iota + 1
+
+	// TransactionEventPhaseEnd is emitted at the end of each evaluated phase.
+	// The PhaseDuration field carries the time spent inside that phase.
+	TransactionEventPhaseEnd
+
+	// TransactionEventFinish is emitted once, at transaction close. Carries
+	// the final interruption (if any) so a sink can classify the outcome.
+	TransactionEventFinish
+)
+
+// String returns a short, stable identifier for the event kind suitable for
+// use as a metric label value or a log key.
+func (k TransactionEventKind) String() string {
+	switch k {
+	case TransactionEventStart:
+		return "start"
+	case TransactionEventPhaseEnd:
+		return "phase_end"
+	case TransactionEventFinish:
+		return "finish"
+	}
+	return "unknown"
+}
+
+// TransactionEvent is passed to TelemetrySink.OnTransaction.
+//
+// TransactionEvent is a value type and safe to copy. Fields not relevant to
+// the event kind are zero-valued; sinks must branch on Kind.
+type TransactionEvent struct {
+	// Kind identifies the lifecycle point that produced the event.
+	Kind TransactionEventKind
+
+	// TransactionID is the transaction identifier and is always set.
+	TransactionID string
+
+	// Context is the transaction's parent context (typically the HTTP request
+	// context). Sinks that start OpenTelemetry spans should pass this context
+	// to their tracer so spans chain to the parent request trace. Never nil.
+	Context context.Context
+
+	// Phase is only meaningful for TransactionEventPhaseEnd and identifies
+	// which phase just finished evaluating.
+	Phase types.RulePhase
+
+	// PhaseDuration is only meaningful for TransactionEventPhaseEnd and
+	// contains the wall-clock time spent inside the phase.
+	PhaseDuration time.Duration
+
+	// RulesEvaluated is only meaningful for TransactionEventPhaseEnd and
+	// carries how many rules actually executed in that phase (after
+	// skips/excludes/allow-type short-circuits). Useful for answering
+	// "why did this request spend so long in phase 2?" without enabling
+	// per-rule timing.
+	RulesEvaluated int
+
+	// Interruption carries the current interruption (if any). For
+	// TransactionEventPhaseEnd it reflects whether the phase ended with an
+	// interruption. For TransactionEventFinish it is the terminal decision.
+	// nil if the transaction has not been interrupted.
+	Interruption *types.Interruption
+}
+
+// RuleMatchEvent is passed to TelemetrySink.OnRuleMatch. It is emitted
+// synchronously after a rule has matched and its metadata has been appended
+// to the transaction's matched-rule list.
+type RuleMatchEvent struct {
+	// TransactionID is the ID of the transaction in which the match occurred.
+	TransactionID string
+
+	// Context is the transaction context. Never nil.
+	Context context.Context
+
+	// Rule is the metadata of the rule that matched. Never nil.
+	Rule types.RuleMetadata
+
+	// Phase is the phase during which the match was evaluated.
+	Phase types.RulePhase
+
+	// Action is the disruptive-type action configured on the rule, if any:
+	// one of "deny", "drop", "pass", "allow", "redirect", or the empty
+	// string when the rule has no disruptive-type action slot (log-only
+	// matches, chained sub-rules).
+	//
+	// Note: "pass" is classified as a disruptive-type action by SecLang
+	// semantics even though it does not block. Metrics that count "real"
+	// blocks should filter on Action == "deny" || "drop" || "redirect",
+	// ideally combined with Enforced == true.
+	Action string
+
+	// Enforced is true when the engine actually applied the Action — i.e.
+	// the rule engine is On (not DetectionOnly) and the rule had a
+	// disruptive-type action. In DetectionOnly mode, Action still carries
+	// the intended action but Enforced is false so sinks can distinguish
+	// "would-be blocks" from real ones.
+	Enforced bool
+
+	// Data carries the matched variables and their values.
+	//
+	// Security: Data values are attacker-controlled (they are the request
+	// bytes that tripped the rule). Sinks MUST NOT use these values as
+	// metric labels or span attributes — an attacker can trivially force
+	// cardinality explosion on the metrics backend. Log them only after
+	// redaction and truncation, or drop them entirely. Values may also
+	// contain PII (credit cards, bearer tokens, session data) that a naive
+	// log-shipper would leak to downstream systems.
+	Data []types.MatchData
+}
+
+// EngineEventKind enumerates engine-internal error categories. The set is
+// intentionally small so sinks can use Kind as a bounded-cardinality metric
+// label.
+type EngineEventKind uint8
+
+const (
+	// EngineEventInit signals a failure during WAF construction or validation.
+	EngineEventInit EngineEventKind = iota + 1
+
+	// EngineEventParse signals a failure while parsing SecLang directives.
+	EngineEventParse
+
+	// EngineEventBodyProcessor signals a failure in a configured body
+	// processor (URLENCODED, JSON, XML, etc.).
+	EngineEventBodyProcessor
+
+	// EngineEventBodyTruncated signals that a request or response body was
+	// truncated because it exceeded the configured limit and the engine
+	// interrupted the transaction as a result. This is not an unexpected
+	// failure but operators need to see it to tune limits.
+	EngineEventBodyTruncated
+
+	// EngineEventTransaction signals a generic transaction-time error.
+	EngineEventTransaction
+)
+
+// String returns a short, stable identifier for the kind suitable for use
+// as a metric label value or a log key.
+func (k EngineEventKind) String() string {
+	switch k {
+	case EngineEventInit:
+		return "init"
+	case EngineEventParse:
+		return "parse"
+	case EngineEventBodyProcessor:
+		return "body_processor"
+	case EngineEventBodyTruncated:
+		return "body_truncated"
+	case EngineEventTransaction:
+		return "transaction"
+	}
+	return "unknown"
+}
+
+// EngineEvent is passed to TelemetrySink.OnEngineError. It is emitted for
+// engine-internal failures that are not themselves rule matches.
+type EngineEvent struct {
+	// Kind identifies the failure category.
+	Kind EngineEventKind
+
+	// TransactionID is set when the failure is transaction-scoped and empty
+	// for init- or parse-time failures that have no transaction.
+	TransactionID string
+
+	// Phase is the rule phase in which the failure occurred. Zero when the
+	// failure is not phase-scoped.
+	Phase types.RulePhase
+
+	// Err is the underlying error. May be nil when only Message is set.
+	Err error
+
+	// Message is a short human-readable description of the failure. May be
+	// empty when only Err is set.
+	Message string
+}
+
+// RuleTimingEvent is emitted for every evaluated rule when per-rule timing
+// is enabled on the WAF. This is a HIGH-FREQUENCY, HIGH-CARDINALITY signal
+// — expect hundreds of events per transaction and bounded only by the
+// loaded ruleset size (~450 for CRS paranoia 2). Opt in only when
+// investigating a specific performance issue.
+type RuleTimingEvent struct {
+	// TransactionID is the ID of the transaction in which the rule ran.
+	TransactionID string
+
+	// Rule is the metadata of the rule that was evaluated.
+	Rule types.RuleMetadata
+
+	// Phase is the phase in which the rule ran.
+	Phase types.RulePhase
+
+	// Duration is the wall-clock time the rule evaluation took, including
+	// variable resolution, transformations, operator execution, and any
+	// disruptive action evaluation.
+	Duration time.Duration
+
+	// Matched is true when the rule's evaluation produced at least one
+	// match record on this invocation.
+	Matched bool
+}
+
+// RuleTimingSink is an optional extension interface. TelemetrySinks that
+// want per-rule timing events should implement it in addition to
+// TelemetrySink. The engine type-asserts once at NewWAF time and caches
+// the result, so unimplemented sinks pay no runtime cost.
+//
+// Implementations MUST follow the same non-blocking / concurrent-safe /
+// no-panic contract as TelemetrySink.
+type RuleTimingSink interface {
+	OnRuleTimed(ev RuleTimingEvent)
+}
+
+// EngineReadyEvent is passed to TelemetrySink.OnEngineReady once per WAF
+// instance, after all directives have been parsed and the WAF has validated.
+// Sinks use it to emit process-scope "info" metrics: what is this node
+// running and how long did it take to boot.
+type EngineReadyEvent struct {
+	// RulesLoaded is the number of compiled SecLang rules loaded into the
+	// WAF. Useful for alerting on config-reload surprises
+	// ("we lost 40 rules after that deploy").
+	RulesLoaded int
+
+	// InitDuration is the wall-clock time spent inside coraza.NewWAF —
+	// parsing directives, compiling regex, resolving rule chains. Critical
+	// for serverless/edge cold-start budgets.
+	InitDuration time.Duration
+}
+
+// TelemetrySink receives engine telemetry events.
+//
+// The engine invokes sink methods synchronously on the request-evaluation hot
+// path. Implementations MUST therefore:
+//
+//   - return quickly (buffer to a channel or similar if heavy work is needed);
+//   - be safe for concurrent invocation from multiple transactions;
+//   - never panic.
+//
+// All methods receive events by value. Implementations must not retain
+// pointers to Err or Interruption beyond the duration of the call: the engine
+// may pool and reuse transaction objects once the event returns.
+//
+// The engine treats a nil TelemetrySink as "no telemetry" and short-circuits
+// all event emission without allocation.
+//
+// A minimal implementation is six lines — use it as a starting point before
+// wiring events into Prometheus, OpenTelemetry, or your host's native
+// telemetry stack:
+//
+//	type printSink struct{}
+//	func (printSink) OnEngineReady(ev plugintypes.EngineReadyEvent)  {}
+//	func (printSink) OnTransaction(ev plugintypes.TransactionEvent)  { fmt.Printf("%+v\n", ev) }
+//	func (printSink) OnRuleMatch(ev plugintypes.RuleMatchEvent)       { fmt.Printf("%+v\n", ev) }
+//	func (printSink) OnEngineError(ev plugintypes.EngineEvent)        { fmt.Printf("%+v\n", ev) }
+//
+// This interface is experimental and may change before Coraza v4.
+type TelemetrySink interface {
+	// OnEngineReady is invoked exactly once per WAF instance, after all
+	// directives have been parsed and validation has succeeded.
+	OnEngineReady(ev EngineReadyEvent)
+
+	// OnTransaction is invoked at transaction start, at the end of each
+	// evaluated phase, and at transaction close.
+	OnTransaction(ev TransactionEvent)
+
+	// OnRuleMatch is invoked once per rule match, synchronously, after the
+	// rule's match record has been appended to the transaction.
+	OnRuleMatch(ev RuleMatchEvent)
+
+	// OnEngineError is invoked for engine-internal failures that are not rule
+	// matches (body processor errors, body truncation, etc.).
+	OnEngineError(ev EngineEvent)
+}

--- a/experimental/telemetry_sink.go
+++ b/experimental/telemetry_sink.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package experimental
+
+import (
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+)
+
+// wafConfigWithTelemetrySink is the private capability interface implemented
+// by the package-internal wafConfig. Keeping the method off the public
+// WAFConfig interface lets us iterate on the telemetry contract before v4
+// without breaking embedders.
+type wafConfigWithTelemetrySink interface {
+	WithTelemetrySink(plugintypes.TelemetrySink) coraza.WAFConfig
+}
+
+// WAFConfigWithTelemetrySink attaches a TelemetrySink to the provided
+// WAFConfig. A nil sink disables telemetry emission without allocation on
+// the hot path.
+//
+// The returned WAFConfig is a new value; the input is not mutated. If the
+// provided WAFConfig does not support telemetry (e.g. a third-party
+// implementation), the input is returned unchanged.
+//
+// This API is experimental and may change before Coraza v4.
+func WAFConfigWithTelemetrySink(
+	cfg coraza.WAFConfig,
+	sink plugintypes.TelemetrySink,
+) coraza.WAFConfig {
+	if c, ok := cfg.(wafConfigWithTelemetrySink); ok {
+		return c.WithTelemetrySink(sink)
+	}
+	return cfg
+}
+
+// wafConfigWithPerRuleTiming is the private capability interface for
+// enabling per-rule timing at startup.
+type wafConfigWithPerRuleTiming interface {
+	WithPerRuleTiming(bool) coraza.WAFConfig
+}
+
+// WAFConfigWithPerRuleTiming turns on per-rule timing at startup.
+//
+// Per-rule timing is HIGH-CARDINALITY (one event per rule per request,
+// ~450 for CRS) and HIGH-FREQUENCY. It is meant for investigating a
+// specific slow rule, not for continuous observability. Leave it off
+// unless you are actively debugging — the off-state cost is a single
+// atomic load per phase; the on-state cost is roughly +4–10µs per
+// transaction at typical rulesets.
+//
+// For a running WAF, prefer WAFEnablePerRuleTiming to flip the flag
+// without a rebuild.
+//
+// This API is experimental and may change before Coraza v4.
+func WAFConfigWithPerRuleTiming(cfg coraza.WAFConfig, enabled bool) coraza.WAFConfig {
+	if c, ok := cfg.(wafConfigWithPerRuleTiming); ok {
+		return c.WithPerRuleTiming(enabled)
+	}
+	return cfg
+}
+
+// wafWithPerRuleTimingToggle is the private capability interface for
+// flipping per-rule timing on a live WAF.
+type wafWithPerRuleTimingToggle interface {
+	SetPerRuleTimingEnabled(bool)
+}
+
+// WAFEnablePerRuleTiming toggles per-rule timing on a running WAF. Returns
+// true when the operation was honoured, false when the WAF implementation
+// does not support runtime telemetry toggles (e.g. a third-party WAF).
+//
+// Safe to call concurrently with active transactions; the change is
+// observed on the next rule-evaluation loop.
+//
+// Typical usage: flip on when investigating a p99 spike, flip off when
+// done. Leaving it on continuously is not recommended.
+//
+// This API is experimental and may change before Coraza v4.
+func WAFEnablePerRuleTiming(waf coraza.WAF, enabled bool) bool {
+	if w, ok := waf.(wafWithPerRuleTimingToggle); ok {
+		w.SetPerRuleTimingEnabled(enabled)
+		return true
+	}
+	return false
+}
+
+// NoopTelemetrySink returns a plugintypes.TelemetrySink that discards every
+// event.
+//
+// The engine already treats a nil sink as "no telemetry" for free, so this
+// factory exists only for callers that prefer an explicit non-nil sink —
+// typically tests or configuration-plumbing code where a nil assignment is
+// ambiguous. In production, pass nil.
+func NoopTelemetrySink() plugintypes.TelemetrySink {
+	return noopSink{}
+}
+
+type noopSink struct{}
+
+// Bodies contain a single statement so the coverage tool counts them when
+// invoked; an empty body is reported as 0/0 which some dashboards treat as
+// uncovered.
+func (noopSink) OnEngineReady(ev plugintypes.EngineReadyEvent) { _ = ev }
+func (noopSink) OnTransaction(ev plugintypes.TransactionEvent) { _ = ev }
+func (noopSink) OnRuleMatch(ev plugintypes.RuleMatchEvent)     { _ = ev }
+func (noopSink) OnEngineError(ev plugintypes.EngineEvent)      { _ = ev }

--- a/experimental/telemetry_sink_bench_test.go
+++ b/experimental/telemetry_sink_bench_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package experimental_test
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+)
+
+// countingSink increments counters per method without touching any mutex
+// or I/O — upper bound on the cost of a well-written sink that only reads
+// event fields.
+type countingSink struct {
+	tx, match, err, ready int
+}
+
+func (s *countingSink) OnEngineReady(plugintypes.EngineReadyEvent) { s.ready++ }
+func (s *countingSink) OnTransaction(plugintypes.TransactionEvent) { s.tx++ }
+func (s *countingSink) OnRuleMatch(plugintypes.RuleMatchEvent)     { s.match++ }
+func (s *countingSink) OnEngineError(plugintypes.EngineEvent)      { s.err++ }
+
+// timedSink also implements RuleTimingSink so the per-rule benchmark can
+// exercise the full hot path.
+type timedSink struct {
+	countingSink
+	timings int
+}
+
+func (s *timedSink) OnRuleTimed(plugintypes.RuleTimingEvent) { s.timings++ }
+
+func newBenchWAF(b *testing.B, sink plugintypes.TelemetrySink) coraza.WAF {
+	b.Helper()
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+		SecRule REQUEST_HEADERS "@rx .*" "id:2,phase:1,pass,nolog"
+	`)
+	if sink != nil {
+		cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	}
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return waf
+}
+
+func runBenchTransaction(waf coraza.WAF) {
+	tx := waf.NewTransaction()
+	tx.ProcessConnection("127.0.0.1", 0, "127.0.0.1", 80)
+	tx.ProcessURI("/", "GET", "HTTP/1.1")
+	tx.AddRequestHeader("Host", "example.com")
+	tx.ProcessRequestHeaders()
+	tx.ProcessLogging()
+	_ = tx.Close()
+}
+
+// BenchmarkTelemetry_NoSink measures the baseline: engine runs with a nil
+// TelemetrySink. Hot-path cost per event is a single nil-check.
+func BenchmarkTelemetry_NoSink(b *testing.B) {
+	waf := newBenchWAF(b, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchTransaction(waf)
+	}
+}
+
+// BenchmarkTelemetry_NoopSink measures the cost with a non-nil sink whose
+// methods are empty bodies. Difference vs _NoSink isolates the cost of
+// dispatching through the interface and building event structs.
+func BenchmarkTelemetry_NoopSink(b *testing.B) {
+	waf := newBenchWAF(b, experimental.NoopTelemetrySink())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchTransaction(waf)
+	}
+}
+
+// BenchmarkTelemetry_CountingSink exercises a sink that actually reads
+// event fields but does no I/O. Upper bound on the cost of a well-written
+// in-process metrics sink.
+func BenchmarkTelemetry_CountingSink(b *testing.B) {
+	waf := newBenchWAF(b, &countingSink{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchTransaction(waf)
+	}
+}
+
+// BenchmarkTelemetry_PerRuleTimingOff measures the off-state overhead of
+// per-rule timing when a RuleTimingSink is wired but the flag is false.
+// The hot-path cost is a single atomic load plus a cached nil check per
+// phase — must stay within noise of the plain counting sink.
+func BenchmarkTelemetry_PerRuleTimingOff(b *testing.B) {
+	waf := newBenchWAFWithTiming(b, &timedSink{}, false)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchTransaction(waf)
+	}
+}
+
+// BenchmarkTelemetry_PerRuleTimingOn measures the on-state cost. Each rule
+// evaluated pays two time.Now() calls plus one interface dispatch.
+func BenchmarkTelemetry_PerRuleTimingOn(b *testing.B) {
+	waf := newBenchWAFWithTiming(b, &timedSink{}, true)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchTransaction(waf)
+	}
+}
+
+func newBenchWAFWithTiming(b *testing.B, sink plugintypes.TelemetrySink, timingOn bool) coraza.WAF {
+	b.Helper()
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+		SecRule REQUEST_HEADERS "@rx .*" "id:2,phase:1,pass,nolog"
+	`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	cfg = experimental.WAFConfigWithPerRuleTiming(cfg, timingOn)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return waf
+}

--- a/experimental/telemetry_sink_test.go
+++ b/experimental/telemetry_sink_test.go
@@ -1,0 +1,698 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package experimental_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+// recordingSink captures every event the engine fires, in order. It also
+// implements plugintypes.RuleTimingSink so tests can inspect per-rule
+// timing events when enabled.
+type recordingSink struct {
+	mu           sync.Mutex
+	readyEvents  []plugintypes.EngineReadyEvent
+	transactions []plugintypes.TransactionEvent
+	matches      []plugintypes.RuleMatchEvent
+	errors       []plugintypes.EngineEvent
+	timings      []plugintypes.RuleTimingEvent
+}
+
+func (s *recordingSink) OnRuleTimed(ev plugintypes.RuleTimingEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.timings = append(s.timings, ev)
+}
+
+func (s *recordingSink) OnEngineReady(ev plugintypes.EngineReadyEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readyEvents = append(s.readyEvents, ev)
+}
+
+func (s *recordingSink) OnTransaction(ev plugintypes.TransactionEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.transactions = append(s.transactions, ev)
+}
+
+func (s *recordingSink) OnRuleMatch(ev plugintypes.RuleMatchEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.matches = append(s.matches, ev)
+}
+
+func (s *recordingSink) OnEngineError(ev plugintypes.EngineEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errors = append(s.errors, ev)
+}
+
+// runAllPhases walks a transaction through every lifecycle point exactly once
+// with the given directives loaded into the WAF. The bodyText is provided to
+// request and response body phases.
+func runAllPhases(t *testing.T, directives, bodyText string, sink plugintypes.TelemetrySink) {
+	t.Helper()
+	cfg := coraza.NewWAFConfig().
+		WithDirectives(directives).
+		WithRequestBodyAccess().
+		WithResponseBodyAccess().
+		WithResponseBodyMimeTypes([]string{"text/plain"})
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+
+	tx := waf.NewTransaction()
+	defer func() { _ = tx.Close() }()
+
+	tx.ProcessConnection("127.0.0.1", 12345, "127.0.0.1", 80)
+	tx.ProcessURI("/test", "POST", "HTTP/1.1")
+	tx.AddRequestHeader("Host", "example.com")
+	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+	if it := tx.ProcessRequestHeaders(); it != nil {
+		// Short-circuit on early interruption; later phases must not run.
+		tx.ProcessLogging()
+		return
+	}
+	if _, _, err := tx.WriteRequestBody([]byte(bodyText)); err != nil {
+		t.Fatalf("write req body: %v", err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatalf("process req body: %v", err)
+	}
+	tx.AddResponseHeader("Content-Type", "text/plain")
+	if it := tx.ProcessResponseHeaders(200, "HTTP/1.1"); it != nil {
+		tx.ProcessLogging()
+		return
+	}
+	if _, _, err := tx.WriteResponseBody([]byte(bodyText)); err != nil {
+		t.Fatalf("write resp body: %v", err)
+	}
+	if _, err := tx.ProcessResponseBody(); err != nil {
+		t.Fatalf("process resp body: %v", err)
+	}
+	tx.ProcessLogging()
+}
+
+// TestTelemetrySink_FullLifecycle: for a clean transaction, expect one
+// EngineReady, one Start, one PhaseEnd per phase (1..5), and one Finish.
+// Also asserts phase durations are non-negative and at least one is > 0.
+func TestTelemetrySink_FullLifecycle(t *testing.T) {
+	sink := &recordingSink{}
+	// Load a rule so phases do non-trivial work; empty phases can finish in
+	// under a nanosecond on fast hardware and give PhaseDuration=0.
+	runAllPhases(t, `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+	`, "hello", sink)
+
+	if len(sink.readyEvents) != 1 {
+		t.Fatalf("want 1 EngineReady, got %d", len(sink.readyEvents))
+	}
+	if sink.readyEvents[0].InitDuration <= 0 {
+		t.Errorf("EngineReady duration must be > 0, got %v", sink.readyEvents[0].InitDuration)
+	}
+	if len(sink.transactions) < 7 {
+		t.Fatalf("want >=7 transaction events, got %d", len(sink.transactions))
+	}
+	if sink.transactions[0].Kind != plugintypes.TransactionEventStart {
+		t.Fatalf("first event is not Start: %v", sink.transactions[0].Kind)
+	}
+	last := sink.transactions[len(sink.transactions)-1]
+	if last.Kind != plugintypes.TransactionEventFinish {
+		t.Fatalf("last event is not Finish: %v", last.Kind)
+	}
+	// All five phases emitted exactly once, duration non-negative, at least
+	// one phase > 0 ns.
+	seen := map[types.RulePhase]int{}
+	var sawNonZero bool
+	for _, ev := range sink.transactions {
+		if ev.Kind != plugintypes.TransactionEventPhaseEnd {
+			continue
+		}
+		seen[ev.Phase]++
+		if ev.PhaseDuration < 0 {
+			t.Errorf("phase %d negative duration", ev.Phase)
+		}
+		if ev.PhaseDuration > 0 {
+			sawNonZero = true
+		}
+	}
+	for p := types.PhaseRequestHeaders; p <= types.PhaseLogging; p++ {
+		if seen[p] != 1 {
+			t.Errorf("phase %d fired %d times, want 1", p, seen[p])
+		}
+	}
+	if !sawNonZero {
+		t.Error("no phase reported non-zero duration")
+	}
+	// Contexts + tx ids propagated.
+	for i, ev := range sink.transactions {
+		if ev.Context == nil {
+			t.Errorf("event[%d] has nil context", i)
+		}
+		if ev.TransactionID == "" {
+			t.Errorf("event[%d] missing tx_id", i)
+		}
+	}
+}
+
+// TestTelemetrySink_RuleMatchFires: a disruptive rule matches — expect a
+// RuleMatch event with Disruptive=true.
+func TestTelemetrySink_RuleMatchFires(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@contains /test" "id:9001,phase:1,deny,status:403,severity:CRITICAL,tag:sqli"
+	`
+	runAllPhases(t, directives, "", sink)
+
+	if len(sink.matches) != 1 {
+		t.Fatalf("want 1 rule match, got %d", len(sink.matches))
+	}
+	m := sink.matches[0]
+	if m.Rule.ID() != 9001 {
+		t.Fatalf("rule id = %d", m.Rule.ID())
+	}
+	if m.Action != "deny" {
+		t.Fatalf("match action = %q, want deny", m.Action)
+	}
+	if !m.Enforced {
+		t.Fatalf("match must be enforced in RuleEngine=On")
+	}
+	if m.Phase != types.PhaseRequestHeaders {
+		t.Fatalf("phase = %v", m.Phase)
+	}
+	if m.Context == nil {
+		t.Fatalf("match context must not be nil")
+	}
+	// Finish event should report blocked decision via an interruption.
+	last := sink.transactions[len(sink.transactions)-1]
+	if last.Kind != plugintypes.TransactionEventFinish {
+		t.Fatalf("last event is not Finish")
+	}
+	if last.Interruption == nil {
+		t.Fatalf("finish event should carry interruption for blocked tx")
+	}
+	if last.Interruption.RuleID != 9001 {
+		t.Fatalf("interruption rule id = %d", last.Interruption.RuleID)
+	}
+}
+
+// TestTelemetrySink_MultipleMatchesNoBlock: two matching pass,log rules
+// produce two match events with Action="pass" and the transaction finishes
+// without an interruption. Operator-facing metrics should count blocks as
+// Action="deny|drop|redirect" AND Enforced=true, and log-only or pass
+// matches by their action label.
+func TestTelemetrySink_MultipleMatchesNoBlock(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@contains /test" "id:1,phase:1,pass,log,severity:WARNING"
+		SecRule REQUEST_METHOD "@streq POST" "id:2,phase:1,pass,log,severity:NOTICE"
+	`
+	runAllPhases(t, directives, "", sink)
+
+	if len(sink.matches) != 2 {
+		t.Fatalf("want 2 matches, got %d", len(sink.matches))
+	}
+	for i, m := range sink.matches {
+		if m.Action != "pass" {
+			t.Errorf("match[%d] action = %q, want pass", i, m.Action)
+		}
+	}
+	// Transaction must finish with decision=allowed (no interruption).
+	last := sink.transactions[len(sink.transactions)-1]
+	if last.Interruption != nil {
+		t.Fatalf("finish event should not carry interruption for allowed tx: %+v", last.Interruption)
+	}
+}
+
+// TestTelemetrySink_DetectionOnlyMode: a deny rule under DetectionOnly must
+// produce a match event with Disruptive=false (the engine is not
+// enforcing) and the transaction must finish without interruption.
+func TestTelemetrySink_DetectionOnlyMode(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine DetectionOnly
+		SecRule REQUEST_URI "@contains /test" "id:1,phase:1,deny,status:403,severity:CRITICAL"
+	`
+	runAllPhases(t, directives, "", sink)
+
+	if len(sink.matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(sink.matches))
+	}
+	if sink.matches[0].Enforced {
+		t.Fatalf("DetectionOnly match must report Enforced=false")
+	}
+	if sink.matches[0].Action != "deny" {
+		t.Fatalf("DetectionOnly match should still carry Action=deny, got %q", sink.matches[0].Action)
+	}
+	last := sink.transactions[len(sink.transactions)-1]
+	if last.Interruption != nil {
+		t.Fatalf("DetectionOnly must not actually interrupt")
+	}
+}
+
+// TestTelemetrySink_NilShimReturnsInputConfig: passing a non-wafConfig
+// returns the input unchanged (third-party config implementations are not
+// mutated).
+func TestTelemetrySink_NilShimReturnsInputConfig(t *testing.T) {
+	type fakeCfg struct{ coraza.WAFConfig }
+	input := fakeCfg{}
+	got := experimental.WAFConfigWithTelemetrySink(input, nil)
+	if got != input {
+		t.Fatalf("shim must return input unchanged for unsupported config types")
+	}
+}
+
+// TestTelemetrySink_PerRuleTimingShims_Fallback: the timing shims also
+// degrade gracefully when handed a third-party WAFConfig / WAF that
+// doesn't implement the private capability interfaces.
+func TestTelemetrySink_PerRuleTimingShims_Fallback(t *testing.T) {
+	type fakeCfg struct{ coraza.WAFConfig }
+	cfgIn := fakeCfg{}
+	if got := experimental.WAFConfigWithPerRuleTiming(cfgIn, true); got != cfgIn {
+		t.Fatalf("config shim must return input unchanged for unsupported types")
+	}
+
+	type fakeWAF struct{ coraza.WAF }
+	wafIn := fakeWAF{}
+	if experimental.WAFEnablePerRuleTiming(wafIn, true) {
+		t.Fatalf("waf shim must return false for unsupported types")
+	}
+}
+
+// TestTelemetrySink_BodyProcessorError: an invalid body processor triggers
+// an engine.error event.
+func TestTelemetrySink_BodyProcessorError(t *testing.T) {
+	sink := &recordingSink{}
+	// ctl:requestBodyProcessor=INVALID is ignored silently unless the
+	// processor is invoked; force invocation by providing a body.
+	directives := `
+		SecRuleEngine On
+		SecRequestBodyAccess On
+		SecRule REQUEST_URI "@rx .*" "id:42,phase:1,pass,ctl:requestBodyProcessor=invalid-proc"
+	`
+	runAllPhases(t, directives, "data", sink)
+
+	var found bool
+	for _, e := range sink.errors {
+		if e.Kind == plugintypes.EngineEventBodyProcessor {
+			found = true
+			if !strings.Contains(e.Message, "request body processor failed") {
+				t.Errorf("unexpected msg: %q", e.Message)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected body_processor engine.error, got %+v", sink.errors)
+	}
+}
+
+// TestTelemetrySink_NilSinkIsAccepted exercises every emit helper's nil-sink
+// short-circuit: rule matches, body processor errors, and all transaction
+// events must be absorbed without panic or allocation when sink is nil.
+func TestTelemetrySink_NilSinkIsAccepted(t *testing.T) {
+	cfg := coraza.NewWAFConfig().
+		WithDirectives(`
+			SecRuleEngine On
+			SecRequestBodyAccess On
+			SecRule REQUEST_URI "@contains /" "id:1,phase:1,pass,log,ctl:requestBodyProcessor=invalid-proc"
+		`).
+		WithRequestBodyAccess()
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, nil)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/", "POST", "HTTP/1.1")
+	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+	tx.ProcessRequestHeaders()
+	if _, _, err := tx.WriteRequestBody([]byte("data")); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatalf("process body: %v", err)
+	}
+	tx.ProcessLogging()
+	if err := tx.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// TestTelemetrySink_BodyTruncated: exceeding SecRequestBodyLimit emits an
+// engine.error of kind body_truncated. Operators use this to tune limits.
+func TestTelemetrySink_BodyTruncated(t *testing.T) {
+	sink := &recordingSink{}
+	cfg := coraza.NewWAFConfig().
+		WithDirectives(`
+			SecRuleEngine On
+			SecRequestBodyAccess On
+			SecRequestBodyLimit 16
+			SecRequestBodyLimitAction Reject
+		`).
+		WithRequestBodyAccess().
+		WithRequestBodyLimit(16)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/", "POST", "HTTP/1.1")
+	tx.AddRequestHeader("Content-Type", "application/x-www-form-urlencoded")
+	tx.ProcessRequestHeaders()
+	// Write more than the 16-byte limit.
+	if _, _, err := tx.WriteRequestBody([]byte("a=veryLongValueBeyondTheLimit")); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	tx.ProcessLogging()
+	_ = tx.Close()
+
+	var found bool
+	for _, e := range sink.errors {
+		if e.Kind == plugintypes.EngineEventBodyTruncated {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected body_truncated engine.error, got %+v", sink.errors)
+	}
+}
+
+// TestTelemetrySink_RulesEvaluatedCount: PhaseEnd events report how many
+// rules actually ran in each phase. Uses phase-1-only rules so the result
+// is insensitive to the coraza.rule.multiphase_evaluation build tag, which
+// can re-run rules across inferred phases.
+func TestTelemetrySink_RulesEvaluatedCount(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+		SecRule REQUEST_HEADERS "@rx .*" "id:2,phase:1,pass,nolog"
+	`
+	runAllPhases(t, directives, "x", sink)
+
+	byPhase := map[types.RulePhase]int{}
+	for _, ev := range sink.transactions {
+		if ev.Kind == plugintypes.TransactionEventPhaseEnd {
+			byPhase[ev.Phase] = ev.RulesEvaluated
+		}
+	}
+	if byPhase[types.PhaseRequestHeaders] != 2 {
+		t.Errorf("phase 1 rules_evaluated = %d, want 2", byPhase[types.PhaseRequestHeaders])
+	}
+	// Phases 2..5 have no rules configured; multiphase may still re-run
+	// phase-1 rules in phase 2, so we only assert the primary phase.
+}
+
+// TestTelemetrySink_EngineReadyReportsRuleCount: OnEngineReady surfaces the
+// loaded rule count so operators can alert on config-reload surprises.
+func TestTelemetrySink_EngineReadyReportsRuleCount(t *testing.T) {
+	sink := &recordingSink{}
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:100,phase:1,pass,nolog"
+		SecRule REQUEST_URI "@rx .*" "id:101,phase:1,pass,nolog"
+		SecRule REQUEST_URI "@rx .*" "id:102,phase:1,pass,nolog"
+	`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	if _, err := coraza.NewWAF(cfg); err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	if len(sink.readyEvents) != 1 {
+		t.Fatalf("want 1 EngineReady, got %d", len(sink.readyEvents))
+	}
+	if got := sink.readyEvents[0].RulesLoaded; got != 3 {
+		t.Errorf("RulesLoaded = %d, want 3", got)
+	}
+}
+
+// TestTelemetrySink_PerRuleTiming_OffByDefault: no RuleTimingEvents are
+// emitted unless the flag is explicitly enabled.
+func TestTelemetrySink_PerRuleTiming_OffByDefault(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+		SecRule REQUEST_HEADERS "@rx .*" "id:2,phase:1,pass,nolog"
+	`
+	runAllPhases(t, directives, "", sink)
+	if len(sink.timings) != 0 {
+		t.Fatalf("per-rule timing must default off: got %d events", len(sink.timings))
+	}
+}
+
+// TestTelemetrySink_PerRuleTiming_EmitsPerRule: when enabled at startup,
+// each evaluated rule fires a RuleTimingEvent. Uses phase-1-only rules so
+// the assertion is insensitive to coraza.rule.multiphase_evaluation, which
+// can legitimately re-evaluate rules in later phases.
+func TestTelemetrySink_PerRuleTiming_EmitsPerRule(t *testing.T) {
+	sink := &recordingSink{}
+	directives := `
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+		SecRule REQUEST_HEADERS "@rx .*" "id:2,phase:1,pass,nolog"
+	`
+	cfg := coraza.NewWAFConfig().WithDirectives(directives)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	cfg = experimental.WAFConfigWithPerRuleTiming(cfg, true)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/x", "GET", "HTTP/1.1")
+	tx.AddRequestHeader("Host", "example.com")
+	tx.ProcessRequestHeaders()
+	tx.ProcessLogging()
+	_ = tx.Close()
+
+	// Phase 1 has 2 rules. Both must have timed at least once.
+	if len(sink.timings) < 2 {
+		t.Fatalf("want >=2 timing events, got %d", len(sink.timings))
+	}
+	seen := map[int]bool{}
+	for i, ev := range sink.timings {
+		if ev.Duration < 0 {
+			t.Errorf("event[%d] negative duration", i)
+		}
+		if ev.Rule == nil {
+			t.Fatalf("event[%d] has nil rule", i)
+		}
+		seen[ev.Rule.ID()] = true
+	}
+	if !seen[1] || !seen[2] {
+		t.Errorf("expected timing events for rule 1 and 2, saw %v", seen)
+	}
+}
+
+// TestTelemetrySink_PerRuleTiming_RuntimeToggle: flipping the flag on a
+// running WAF starts emission; flipping it off stops emission.
+func TestTelemetrySink_PerRuleTiming_RuntimeToggle(t *testing.T) {
+	sink := &recordingSink{}
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+	`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	// Initial: off.
+	runTx := func() {
+		tx := waf.NewTransaction()
+		tx.ProcessURI("/", "GET", "HTTP/1.1")
+		tx.ProcessRequestHeaders()
+		tx.ProcessLogging()
+		_ = tx.Close()
+	}
+	runTx()
+	if len(sink.timings) != 0 {
+		t.Fatalf("pre-toggle: expected 0 timings, got %d", len(sink.timings))
+	}
+
+	// Flip on.
+	if !experimental.WAFEnablePerRuleTiming(waf, true) {
+		t.Fatal("WAF must support runtime toggle")
+	}
+	runTx()
+	if len(sink.timings) != 1 {
+		t.Fatalf("after on: expected 1 timing, got %d", len(sink.timings))
+	}
+
+	// Flip off.
+	experimental.WAFEnablePerRuleTiming(waf, false)
+	runTx()
+	if len(sink.timings) != 1 {
+		t.Fatalf("after off: expected still 1 timing, got %d", len(sink.timings))
+	}
+}
+
+// TestTelemetrySink_PerRuleTimingEnabled_Reader: the runtime toggle has a
+// sibling getter on the WAF so operators can query current state.
+func TestTelemetrySink_PerRuleTimingEnabled_Reader(t *testing.T) {
+	type wafWithReader interface {
+		PerRuleTimingEnabled() bool
+	}
+	cfg := coraza.NewWAFConfig().WithDirectives(`SecRuleEngine On`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, &recordingSink{})
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, ok := waf.(wafWithReader)
+	if !ok {
+		t.Skip("WAF does not expose PerRuleTimingEnabled reader")
+	}
+	if reader.PerRuleTimingEnabled() {
+		t.Errorf("default must be false")
+	}
+	experimental.WAFEnablePerRuleTiming(waf, true)
+	if !reader.PerRuleTimingEnabled() {
+		t.Errorf("after enable, must be true")
+	}
+	experimental.WAFEnablePerRuleTiming(waf, false)
+	if reader.PerRuleTimingEnabled() {
+		t.Errorf("after disable, must be false")
+	}
+}
+
+// TestTelemetrySink_PerRuleTiming_IgnoredWhenSinkMissingExtension: a sink
+// that implements TelemetrySink but NOT RuleTimingSink must not cause
+// panics or errors when the flag is on — the engine simply drops the
+// would-be timing events.
+func TestTelemetrySink_PerRuleTiming_IgnoredWhenSinkMissingExtension(t *testing.T) {
+	sink := &basicOnlySink{}
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+	`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	cfg = experimental.WAFConfigWithPerRuleTiming(cfg, true)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/", "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	tx.ProcessLogging()
+	_ = tx.Close()
+	// No panic is the assertion.
+}
+
+// basicOnlySink implements TelemetrySink but NOT RuleTimingSink.
+type basicOnlySink struct{}
+
+func (*basicOnlySink) OnEngineReady(plugintypes.EngineReadyEvent) {}
+func (*basicOnlySink) OnTransaction(plugintypes.TransactionEvent) {}
+func (*basicOnlySink) OnRuleMatch(plugintypes.RuleMatchEvent)     {}
+func (*basicOnlySink) OnEngineError(plugintypes.EngineEvent)      {}
+
+// TestNoopTelemetrySink: the factory returns a sink that satisfies the
+// interface and whose methods are safe to call with zero-value events.
+// Also exercised indirectly by TestTelemetrySink_PerRuleTiming_NoopSink
+// below to confirm the engine accepts it end-to-end.
+func TestNoopTelemetrySink(t *testing.T) {
+	// Factory's return type is plugintypes.TelemetrySink; calling all four
+	// methods with zero-value events must not panic.
+	s := experimental.NoopTelemetrySink()
+	s.OnEngineReady(plugintypes.EngineReadyEvent{})
+	s.OnTransaction(plugintypes.TransactionEvent{})
+	s.OnRuleMatch(plugintypes.RuleMatchEvent{})
+	s.OnEngineError(plugintypes.EngineEvent{})
+}
+
+// TestTelemetrySink_PerRuleTiming_NoopSink wires the Noop sink through the
+// full engine path with per-rule timing enabled. Since Noop does not
+// implement RuleTimingSink, the engine short-circuits rule-timing emission
+// and never panics.
+func TestTelemetrySink_PerRuleTiming_NoopSink(t *testing.T) {
+	cfg := coraza.NewWAFConfig().WithDirectives(`
+		SecRuleEngine On
+		SecRule REQUEST_URI "@rx .*" "id:1,phase:1,pass,nolog"
+	`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, experimental.NoopTelemetrySink())
+	cfg = experimental.WAFConfigWithPerRuleTiming(cfg, true)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/", "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	tx.ProcessLogging()
+	_ = tx.Close()
+}
+
+// TestEventKind_Strings exercises the String() methods on the event-kind
+// enums and types.RulePhase, including every "unknown" default branch.
+func TestEventKind_Strings(t *testing.T) {
+	cases := []struct {
+		got, want string
+	}{
+		{plugintypes.TransactionEventStart.String(), "start"},
+		{plugintypes.TransactionEventPhaseEnd.String(), "phase_end"},
+		{plugintypes.TransactionEventFinish.String(), "finish"},
+		{plugintypes.TransactionEventKind(0).String(), "unknown"},
+		{plugintypes.EngineEventInit.String(), "init"},
+		{plugintypes.EngineEventParse.String(), "parse"},
+		{plugintypes.EngineEventBodyProcessor.String(), "body_processor"},
+		{plugintypes.EngineEventBodyTruncated.String(), "body_truncated"},
+		{plugintypes.EngineEventTransaction.String(), "transaction"},
+		{plugintypes.EngineEventKind(0).String(), "unknown"},
+		{types.PhaseRequestHeaders.String(), "request_headers"},
+		{types.PhaseRequestBody.String(), "request_body"},
+		{types.PhaseResponseHeaders.String(), "response_headers"},
+		{types.PhaseResponseBody.String(), "response_body"},
+		{types.PhaseLogging.String(), "logging"},
+		{types.PhaseUnknown.String(), "unknown"},
+	}
+	for i, c := range cases {
+		if c.got != c.want {
+			t.Errorf("case %d: got %q, want %q", i, c.got, c.want)
+		}
+	}
+}
+
+// TestTelemetrySink_ContextPropagation: if the caller creates a transaction
+// with a specific context, that context must surface in every tx event. This
+// is the APM span-chaining contract.
+func TestTelemetrySink_ContextPropagation(t *testing.T) {
+	sink := &recordingSink{}
+	cfg := coraza.NewWAFConfig().WithDirectives(`SecRuleEngine On`)
+	cfg = experimental.WAFConfigWithTelemetrySink(cfg, sink)
+	waf, err := coraza.NewWAF(cfg)
+	if err != nil {
+		t.Fatalf("new waf: %v", err)
+	}
+	tx := waf.NewTransactionWithID("my-request-id")
+	tx.ProcessURI("/", "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	tx.ProcessLogging()
+	_ = tx.Close()
+
+	if len(sink.transactions) == 0 {
+		t.Fatal("no transaction events recorded")
+	}
+	for _, ev := range sink.transactions {
+		if ev.TransactionID != "my-request-id" {
+			t.Errorf("tx id mismatch: %s", ev.TransactionID)
+		}
+	}
+}

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -160,6 +160,10 @@ func (rg *RuleGroup) Eval(phase types.RulePhase, tx *Transaction) bool {
 	tx.lastPhase = phase
 	usedRules := 0
 	ts := time.Now().UnixNano()
+	// Load the per-rule timing gate once per phase. When off, the only
+	// hot-path cost is this single atomic load + branch; the inner loop
+	// stays identical to the no-telemetry baseline.
+	perRuleTiming := tx.WAF.perRuleTimingEnabled.Load() && tx.WAF.ruleTimingSink != nil
 	transformationCache := tx.transformationCache
 	for k := range transformationCache {
 		delete(transformationCache, k)
@@ -258,7 +262,17 @@ RulesLoop:
 			tx.variables.matchedVars.Reset()
 		}
 
-		r.Evaluate(phase, tx, transformationCache)
+		if perRuleTiming {
+			ruleStart := time.Now().UnixNano()
+			matchCountBefore := len(tx.matchedRules)
+			r.Evaluate(phase, tx, transformationCache)
+			tx.emitRuleTimed(r,
+				time.Duration(time.Now().UnixNano()-ruleStart),
+				len(tx.matchedRules) > matchCountBefore,
+			)
+		} else {
+			r.Evaluate(phase, tx, transformationCache)
+		}
 		tx.Capture = false // we reset captures
 		usedRules++
 	}
@@ -275,7 +289,9 @@ RulesLoop:
 	// Reset Skip counter at the end of each phase. Skip actions work only within the current processing phase
 	tx.Skip = 0
 
-	tx.stopWatches[phase] = time.Now().UnixNano() - ts
+	elapsed := time.Now().UnixNano() - ts
+	tx.stopWatches[phase] = elapsed
+	tx.emitPhaseEnd(phase, time.Duration(elapsed), usedRules)
 	return tx.IsInterrupted()
 }
 

--- a/internal/corazawaf/telemetry.go
+++ b/internal/corazawaf/telemetry.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package corazawaf
+
+import (
+	"time"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+// The helpers in this file centralize telemetry emission. They all return
+// immediately when no sink is configured, so the hot path pays only a nil
+// pointer comparison per event.
+
+// SetTelemetrySink attaches a sink to the WAF and caches the optional
+// RuleTimingSink interface assertion so the hot path doesn't pay for it
+// on every rule evaluation.
+//
+// Thread-safety: this method is NOT safe to call concurrently with active
+// transactions. It writes two plain fields (TelemetrySink and
+// ruleTimingSink) that the hot path reads without synchronization; a
+// runtime swap would be a data race. Callers must invoke SetTelemetrySink
+// before the WAF is handed to any transaction — which is exactly how
+// coraza.NewWAF wires it. Use the runtime-togglable
+// SetPerRuleTimingEnabled if you need to change behaviour on a live WAF.
+func (w *WAF) SetTelemetrySink(sink plugintypes.TelemetrySink) {
+	w.TelemetrySink = sink
+	if rt, ok := sink.(plugintypes.RuleTimingSink); ok {
+		w.ruleTimingSink = rt
+	} else {
+		w.ruleTimingSink = nil
+	}
+}
+
+// SetPerRuleTimingEnabled toggles per-rule timing emission at runtime.
+// Safe to call concurrently with transaction evaluation; the change is
+// observed on the next rule-loop iteration.
+func (w *WAF) SetPerRuleTimingEnabled(enabled bool) {
+	w.perRuleTimingEnabled.Store(enabled)
+}
+
+// PerRuleTimingEnabled reports whether per-rule timing is currently active.
+func (w *WAF) PerRuleTimingEnabled() bool {
+	return w.perRuleTimingEnabled.Load()
+}
+
+// emitRuleTimed fires a RuleTimingEvent. Callers (rulegroup.Eval) must have
+// verified that emission should occur by checking the cached
+// tx.WAF.ruleTimingSink pointer against nil — this helper trusts them and
+// skips the redundant nil check.
+func (tx *Transaction) emitRuleTimed(r *Rule, duration time.Duration, matched bool) {
+	tx.WAF.ruleTimingSink.OnRuleTimed(plugintypes.RuleTimingEvent{
+		TransactionID: tx.id,
+		Rule:          &r.RuleMetadata,
+		Phase:         tx.lastPhase,
+		Duration:      duration,
+		Matched:       matched,
+	})
+}
+
+// emitTransactionStart emits a TransactionEventStart event for the receiver.
+func (tx *Transaction) emitTransactionStart() {
+	sink := tx.WAF.TelemetrySink
+	if sink == nil {
+		return
+	}
+	sink.OnTransaction(plugintypes.TransactionEvent{
+		Kind:          plugintypes.TransactionEventStart,
+		TransactionID: tx.id,
+		Context:       tx.context,
+	})
+}
+
+// emitPhaseEnd emits a TransactionEventPhaseEnd event carrying the duration
+// spent in the phase, the number of rules that actually ran, and the
+// current interruption (if any).
+func (tx *Transaction) emitPhaseEnd(phase types.RulePhase, duration time.Duration, rulesEvaluated int) {
+	sink := tx.WAF.TelemetrySink
+	if sink == nil {
+		return
+	}
+	sink.OnTransaction(plugintypes.TransactionEvent{
+		Kind:           plugintypes.TransactionEventPhaseEnd,
+		TransactionID:  tx.id,
+		Context:        tx.context,
+		Phase:          phase,
+		PhaseDuration:  duration,
+		RulesEvaluated: rulesEvaluated,
+		Interruption:   tx.interruption,
+	})
+}
+
+// emitTransactionFinish emits a TransactionEventFinish event. It is called
+// from Transaction.Close before the transaction is returned to the pool.
+func (tx *Transaction) emitTransactionFinish() {
+	sink := tx.WAF.TelemetrySink
+	if sink == nil {
+		return
+	}
+	sink.OnTransaction(plugintypes.TransactionEvent{
+		Kind:          plugintypes.TransactionEventFinish,
+		TransactionID: tx.id,
+		Context:       tx.context,
+		Interruption:  tx.interruption,
+	})
+}
+
+// emitRuleMatch emits a RuleMatchEvent synchronously after a rule match has
+// been recorded. The event carries the rule metadata, the configured
+// disruptive action name (if any), whether it was enforced, and the
+// matched-data slice. Sinks that log matched data are responsible for
+// redaction and truncation.
+func (tx *Transaction) emitRuleMatch(r *Rule, action string, enforced bool, mds []types.MatchData) {
+	sink := tx.WAF.TelemetrySink
+	if sink == nil {
+		return
+	}
+	sink.OnRuleMatch(plugintypes.RuleMatchEvent{
+		TransactionID: tx.id,
+		Context:       tx.context,
+		Rule:          &r.RuleMetadata,
+		Phase:         tx.lastPhase,
+		Action:        action,
+		Enforced:      enforced,
+		Data:          mds,
+	})
+}
+
+// emitEngineError emits an EngineEvent for transaction-scoped engine
+// failures. It is a transaction-bound helper so the transaction context is
+// always set.
+func (tx *Transaction) emitEngineError(kind plugintypes.EngineEventKind, err error, msg string) {
+	sink := tx.WAF.TelemetrySink
+	if sink == nil {
+		return
+	}
+	sink.OnEngineError(plugintypes.EngineEvent{
+		Kind:          kind,
+		TransactionID: tx.id,
+		Phase:         tx.lastPhase,
+		Err:           err,
+		Message:       msg,
+	})
+}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -581,12 +581,14 @@ func (tx *Transaction) MatchRule(r *Rule, mds []types.MatchData) {
 	// The Disruptive_ boolean still allows to identify actual disruptions from "potential" disruptions.
 	// Disruptive_ field is also used during logging to print different messages if the disruption has been real or not
 	// so it is important to set it according to the RuleEngine mode.
+	var actionName string
 	for _, a := range r.actions {
 		// There can be only one disruptive action per rule
 		if a.Function.Type() == plugintypes.ActionTypeDisruptive {
 			// if not found it will default to DisruptiveActionUnknown.
 			mr.DisruptiveAction_ = corazarules.DisruptiveActionMap[a.Name]
 			mr.Disruptive_ = tx.RuleEngine == types.RuleEngineOn
+			actionName = a.Name
 			break
 		}
 	}
@@ -604,6 +606,8 @@ func (tx *Transaction) MatchRule(r *Rule, mds []types.MatchData) {
 	if tx.WAF.ErrorLogCb != nil && r.Log {
 		tx.WAF.ErrorLogCb(mr)
 	}
+
+	tx.emitRuleMatch(r, actionName, mr.Disruptive_, mds)
 }
 
 // GetStopWatch is used to debug phase durations
@@ -909,6 +913,7 @@ func setAndReturnBodyLimitInterruption(tx *Transaction, status int) (*types.Inte
 		Status: status,
 		Action: "deny",
 	}
+	tx.emitEngineError(plugintypes.EngineEventBodyTruncated, nil, "body exceeded configured limit")
 	return tx.interruption, 0, nil
 }
 
@@ -1664,7 +1669,14 @@ func (tx *Transaction) auditLogCollectFiles() []plugintypes.AuditLogTransactionR
 // This method helps the GC to clean up the transaction faster and release resources
 // It also allows caches the transaction back into the sync.Pool
 func (tx *Transaction) Close() error {
+	// Defers execute LIFO: txPool.Put is registered first so it runs last.
+	// emitTransactionFinish runs between the cleanup body (variables.reset
+	// / buffer.Reset below) and the pool put, so if a user-supplied sink
+	// panics the cleanup has already run and the transaction is returned
+	// to the pool in a clean state. Without this ordering a panicking sink
+	// would leave dirty buffers and stale variables in the pooled tx.
 	defer tx.WAF.txPool.Put(tx)
+	defer tx.emitTransactionFinish()
 
 	var errs []error
 	if environment.HasAccessToFS {
@@ -1737,6 +1749,7 @@ func (tx *Transaction) generateRequestBodyError(err error) {
 	tx.variables.reqbodyErrorMsg.Set(fmt.Sprintf("%s: %s", tx.variables.reqbodyProcessor.Get(), err.Error()))
 	tx.variables.reqbodyProcessorError.Set("1")
 	tx.variables.reqbodyProcessorErrorMsg.Set(err.Error())
+	tx.emitEngineError(plugintypes.EngineEventBodyProcessor, err, "request body processor failed")
 }
 
 // generateResponseBodyError generates all the error variables for the response body parser
@@ -1745,6 +1758,7 @@ func (tx *Transaction) generateResponseBodyError(err error) {
 	tx.variables.resBodyErrorMsg.Set(fmt.Sprintf("%s: %s", tx.variables.resBodyProcessor.Get(), err.Error()))
 	tx.variables.resBodyProcessorError.Set("1")
 	tx.variables.resBodyProcessorErrorMsg.Set(err.Error())
+	tx.emitEngineError(plugintypes.EngineEventBodyProcessor, err, "response body processor failed")
 }
 
 // setTimeVariables sets all the time variables

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -48,7 +48,13 @@ const (
 // You can use as many WAF instances as you want, and they are
 // concurrent safe
 // All WAF instance fields are immutable, if you update any
-// of them in runtime you might create concurrency issues
+// of them in runtime you might create concurrency issues.
+//
+// Exception: the perRuleTimingEnabled atomic is designed to be toggled
+// at runtime via SetPerRuleTimingEnabled. The TelemetrySink and cached
+// ruleTimingSink fields must only be set before the WAF is published to
+// any transaction (use SetTelemetrySink; direct assignment bypasses the
+// RuleTimingSink assertion and races with the hot path).
 type WAF struct {
 	txPool sync.Pool
 
@@ -132,6 +138,26 @@ type WAF struct {
 	Logger debuglog.Logger
 
 	ErrorLogCb func(rule types.MatchedRule)
+
+	// TelemetrySink receives engine events (transaction lifecycle, rule
+	// matches, engine errors). A nil sink disables all telemetry without
+	// allocation on the hot path. See plugintypes.TelemetrySink.
+	//
+	// Do not assign this field directly after WAF construction: use
+	// SetTelemetrySink so the cached ruleTimingSink assertion stays in
+	// sync. Runtime reassignment is unsupported and races with the
+	// unsynchronized hot-path reads in emitTransactionStart et al.
+	TelemetrySink plugintypes.TelemetrySink
+
+	// ruleTimingSink is the cached type assertion of TelemetrySink to
+	// plugintypes.RuleTimingSink. Populated at NewWAF time so the hot path
+	// pays only a pointer compare (not a type assertion) per rule.
+	ruleTimingSink plugintypes.RuleTimingSink
+
+	// perRuleTimingEnabled gates per-rule timing emission. Uses atomic so
+	// operators can toggle it at runtime without a WAF rebuild. When off,
+	// the hot-path cost is a single atomic load per rule evaluation loop.
+	perRuleTimingEnabled atomic.Bool
 
 	// Audit mode status
 	AuditEngine types.AuditEngineStatus
@@ -274,6 +300,8 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 	tx.setTimeVariables()
 
 	tx.debugLogger.Debug().Msg("Transaction started")
+
+	tx.emitTransactionStart()
 
 	return tx
 }

--- a/types/phase.go
+++ b/types/phase.go
@@ -27,6 +27,24 @@ const (
 	PhaseLogging RulePhase = 5
 )
 
+// String returns a short stable identifier for the phase, suitable for use
+// as a metric label or log key.
+func (p RulePhase) String() string {
+	switch p {
+	case PhaseRequestHeaders:
+		return "request_headers"
+	case PhaseRequestBody:
+		return "request_body"
+	case PhaseResponseHeaders:
+		return "response_headers"
+	case PhaseResponseBody:
+		return "response_body"
+	case PhaseLogging:
+		return "logging"
+	}
+	return "unknown"
+}
+
 // ParseRulePhase parses the phase of the rule from a to 5
 // or request:2, response:4, logging:5
 // if the phase is invalid it will return an error

--- a/waf.go
+++ b/waf.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 	"github.com/corazawaf/coraza/v3/internal/environment"
 	"github.com/corazawaf/coraza/v3/internal/seclang"
@@ -29,6 +31,7 @@ type WAF interface {
 
 // NewWAF creates a new WAF instance with the provided configuration.
 func NewWAF(config WAFConfig) (WAF, error) {
+	initStart := time.Now()
 	c := config.(*wafConfig)
 
 	waf := corazawaf.NewWAF()
@@ -45,6 +48,13 @@ func NewWAF(config WAFConfig) (WAF, error) {
 
 	if c.ruleObserver != nil {
 		waf.Rules.SetObserver(c.ruleObserver)
+	}
+
+	if c.telemetrySink != nil {
+		waf.SetTelemetrySink(c.telemetrySink)
+	}
+	if c.perRuleTiming {
+		waf.SetPerRuleTimingEnabled(true)
 	}
 
 	parser := seclang.NewParser(waf)
@@ -120,6 +130,13 @@ func NewWAF(config WAFConfig) (WAF, error) {
 		return nil, err
 	}
 
+	if waf.TelemetrySink != nil {
+		waf.TelemetrySink.OnEngineReady(plugintypes.EngineReadyEvent{
+			RulesLoaded:  waf.Rules.Count(),
+			InitDuration: time.Since(initStart),
+		})
+	}
+
 	return wafWrapper{waf: waf}, nil
 }
 
@@ -175,4 +192,15 @@ func (w wafWrapper) RulesCount() int {
 // Close releases cached resources owned by this WAF instance.
 func (w wafWrapper) Close() error {
 	return w.waf.Close()
+}
+
+// SetPerRuleTimingEnabled flips per-rule timing on the underlying WAF.
+// Exported so experimental.WAFEnablePerRuleTiming can type-assert to it.
+func (w wafWrapper) SetPerRuleTimingEnabled(enabled bool) {
+	w.waf.SetPerRuleTimingEnabled(enabled)
+}
+
+// PerRuleTimingEnabled reports the current per-rule timing flag state.
+func (w wafWrapper) PerRuleTimingEnabled() bool {
+	return w.waf.PerRuleTimingEnabled()
 }


### PR DESCRIPTION
## Summary

Adds a minimal, opt-in `TelemetrySink` interface that lets connectors (coraza-caddy, coraza-proxy-wasm, coraza-spoa, libcoraza) route coraza engine events into their native observability stacks. Coraza core ships the hooks; it does **not** ship a Prometheus client, an OTel SDK, or any log schema. Zero new dependencies in `go.mod`.

## Performance impact for non-opt-in users

Measured on Apple M4, `go test -bench -benchtime=5s -count=10`, identical 2-rule transaction shape on both branches:

| | main (no telemetry code) | this branch (telemetry disabled) | Δ |
|---|---|---|---|
| Mean ns/op | 3,241.6 | 3,271.4 | **+29.8 ns (+0.92%)** |
| Allocations | 74 | **74** | **0** |
| Bytes | ~3,974 | ~3,973 | ≈0 |

The ~30 ns delta corresponds to 6 nil-pointer checks at phase boundaries plus one `atomic.Bool.Load()` per phase. No heap allocation, no semantic change when no sink is attached.

## Motivation

Today coraza is invisible to operators. No phase timings, no per-rule match counters, no structured hook for "is the engine healthy." The existing `ErrorLogCb` is called only on matched rules with `log:true` — an operator cannot answer "is coraza 30 ms of my 40 ms tail?" or "did my rule change double the block rate?" without writing bespoke glue.

## Events emitted

Core ships five events. Sinks turn them into metrics, logs, or spans in the operator's native stack. Coraza makes no assumption about which.

### `EngineReadyEvent` — once per WAF, at end of `NewWAF`
| Field | Type | Meaning |
|---|---|---|
| `RulesLoaded` | `int` | Number of compiled SecLang rules after directive parsing |
| `InitDuration` | `time.Duration` | Wall-clock time spent inside `NewWAF` |

### `TransactionEvent` — at transaction start, each phase end, and transaction close
| Field | Type | Meaning |
|---|---|---|
| `Kind` | `TransactionEventKind` | `start` \| `phase_end` \| `finish` |
| `TransactionID` | `string` | Caller-supplied or auto-generated id |
| `Context` | `context.Context` | Parent request context (for OTel span chaining) |
| `Phase` | `types.RulePhase` | Only meaningful on `phase_end` |
| `PhaseDuration` | `time.Duration` | Time spent inside the phase |
| `RulesEvaluated` | `int` | Rules actually executed in that phase |
| `Interruption` | `*types.Interruption` | Terminal decision on `finish`; current state on `phase_end` |

### `RuleMatchEvent` — once per rule match, synchronously after match record is appended
| Field | Type | Meaning |
|---|---|---|
| `TransactionID` | `string` | |
| `Context` | `context.Context` | |
| `Rule` | `types.RuleMetadata` | Full rule metadata (id, tags, severity, …) |
| `Phase` | `types.RulePhase` | |
| `Action` | `string` | `"deny"` \| `"drop"` \| `"pass"` \| `"allow"` \| `"redirect"` \| `""` (no disruptive action) |
| `Enforced` | `bool` | True when the engine actually applied the action (false in DetectionOnly) |
| `Data` | `[]types.MatchData` | Matched variables + values (attacker-controlled — sinks must not use as metric labels) |

### `EngineEvent` — on engine-internal failures
| Field | Type | Meaning |
|---|---|---|
| `Kind` | `EngineEventKind` | `init` \| `parse` \| `body_processor` \| `body_truncated` \| `transaction` |
| `TransactionID` | `string` | Empty for init/parse errors |
| `Phase` | `types.RulePhase` | Zero when not phase-scoped |
| `Err` | `error` | Underlying error, may be nil |
| `Message` | `string` | Human-readable description |

### `RuleTimingEvent` — opt-in per-rule timing (see dedicated section below)
| Field | Type | Meaning |
|---|---|---|
| `TransactionID` | `string` | |
| `Rule` | `types.RuleMetadata` | |
| `Phase` | `types.RulePhase` | |
| `Duration` | `time.Duration` | Full rule evaluation cost (variables, transformations, operator, actions) |
| `Matched` | `bool` | Did this invocation produce a match record? |

## Per-rule timing — opt-in, investigation-only

Per-rule timing answers the question **"which specific rule is making phase 2 slow?"**. It is deliberately separated from the base telemetry for three reasons: high cardinality (one event per rule per request — at CRS full that's ~450), high frequency, and measurable hot-path cost when active.

### How to enable it

Two APIs, one atomic flag under the hood.

**At startup:**
```go
cfg := coraza.NewWAFConfig().WithDirectives(rules)
cfg = experimental.WAFConfigWithTelemetrySink(cfg, mySink)
cfg = experimental.WAFConfigWithPerRuleTiming(cfg, true)
waf, _ := coraza.NewWAF(cfg)
```

**At runtime** — flip on a live WAF when an alert fires, flip off when investigation is done:
```go
experimental.WAFEnablePerRuleTiming(waf, true)
// ...5 minutes of observation...
experimental.WAFEnablePerRuleTiming(waf, false)
```

Safe to call concurrently with active transactions; the change is observed on the next rule-evaluation loop.

### How the sink consumes it

`RuleTimingEvent` is delivered via a separate optional interface. A sink opts in by implementing **both** `TelemetrySink` and `RuleTimingSink`:

```go
type mySink struct{ /* the 4 regular methods */ }

// Optional extension — implement only if you want per-rule timing:
func (s *mySink) OnRuleTimed(ev plugintypes.RuleTimingEvent) {
    ruleDurSeconds.WithLabelValues(strconv.Itoa(ev.Rule.ID())).Observe(ev.Duration.Seconds())
}
```

A sink that does NOT implement `RuleTimingSink` is fine — the engine type-asserts once at `SetTelemetrySink` time and caches the result, so sinks without the extension pay zero runtime cost even when the flag is toggled on.

### Performance

| State | Cost per transaction | What you pay for |
|---|---|---|
| Off (default) | ~1 ns per phase | Single `atomic.Bool.Load()` + cached pointer compare |
| On | ~75 ns per rule evaluated | Two `time.Now()` calls + one interface dispatch |

At CRS paranoia 2 (~450 rules across phases) the on-state cost is roughly **+34 µs per transaction** — around 10% of baseline. Acceptable for a 5-minute debug window, too much for always-on. The off-state cost is sub-1% and was measured at **+1.0% over the counting sink** across 5 benchmark runs — within noise.

### When to use it

- ✅ Investigating a p99 spike on a specific route
- ✅ Proving "rule X is the slow one" before requesting a CRS upstream change
- ✅ Short, targeted windows (minutes, not hours)
- ❌ Always-on production dashboards — use `TransactionEvent.PhaseDuration` + `RulesEvaluated` instead

## Operator use cases → events

| Operator question | Signal built from |
|---|---|
| **Am I under attack right now?** | `TransactionEvent{Kind=finish, Interruption!=nil}` → `requests_total{decision="blocked"}` counter |
| **How many real blocks in the last 5 minutes?** | `RuleMatchEvent{Action="deny"\|"drop"\|"redirect", Enforced=true}` → per-minute rate |
| **Which rules actually do work?** | `RuleMatchEvent` aggregated by `Rule.ID()` → top-N over time |
| **Did my rule change double the block rate?** | Same signal, compared against baseline window |
| **Is my DetectionOnly ruleset too noisy to enforce?** | `RuleMatchEvent{Action="deny", Enforced=false}` → would-have-blocked rate |
| **Why is p99 up?** | `TransactionEvent{Kind=phase_end, PhaseDuration, RulesEvaluated}` → p99 histogram per phase |
| **Which rule is the slow one?** | Opt in per-rule timing (section above), then `RuleTimingEvent.Duration` per `Rule.ID()` |
| **Is the engine healthy?** | `EngineEvent` stream grouped by `Kind` |
| **Is SecRequestBodyLimit too low?** | `EngineEvent{Kind=body_truncated}` counter; spike = raise limit |
| **What ruleset is this node running?** | `EngineReadyEvent{RulesLoaded, InitDuration}` → info gauge |
| **Cold-start budget on serverless / edge?** | `EngineReadyEvent.InitDuration` on each instance boot |
| **Is Coraza N ms of my tail?** | Pass request `context.Context` through `NewTransactionWithOptions`; OTel sink starts `coraza.evaluate` span chained to parent trace |
| **Config reload regression?** | Alert on `EngineReadyEvent.RulesLoaded` delta after deploys |

## Example — wiring into coraza-caddy

To expose these events as Prometheus counters on Caddy's existing `/metrics` endpoint, a Caddy module attaches a sink in its `buildWAF`:

```go
import (
    "github.com/corazawaf/coraza/v3"
    "github.com/corazawaf/coraza/v3/experimental"
    "github.com/prometheus/client_golang/prometheus/promauto"
)

var wafRequests = promauto.NewCounterVec(
    prometheus.CounterOpts{Namespace: "caddy", Subsystem: "waf", Name: "requests_total"},
    []string{"decision"},
)

type caddySink struct{}
func (*caddySink) OnEngineReady(plugintypes.EngineReadyEvent) {}
func (*caddySink) OnRuleMatch(plugintypes.RuleMatchEvent)     {}
func (*caddySink) OnEngineError(plugintypes.EngineEvent)      {}
func (*caddySink) OnTransaction(ev plugintypes.TransactionEvent) {
    if ev.Kind == plugintypes.TransactionEventFinish {
        decision := "allowed"
        if ev.Interruption != nil { decision = "blocked" }
        wafRequests.WithLabelValues(decision).Inc()
    }
}

// In the Caddy module's buildWAF():
cfg = experimental.WAFConfigWithTelemetrySink(cfg, &caddySink{})
```

No new scrape target, no new registry — the series appear on Caddy's built-in `/metrics` endpoint as `caddy_waf_requests_total`. Operators add `rate(caddy_waf_requests_total{decision="blocked"}[5m])` to their existing dashboard. Same pattern works for Envoy stats (proxy-wasm), HAProxy SPOP (spoa), zap, slog, OpenTelemetry — each connector maps events to its native telemetry primitives.

## What's in

### Public surface (all under `experimental/` or additive on existing types)

- `experimental/plugins/plugintypes.TelemetrySink` — 4-method interface: `OnEngineReady`, `OnTransaction`, `OnRuleMatch`, `OnEngineError`
- `experimental/plugins/plugintypes.RuleTimingSink` — optional extension interface for opt-in per-rule timing
- Event structs: `TransactionEvent`, `RuleMatchEvent`, `EngineEvent`, `EngineReadyEvent`, `RuleTimingEvent`
- Experimental shims and helpers:
  - `experimental.WAFConfigWithTelemetrySink(cfg, sink)`
  - `experimental.WAFConfigWithPerRuleTiming(cfg, bool)`
  - `experimental.WAFEnablePerRuleTiming(waf, bool)` — runtime toggle
  - `experimental.NoopTelemetrySink()` — explicit no-op for callers that prefer a non-nil value (the engine treats `nil` as no-op for free)
- `types.RulePhase.String()` — stable label value for metrics

### Internal changes

- `internal/corazawaf.WAF` gains `TelemetrySink`, cached `ruleTimingSink` (optional extension), and `perRuleTimingEnabled atomic.Bool`
- Emit calls at 6 existing seams: transaction start, each phase end, rule match, transaction finish, body-processor error, body-limit truncation
- Per-rule timing path in `RuleGroup.Eval` gated on an `atomic.Bool`; off-state cost is one atomic load per phase

## No breaking changes

- `coraza.WAFConfig` public interface: unchanged
- `coraza.WAF` public interface: unchanged
- `types.RulePhase.String()` is additive — the codebase's internal `fmt` calls all use `%d`, so format output for existing callers is unaffected
- All additions behind the `experimental` shim pattern (mirrors `WAFConfigWithRuleObserver`), so iteration before v4 won't break third-party `WAFConfig` implementers

## TinyGo

Validated with `tinygo build -target=wasip1`. 953 KB wasm, clean build, no new imports outside stdlib in core.

## Security posture

Documented operator responsibilities (same character as the existing `ErrorLogCb` contract):

- **Cardinality:** `RuleMatchEvent.Data` values are attacker-controlled. Sinks MUST NOT use them as metric labels or span attributes — doing so is a cardinality-bomb DoS on the metrics backend. Use them only in structured logs, with redaction and truncation.
- **Non-blocking:** Sink callbacks run synchronously on the request hot path. Buffer to a channel if heavy work is needed.
- **No panics:** A panicking sink crashes the request, same as a panicking `ErrorLogCb`.

No detection-evasion path: emits are unconditional at every seam. Sink absence/errors do not mask rule matches. Sink configuration is immutable post-`NewWAF` except for the per-rule timing atomic flag, which is explicitly concurrent-safe.

## Tests

- 18 integration tests in `experimental/telemetry_sink_test.go` exercising every emit seam, Action/Enforced semantics, DetectionOnly mode, body-truncation, runtime toggle, sink-without-extension graceful degradation, nil sink, context propagation, EngineReady, and the third-party WAFConfig/WAF fallback paths
- 5 benchmarks (baseline, noop, counting, per-rule-off, per-rule-on) in `experimental/telemetry_sink_bench_test.go`
- Race detector green across full 25-package sweep, on default build and `coraza.rule.multiphase_evaluation`
- Coverage: patch **99.41%**, project **87.66% (+0.27%)** per codecov

## Opportunity for future metrics: OWASP CRS awareness

A small future subpackage — e.g. `coraza/v3/telemetry/crs` — could map CRS rule id ranges to category labels (sqli, xss, rce, …) and read `tx.anomaly_score_*` variables. Sinks opt in by importing; users not on CRS pay nothing. Mentioning this only as a possibility so reviewers understand why the engine stays CRS-agnostic in this PR. Not proposing to ship it.

## Open questions for reviewers

1. **Is `Action string` + `Enforced bool` on `RuleMatchEvent` the right split?** The existing `MatchedRule.Disruptive()` conflates "has a disruptive-type action slot" with "will enforce it." I split them because operators asking "how many blocks?" want `Action="deny" && Enforced=true`, not a boolean that includes `pass`. Worth pushback.

2. **Should `RuleTimingSink` be a separate interface or a 5th method on `TelemetrySink`?** Chose separate extension so existing sinks stay 4-method and don't force every sink to implement a high-cardinality hook. Engine caches the type assertion at `SetTelemetrySink` time so runtime cost is one pointer compare.

3. **`types.RulePhase.String()` — fine or controversial?** Added for metric label stability. Internal callers all use `%d` so no behavior change for them. Any external consumer relying on `%v` output would see `"request_headers"` instead of `"1"`.

4. **`EngineReadyEvent` fields — enough, too much, wrong?** Currently `RulesLoaded` + `InitDuration`. A `RulesetHash` would also be useful but means sha-ing all loaded SecLang sources at startup. Skipped pending a reviewer opinion on whether that cost is justified.

5. **Should `WithTelemetrySink` and `WithPerRuleTiming` move onto the public `coraza.WAFConfig` interface in v4?** Kept them private for now so third-party `WAFConfig` implementations aren't forced to support telemetry.

## What this PR explicitly does not include

- No built-in Prometheus, OpenTelemetry, or log-line sink. Core stays implementation-free.
- No connector changes. Connector integrations (Caddy, proxy-wasm, SPOA) are separate work.
- No redaction helpers, no anomaly-score reader, no CRS categorization helper.
- No Grafana dashboard.

---

Claude Code (Opus 4.7) was used in the development of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added telemetry system capturing transaction lifecycle events, rule matches, and engine errors for WAF monitoring integration
  * Added per-rule timing capability to track individual rule execution duration
  * Introduced APIs to attach custom telemetry sinks and enable per-rule timing configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->