### PR TITLE
fix: ruleRemoveTargetById/Tag/Msg do not apply to chain children #1610

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -231,7 +231,13 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 		}
 		r.matchVariable(tx, md)
 	} else {
-		ecol := tx.ruleRemoveTargetByID[r.ID_]
+		// Chain children carry ID_ == noID; ctl:ruleRemoveTarget* stores exceptions
+		// under the parent's ID, so chain children must look up via ParentID_.
+		rid := r.ID_
+		if rid == noID {
+			rid = r.ParentID_
+		}
+		ecol := tx.ruleRemoveTargetByID[rid]
 		for _, v := range r.variables {
 			if multiphaseEvaluation && multiphaseSkipVariable(r, v.Variable, phase) {
 				continue

--- a/testing/engine/ctl.go
+++ b/testing/engine/ctl.go
@@ -149,6 +149,103 @@ var _ = profile.RegisterProfile(profile.Profile{
 				},
 			},
 		},
+		{
+			Title: "ruleRemoveTargetById chain child",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-id?json.content=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Rule 340 removes ARGS_GET:json.content from rule 341.
+							// Rule 341 is a chain whose child inspects ARGS_GET; the exclusion must
+							// propagate to the chain child.
+							TriggeredRules:    []int{340},
+							NonTriggeredRules: []int{341},
+						},
+					},
+				},
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-id?other=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Negative: ctl removes ARGS_GET:json.content only. ARGS_GET:other is
+							// not excluded, so the chain child must still match.
+							TriggeredRules: []int{340, 341},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "ruleRemoveTargetByMsg chain child",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-msg?json.content=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Rule 360 removes ARGS_GET:json.content from all rules whose parent
+							// has msg:'argument too long'. Rule 361 is a chain with that parent msg
+							// whose child inspects ARGS_GET; the exclusion must propagate.
+							TriggeredRules:    []int{360},
+							NonTriggeredRules: []int{361},
+						},
+					},
+				},
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-msg?other=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Negative: only ARGS_GET:json.content is removed; chain child still fires on `other`.
+							TriggeredRules: []int{360, 361},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "ruleRemoveTargetByTag chain child",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-tag?json.content=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Rule 350 removes ARGS_GET:json.content from all rules tagged OWASP_CRS.
+							// Rule 351 is a chain tagged OWASP_CRS whose child inspects ARGS_GET; the
+							// exclusion must propagate to the chain child.
+							TriggeredRules:    []int{350},
+							NonTriggeredRules: []int{351},
+						},
+					},
+				},
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							Method: "GET",
+							URI:    "/api/chain-tag?other=attack",
+						},
+						Output: profile.ExpectedOutput{
+							// Negative: only ARGS_GET:json.content is removed; chain child still fires on `other`.
+							TriggeredRules: []int{350, 351},
+						},
+					},
+				},
+			},
+		},
 	},
 	Rules: `
 SecDebugLogLevel 9
@@ -210,5 +307,27 @@ SecRule ARGS_GET "@rx attack" "id:321,phase:1,log,tag:OWASP_CRS"
 # Rule 331 has msg:'web shell detection' and would normally match the attack args but must be suppressed.
 SecRule REQUEST_URI "@beginsWith /api/msg-test" "id:330,phase:1,pass,log,ctl:ruleRemoveTargetByMsg=web shell detection;ARGS_GET:/^json\.\d+\.desc$/"
 SecRule ARGS_GET "@rx attack" "id:331,phase:1,log,msg:'web shell detection'"
+
+# ruleRemoveTargetById chain child test:
+# Rule 340 removes ARGS_GET:json.content from rule 341. Rule 341 is a chain whose
+# CHILD inspects ARGS_GET. The exclusion must propagate to the chain child or the
+# request will be blocked by the child despite the ctl removal (issue #1610).
+SecRule REQUEST_URI "@beginsWith /api/chain-id" "id:340,phase:1,pass,log,ctl:ruleRemoveTargetById=341;ARGS_GET:json.content"
+SecRule REQUEST_METHOD "@rx ^GET$" "id:341,phase:1,log,chain"
+    SecRule ARGS_GET "@rx attack" ""
+
+# ruleRemoveTargetByTag chain child test (mirrors the CRS WordPress plugin case):
+# Rule 350 removes ARGS_GET:json.content from all rules tagged OWASP_CRS. Rule 351
+# is a chain tagged OWASP_CRS whose CHILD inspects ARGS_GET.
+SecRule REQUEST_URI "@beginsWith /api/chain-tag" "id:350,phase:1,pass,log,ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS_GET:json.content"
+SecRule REQUEST_METHOD "@rx ^GET$" "id:351,phase:1,log,tag:OWASP_CRS,chain"
+    SecRule ARGS_GET "@rx attack" ""
+
+# ruleRemoveTargetByMsg chain child test:
+# Rule 360 removes ARGS_GET:json.content from all rules with msg:'argument too long'.
+# Rule 361 is a chain whose PARENT has that msg and whose CHILD inspects ARGS_GET.
+SecRule REQUEST_URI "@beginsWith /api/chain-msg" "id:360,phase:1,pass,log,ctl:ruleRemoveTargetByMsg=argument too long;ARGS_GET:json.content"
+SecRule REQUEST_METHOD "@rx ^GET$" "id:361,phase:1,log,msg:'argument too long',chain"
+    SecRule ARGS_GET "@rx attack" ""
 `,
 })


### PR DESCRIPTION
Chain children carry no own ID (noID), but ctl:ruleRemoveTarget* stores exceptions under the parent's ID, which we must use while searching rules. This matches the pattern already used by matchVariable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chain child rules now correctly inherit parent rule variable exceptions/removals so excluded inputs aren’t indexed under a placeholder ID.

* **Tests**
  * Added CTL regression scenarios covering removal-by-ID, removal-by-tag, and removal-by-message, each with positive and negative cases to validate chain child propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->