### PR TITLE
feat(auditlog): add libmodsecurity v3 JSON formatter.

### DIFF
--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -384,24 +384,30 @@ func (m Message) ErrorMessage() string {
 }
 
 func (m Message) Data() plugintypes.AuditLogMessageData {
+	if m.Data_ == nil {
+		return nil
+	}
+
 	return m.Data_
 }
 
 // MessageData contains information about the triggered
 // rules in detail
 type MessageData struct {
-	File_     string             `json:"file"`
-	Line_     int                `json:"line"`
-	ID_       int                `json:"id"`
-	Rev_      string             `json:"rev"`
-	Msg_      string             `json:"msg"`
-	Data_     string             `json:"data"`
-	Severity_ types.RuleSeverity `json:"severity"`
-	Ver_      string             `json:"ver"`
-	Maturity_ int                `json:"maturity"`
-	Accuracy_ int                `json:"accuracy"`
-	Tags_     []string           `json:"tags"`
-	Raw_      string             `json:"raw"`
+	File_      string             `json:"file"`
+	Line_      int                `json:"line"`
+	ID_        int                `json:"id"`
+	Rev_       string             `json:"rev"`
+	Msg_       string             `json:"msg"`
+	Data_      string             `json:"data"`
+	Severity_  types.RuleSeverity `json:"severity"`
+	Ver_       string             `json:"ver"`
+	Maturity_  int                `json:"maturity"`
+	Accuracy_  int                `json:"accuracy"`
+	Tags_      []string           `json:"tags"`
+	Raw_       string             `json:"raw"`
+	Match_     string             `json:"-"`
+	Reference_ string             `json:"-"`
 }
 
 var _ plugintypes.AuditLogMessageData = (*MessageData)(nil)
@@ -452,4 +458,22 @@ func (md *MessageData) Tags() []string {
 
 func (md *MessageData) Raw() string {
 	return md.Raw_
+}
+
+// Match returns the structured operator match detail, when available.
+func (md *MessageData) Match() string {
+	if md == nil {
+		return ""
+	}
+
+	return md.Match_
+}
+
+// Reference returns the ModSecurity-compatible match reference, when available.
+func (md *MessageData) Reference() string {
+	if md == nil {
+		return ""
+	}
+
+	return md.Reference_
 }

--- a/internal/auditlog/formats.go
+++ b/internal/auditlog/formats.go
@@ -7,6 +7,7 @@
 // The following log formats are supported:
 //
 // - JSON
+// - ModSecurityV3
 // - Coraza
 // - Native
 //

--- a/internal/auditlog/formats_json_test.go
+++ b/internal/auditlog/formats_json_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/types"
@@ -156,5 +157,213 @@ func TestJSONFormatterPartJ(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestLibModSecurityJSONFormatter verifies the full libmodsecurity v3 JSON shape.
+func TestLibModSecurityJSONFormatter(t *testing.T) {
+	timestamp := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC).UnixNano()
+	al := &Log{
+		Parts_: types.AuditLogParts("BCEFH"),
+		Transaction_: Transaction{
+			Timestamp_:     "2024/01/02 03:04:05",
+			UnixTimestamp_: timestamp,
+			ID_:            "tx-id",
+			ClientIP_:      "127.0.0.1",
+			ClientPort_:    1234,
+			HostIP_:        "127.0.0.2",
+			HostPort_:      443,
+			ServerID_:      "example.test",
+			IsInterrupted_: true,
+			Request_: &TransactionRequest{
+				Method_:      "GET",
+				URI_:         "/?x=/etc/passwd",
+				Protocol_:    "HTTP/1.1",
+				HTTPVersion_: "HTTP/1.1",
+				Body_:        "request body",
+				Headers_: map[string][]string{
+					"host":   {"example.test"},
+					"x-test": {"one", "two"},
+				},
+			},
+			Response_: &TransactionResponse{
+				Status_: 403,
+				Body_:   "response body",
+				Headers_: map[string][]string{
+					"content-type": {"text/plain"},
+				},
+			},
+			Producer_: &TransactionProducer{
+				Connector_:  "coraza-spoa",
+				Version_:    "v1.0.0",
+				RuleEngine_: "On",
+				Rulesets_:   []string{"OWASP_CRS/4.0.0"},
+			},
+		},
+		Messages_: []plugintypes.AuditLogMessage{
+			Message{
+				Message_: "OS File Access Attempt",
+				Data_: &MessageData{
+					Match_:     "Matched \"Operator `PmFromFile' against variable `ARGS:x'\"",
+					Reference_: "o1,10v8,11",
+					File_:      "/rules/lfi.conf",
+					Line_:      79,
+					ID_:        930120,
+					Data_:      "Matched Data: etc/passwd",
+					Severity_:  types.RuleSeverityCritical,
+					Ver_:       "OWASP_CRS/4.0.0",
+					Tags_:      []string{"attack-lfi"},
+				},
+			},
+		},
+	}
+
+	data, err := (&libmodsecurityJSONFormatter{}).Format(al)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got libmodsecurityJSONLog
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	transaction := got.Transaction
+	if want := time.Unix(0, timestamp).Format(time.ANSIC); transaction.Timestamp != want {
+		t.Fatalf("expected time_stamp %q, got %q", want, transaction.Timestamp)
+	}
+	if transaction.UniqueID != "tx-id" {
+		t.Fatalf("expected unique_id %q, got %q", "tx-id", transaction.UniqueID)
+	}
+	if transaction.Request.HTTPVersion != "1.1" {
+		t.Fatalf("expected HTTP version %q, got %q", "1.1", transaction.Request.HTTPVersion)
+	}
+	if transaction.Request.Body == nil || *transaction.Request.Body != "request body" {
+		t.Fatalf("expected request body, got %#v", transaction.Request.Body)
+	}
+	if transaction.Request.Headers == nil || (*transaction.Request.Headers)["x-test"] != "one, two" {
+		t.Fatalf("expected flattened request headers, got %#v", transaction.Request.Headers)
+	}
+	if transaction.Response.HTTPCode != 403 {
+		t.Fatalf("expected response http_code %d, got %d", 403, transaction.Response.HTTPCode)
+	}
+	if transaction.Response.Body == nil || *transaction.Response.Body != "response body" {
+		t.Fatalf("expected response body, got %#v", transaction.Response.Body)
+	}
+	if transaction.Producer == nil {
+		t.Fatal("expected producer")
+	}
+	if transaction.Producer.ModSecurity != libmodsecurityJSONProducerName {
+		t.Fatalf("expected modsecurity producer %q, got %q", libmodsecurityJSONProducerName, transaction.Producer.ModSecurity)
+	}
+	if transaction.Producer.Connector != "coraza-spoa v1.0.0" {
+		t.Fatalf("expected connector %q, got %q", "coraza-spoa v1.0.0", transaction.Producer.Connector)
+	}
+	if transaction.Producer.SecRulesEngine != "Enabled" {
+		t.Fatalf("expected secrules_engine %q, got %q", "Enabled", transaction.Producer.SecRulesEngine)
+	}
+	if transaction.Messages == nil || len(*transaction.Messages) != 1 {
+		t.Fatalf("expected one message, got %#v", transaction.Messages)
+	}
+	if got := (*transaction.Messages)[0].Details.RuleID; got != "930120" {
+		t.Fatalf("expected ruleId %q, got %q", "930120", got)
+	}
+	if got := (*transaction.Messages)[0].Details.Reference; got != "o1,10v8,11" {
+		t.Fatalf("expected reference %q, got %q", "o1,10v8,11", got)
+	}
+	if got := (*transaction.Messages)[0].Details.Match; got != "Matched \"Operator `PmFromFile' against variable `ARGS:x'\"" {
+		t.Fatalf("expected match text, got %q", got)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := raw["messages"]; ok {
+		t.Fatal("expected messages under transaction, not at top level")
+	}
+	rawTransaction := raw["transaction"].(map[string]any)
+	if _, ok := rawTransaction["timestamp"]; ok {
+		t.Fatal("expected libmodsecurity time_stamp key, not Coraza timestamp key")
+	}
+	if _, ok := rawTransaction["id"]; ok {
+		t.Fatal("expected libmodsecurity unique_id key, not Coraza id key")
+	}
+}
+
+// TestLibModSecurityJSONFormatterHonorsParts verifies audit-part gated fields are omitted correctly.
+func TestLibModSecurityJSONFormatterHonorsParts(t *testing.T) {
+	al := &Log{
+		Parts_: types.AuditLogParts("A"),
+		Transaction_: Transaction{
+			Request_: &TransactionRequest{
+				Body_:    "request body",
+				Headers_: map[string][]string{"host": {"example.test"}},
+			},
+			Response_: &TransactionResponse{
+				Status_:  403,
+				Body_:    "response body",
+				Headers_: map[string][]string{"content-type": {"text/plain"}},
+			},
+			Producer_: &TransactionProducer{
+				RuleEngine_: "DetectionOnly",
+			},
+		},
+	}
+
+	data, err := (&libmodsecurityJSONFormatter{}).Format(al)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	transaction := raw["transaction"].(map[string]any)
+	request := transaction["request"].(map[string]any)
+	response := transaction["response"].(map[string]any)
+	for _, key := range []string{"body", "headers"} {
+		if _, ok := request[key]; ok {
+			t.Fatalf("expected request %s to be omitted without its audit part", key)
+		}
+		if _, ok := response[key]; ok {
+			t.Fatalf("expected response %s to be omitted without its audit part", key)
+		}
+	}
+	if _, ok := transaction["producer"]; ok {
+		t.Fatal("expected producer to be omitted without part H")
+	}
+	if _, ok := transaction["messages"]; ok {
+		t.Fatal("expected messages to be omitted without part H")
+	}
+
+	al.Parts_ = types.AuditLogParts("H")
+	data, err = (&libmodsecurityJSONFormatter{}).Format(al)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = nil
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	transaction = raw["transaction"].(map[string]any)
+	if _, ok := transaction["producer"]; !ok {
+		t.Fatal("expected producer with part H")
+	}
+	messages, ok := transaction["messages"].([]any)
+	if !ok || len(messages) != 0 {
+		t.Fatalf("expected empty messages array with part H, got %#v", transaction["messages"])
+	}
+}
+
+// TestLibModSecurityJSONFormatterRegistered verifies the formatter can be selected by name.
+func TestLibModSecurityJSONFormatterRegistered(t *testing.T) {
+	formatter, err := GetFormatter("ModSecurityV3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := formatter.(*libmodsecurityJSONFormatter); !ok {
+		t.Fatalf("expected ModSecurityV3 formatter, got %T", formatter)
 	}
 }

--- a/internal/auditlog/formats_json_v3.go
+++ b/internal/auditlog/formats_json_v3.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package auditlog
+
+import (
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/types"
+)
+
+// libmodsecurityJSONProducerName is the producer label emitted in ModSecurity v3 JSON logs.
+const libmodsecurityJSONProducerName = "Coraza"
+
+// libmodsecurityJSONFormatter serializes audit logs using the libmodsecurity v3 JSON schema.
+type libmodsecurityJSONFormatter struct{}
+
+// libmodsecurityJSONLog is the root object of a libmodsecurity v3 JSON audit log.
+type libmodsecurityJSONLog struct {
+	Transaction libmodsecurityJSONTransaction `json:"transaction"`
+}
+
+// libmodsecurityJSONTransaction contains the transaction fields emitted by libmodsecurity v3.
+type libmodsecurityJSONTransaction struct {
+	ClientIP      string                       `json:"client_ip"`
+	Timestamp     string                       `json:"time_stamp"`
+	ServerID      string                       `json:"server_id"`
+	ClientPort    int                          `json:"client_port"`
+	HostIP        string                       `json:"host_ip"`
+	HostPort      int                          `json:"host_port"`
+	UniqueID      string                       `json:"unique_id"`
+	IsInterrupted bool                         `json:"is_interrupted"`
+	Request       libmodsecurityJSONRequest    `json:"request"`
+	Response      libmodsecurityJSONResponse   `json:"response"`
+	Producer      *libmodsecurityJSONProducer  `json:"producer,omitempty"`
+	Messages      *[]libmodsecurityJSONMessage `json:"messages,omitempty"`
+}
+
+// libmodsecurityJSONRequest contains the request fields emitted by libmodsecurity v3.
+type libmodsecurityJSONRequest struct {
+	Method      string             `json:"method"`
+	HTTPVersion string             `json:"http_version"`
+	Hostname    string             `json:"hostname"`
+	URI         string             `json:"uri"`
+	Body        *string            `json:"body,omitempty"`
+	Headers     *map[string]string `json:"headers,omitempty"`
+}
+
+// libmodsecurityJSONResponse contains the response fields emitted by libmodsecurity v3.
+type libmodsecurityJSONResponse struct {
+	Body     *string            `json:"body,omitempty"`
+	HTTPCode int                `json:"http_code"`
+	Headers  *map[string]string `json:"headers,omitempty"`
+}
+
+// libmodsecurityJSONProducer contains the producer metadata emitted with audit trailer data.
+type libmodsecurityJSONProducer struct {
+	ModSecurity    string   `json:"modsecurity"`
+	Connector      string   `json:"connector"`
+	SecRulesEngine string   `json:"secrules_engine"`
+	Components     []string `json:"components"`
+}
+
+// libmodsecurityJSONMessage contains one structured rule message.
+type libmodsecurityJSONMessage struct {
+	Message string                          `json:"message"`
+	Details libmodsecurityJSONMessageDetail `json:"details"`
+}
+
+// libmodsecurityJSONMessageDetail contains the rule metadata nested under a message.
+type libmodsecurityJSONMessageDetail struct {
+	Match      string   `json:"match"`
+	Reference  string   `json:"reference"`
+	RuleID     string   `json:"ruleId"`
+	File       string   `json:"file"`
+	LineNumber string   `json:"lineNumber"`
+	Data       string   `json:"data"`
+	Severity   string   `json:"severity"`
+	Ver        string   `json:"ver"`
+	Rev        string   `json:"rev"`
+	Tags       []string `json:"tags"`
+	Maturity   string   `json:"maturity"`
+	Accuracy   string   `json:"accuracy"`
+}
+
+// libmodsecurityJSONMessageData exposes optional ModSecurity v3 message fields.
+type libmodsecurityJSONMessageData interface {
+	Match() string
+	Reference() string
+}
+
+// Format renders an audit log using the libmodsecurity v3 JSON schema.
+func (libmodsecurityJSONFormatter) Format(al plugintypes.AuditLog) ([]byte, error) {
+	transaction := al.Transaction()
+	formatted := libmodsecurityJSONLog{
+		Transaction: libmodsecurityJSONTransaction{
+			ClientIP:      transaction.ClientIP(),
+			Timestamp:     libmodsecurityJSONTimestamp(transaction),
+			ServerID:      transaction.ServerID(),
+			ClientPort:    transaction.ClientPort(),
+			HostIP:        transaction.HostIP(),
+			HostPort:      transaction.HostPort(),
+			UniqueID:      transaction.ID(),
+			IsInterrupted: transaction.IsInterrupted(),
+			Request: libmodsecurityJSONRequest{
+				Method:   "-",
+				Hostname: transaction.ServerID(),
+			},
+		},
+	}
+
+	if transaction.HasRequest() {
+		request := transaction.Request()
+		formatted.Transaction.Request.Method = dashIfEmpty(request.Method())
+		formatted.Transaction.Request.HTTPVersion = libmodsecurityJSONHTTPVersion(request)
+		formatted.Transaction.Request.URI = request.URI()
+
+		if slices.Contains(al.Parts(), types.AuditLogPartRequestBody) {
+			body := request.Body()
+			formatted.Transaction.Request.Body = &body
+		}
+
+		if slices.Contains(al.Parts(), types.AuditLogPartRequestHeaders) {
+			headers := libmodsecurityJSONHeaders(request.Headers())
+			formatted.Transaction.Request.Headers = &headers
+			if formatted.Transaction.Request.Hostname == "" {
+				formatted.Transaction.Request.Hostname = libmodsecurityJSONHeader(headers, "host")
+			}
+		}
+	}
+
+	if transaction.HasResponse() {
+		response := transaction.Response()
+		formatted.Transaction.Response.HTTPCode = response.Status()
+
+		if slices.Contains(al.Parts(), types.AuditLogPartIntermediaryResponseBody) {
+			body := response.Body()
+			formatted.Transaction.Response.Body = &body
+		}
+
+		if slices.Contains(al.Parts(), types.AuditLogPartResponseHeaders) {
+			headers := libmodsecurityJSONHeaders(response.Headers())
+			formatted.Transaction.Response.Headers = &headers
+		}
+	}
+
+	if slices.Contains(al.Parts(), types.AuditLogPartAuditLogTrailer) {
+		formatted.Transaction.Producer = libmodsecurityJSONProducerFrom(transaction.Producer())
+		messages := libmodsecurityJSONMessages(al.Messages())
+		formatted.Transaction.Messages = &messages
+	}
+
+	return json.Marshal(formatted)
+}
+
+// MIME returns the media type for libmodsecurity v3 JSON audit logs.
+func (libmodsecurityJSONFormatter) MIME() string {
+	return "application/json; charset=utf-8"
+}
+
+// libmodsecurityJSONTimestamp returns the timestamp format expected by libmodsecurity v3.
+func libmodsecurityJSONTimestamp(transaction plugintypes.AuditLogTransaction) string {
+	if timestamp := transaction.UnixTimestamp(); timestamp != 0 {
+		return time.Unix(0, timestamp).Format(time.ANSIC)
+	}
+
+	return transaction.Timestamp()
+}
+
+// libmodsecurityJSONHTTPVersion returns the HTTP version without the HTTP/ prefix.
+func libmodsecurityJSONHTTPVersion(request plugintypes.AuditLogTransactionRequest) string {
+	version := request.HTTPVersion()
+	if version == "" {
+		version = request.Protocol()
+	}
+
+	if len(version) >= len("HTTP/") && strings.EqualFold(version[:len("HTTP/")], "HTTP/") {
+		return version[len("HTTP/"):]
+	}
+
+	return version
+}
+
+// libmodsecurityJSONHeaders flattens repeated header values into the v3 JSON representation.
+func libmodsecurityJSONHeaders(headers map[string][]string) map[string]string {
+	formatted := make(map[string]string, len(headers))
+	for key, values := range headers {
+		formatted[key] = strings.Join(values, ", ")
+	}
+
+	return formatted
+}
+
+// libmodsecurityJSONHeader returns a header value using a case-insensitive lookup.
+func libmodsecurityJSONHeader(headers map[string]string, name string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value
+		}
+	}
+
+	return ""
+}
+
+// libmodsecurityJSONProducerFrom builds the v3 producer block from Coraza metadata.
+func libmodsecurityJSONProducerFrom(producer plugintypes.AuditLogTransactionProducer) *libmodsecurityJSONProducer {
+	formatted := &libmodsecurityJSONProducer{
+		ModSecurity: libmodsecurityJSONProducerName,
+		Components:  []string{},
+	}
+	if producer == nil {
+		return formatted
+	}
+
+	formatted.Connector = strings.TrimSpace(strings.Join([]string{producer.Connector(), producer.Version()}, " "))
+	formatted.SecRulesEngine = libmodsecurityJSONRuleEngine(producer.RuleEngine())
+	formatted.Components = append(formatted.Components, producer.Rulesets()...)
+	return formatted
+}
+
+// libmodsecurityJSONRuleEngine maps Coraza rule engine modes to v3 labels.
+func libmodsecurityJSONRuleEngine(ruleEngine string) string {
+	switch strings.ToLower(ruleEngine) {
+	case "on":
+		return "Enabled"
+	case "off":
+		return "Disabled"
+	default:
+		return ruleEngine
+	}
+}
+
+// libmodsecurityJSONMessages converts Coraza audit messages to v3 message entries.
+func libmodsecurityJSONMessages(messages []plugintypes.AuditLogMessage) []libmodsecurityJSONMessage {
+	formatted := make([]libmodsecurityJSONMessage, 0, len(messages))
+	for _, message := range messages {
+		data := message.Data()
+		if data == nil {
+			continue
+		}
+
+		details := libmodsecurityJSONMessageDetail{
+			RuleID:     strconv.Itoa(data.ID()),
+			File:       data.File(),
+			LineNumber: strconv.Itoa(data.Line()),
+			Data:       data.Data(),
+			Severity:   strconv.Itoa(data.Severity().Int()),
+			Ver:        data.Ver(),
+			Rev:        data.Rev(),
+			Tags:       append([]string{}, data.Tags()...),
+			Maturity:   strconv.Itoa(data.Maturity()),
+			Accuracy:   strconv.Itoa(data.Accuracy()),
+		}
+		if details.Tags == nil {
+			details.Tags = []string{}
+		}
+
+		if v3Data, ok := data.(libmodsecurityJSONMessageData); ok {
+			details.Match = v3Data.Match()
+			details.Reference = v3Data.Reference()
+		}
+
+		msg := message.Message()
+		if msg == "" {
+			msg = data.Msg()
+		}
+
+		formatted = append(formatted, libmodsecurityJSONMessage{
+			Message: msg,
+			Details: details,
+		})
+	}
+
+	return formatted
+}
+
+// dashIfEmpty returns the libmodsecurity placeholder for missing string values.
+func dashIfEmpty(value string) string {
+	if value == "" {
+		return "-"
+	}
+
+	return value
+}
+
+var _ plugintypes.AuditLogFormatter = (*libmodsecurityJSONFormatter)(nil)

--- a/internal/auditlog/init.go
+++ b/internal/auditlog/init.go
@@ -22,6 +22,7 @@ func init() {
 	})
 
 	RegisterFormatter("json", &jsonFormatter{})
+	RegisterFormatter("modsecurityv3", &libmodsecurityJSONFormatter{})
 	RegisterFormatter("jsonlegacy", &legacyJSONFormatter{})
 	RegisterFormatter("native", &nativeFormatter{})
 	RegisterFormatter("ocsf", &ocsfFormatter{})

--- a/internal/auditlog/init_tinygo.go
+++ b/internal/auditlog/init_tinygo.go
@@ -22,6 +22,7 @@ func init() {
 	})
 
 	RegisterFormatter("json", &jsonFormatter{})
+	RegisterFormatter("modsecurityv3", &libmodsecurityJSONFormatter{})
 	RegisterFormatter("jsonlegacy", &legacyJSONFormatter{})
 	RegisterFormatter("native", &nativeFormatter{})
 	RegisterFormatter("ocsf", &noopFormatter{})

--- a/internal/auditlog/init_windows.go
+++ b/internal/auditlog/init_windows.go
@@ -22,6 +22,7 @@ func init() {
 	})
 
 	RegisterFormatter("json", &jsonFormatter{})
+	RegisterFormatter("modsecurityv3", &libmodsecurityJSONFormatter{})
 	RegisterFormatter("jsonlegacy", &legacyJSONFormatter{})
 	RegisterFormatter("native", &nativeFormatter{})
 	RegisterFormatter("ocsf", &ocsfFormatter{})

--- a/internal/corazarules/rule_match.go
+++ b/internal/corazarules/rule_match.go
@@ -26,6 +26,10 @@ type MatchData struct {
 	Message_ string
 	// Macro expanded logdata
 	Data_ string
+	// Human-readable operator match detail for structured audit logs.
+	Match_ string
+	// ModSecurity-compatible reference detail, when available.
+	Reference_ string
 	// Keeps track of the chain depth in which the data matched.
 	// Multiphase specific field
 	ChainLevel_ int
@@ -51,6 +55,16 @@ func (m MatchData) Message() string {
 
 func (m MatchData) Data() string {
 	return m.Data_
+}
+
+// Match returns the structured operator match detail, when available.
+func (m MatchData) Match() string {
+	return m.Match_
+}
+
+// Reference returns the ModSecurity-compatible match reference, when available.
+func (m MatchData) Reference() string {
+	return m.Reference_
 }
 
 func (m MatchData) ChainLevel() int {

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -216,6 +216,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 	if r.operator == nil {
 		logger.Debug().Msg("Forcing rule to match")
 		md := &corazarules.MatchData{}
+		md.Match_ = r.auditLogMatch(md)
 		if r.ParentID_ != noID || r.MultiMatch {
 			// In order to support Msg and LogData for inner rules, we need to expand them now
 			if r.Msg != nil {
@@ -295,6 +296,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 							Value_:      carg,
 							ChainLevel_: chainLevel,
 						}
+						mr.Match_ = r.auditLogMatch(mr)
 						// Set the txn variables for expansions before usage
 						r.matchVariable(tx, mr)
 
@@ -708,6 +710,42 @@ func (r *Rule) SetOperator(operator plugintypes.Operator, functionName string, p
 		Data:     params,
 		Negation: len(functionName) > 0 && functionName[0] == '!',
 	}
+}
+
+// auditLogMatch formats a rule match using the libmodsecurity v3 detail syntax.
+func (r *Rule) auditLogMatch(md types.MatchData) string {
+	if r.operator == nil || r.operator.Function == "" {
+		return "Matched."
+	}
+
+	operator := strings.TrimPrefix(r.operator.Function, "!")
+	operator = strings.TrimPrefix(operator, "@")
+	if operator == "" {
+		return "Matched."
+	}
+	operator = strings.ToUpper(operator[:1]) + operator[1:]
+
+	var match strings.Builder
+	match.WriteString("Matched \"Operator `")
+	match.WriteString(operator)
+	match.WriteString("'")
+
+	if r.operator.Data != "" {
+		match.WriteString(" with parameter `")
+		match.WriteString(r.operator.Data)
+		match.WriteString("'")
+	}
+
+	match.WriteString(" against variable `")
+	match.WriteString(md.Variable().Name())
+	if key := md.Key(); key != "" {
+		match.WriteByte(':')
+		match.WriteString(key)
+	}
+	match.WriteString("' (Value: `")
+	match.WriteString(md.Value())
+	match.WriteString("' )\"")
+	return match.String()
 }
 
 func (r *Rule) executeOperator(data string, tx *Transaction) (result bool) {

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -564,6 +564,17 @@ func (tx *Transaction) MatchRule(r *Rule, mds []types.MatchData) {
 		}
 	}
 
+	for _, md := range mds {
+		matchData, ok := md.(*corazarules.MatchData)
+		if !ok || matchData.Match_ != "" || matchData.ChainLevel_ != 0 {
+			continue
+		}
+
+		// Evaluator-created matches already carry origin-specific details.
+		// This fallback covers manually constructed top-level match data.
+		matchData.Match_ = r.auditLogMatch(md)
+	}
+
 	mr := &corazarules.MatchedRule{
 		URI_:             tx.variables.requestURI.Get(),
 		TransactionID_:   tx.id,
@@ -1521,13 +1532,21 @@ func (tx *Transaction) AuditLog() *auditlog.Log {
 		HostPort_:      hostPort,
 		ServerID_:      tx.variables.serverName.Get(), // TODO check
 		Request_: &auditlog.TransactionRequest{
-			Method_:   tx.variables.requestMethod.Get(),
-			URI_:      tx.variables.requestURI.Get(),
-			Protocol_: tx.variables.requestProtocol.Get(),
-			Args_:     tx.variables.args,
-			Length_:   int32(requestLength),
+			Method_:      tx.variables.requestMethod.Get(),
+			URI_:         tx.variables.requestURI.Get(),
+			Protocol_:    tx.variables.requestProtocol.Get(),
+			HTTPVersion_: tx.variables.requestProtocol.Get(),
+			Args_:        tx.variables.args,
+			Length_:      int32(requestLength),
 		},
 		IsInterrupted_: tx.IsInterrupted(),
+	}
+	if responseStatus := tx.variables.responseStatus.Get(); responseStatus != "" || tx.variables.responseProtocol.Get() != "" {
+		status, _ := strconv.Atoi(responseStatus)
+		al.Transaction_.Response_ = &auditlog.TransactionResponse{
+			Protocol_: tx.variables.responseProtocol.Get(),
+			Status_:   status,
+		}
 	}
 
 	var auditLogPartAuditLogTrailerSet, auditLogPartRulesMatchedSet bool
@@ -1550,17 +1569,9 @@ func (tx *Transaction) AuditLog() *auditlog.Log {
 		case types.AuditLogPartUploadedFiles:
 			al.Transaction_.Request_.Files_ = tx.auditLogCollectFiles()
 		case types.AuditLogPartIntermediaryResponseBody:
-			if al.Transaction_.Response_ == nil {
-				al.Transaction_.Response_ = &auditlog.TransactionResponse{}
-			}
-			al.Transaction_.Response_.Body_ = tx.variables.responseBody.Get()
+			tx.auditLogResponse(&al.Transaction_).Body_ = tx.variables.responseBody.Get()
 		case types.AuditLogPartResponseHeaders:
-			if al.Transaction_.Response_ == nil {
-				al.Transaction_.Response_ = &auditlog.TransactionResponse{}
-			}
-			status, _ := strconv.Atoi(tx.variables.responseStatus.Get())
-			al.Transaction_.Response_.Status_ = status
-			al.Transaction_.Response_.Headers_ = tx.variables.responseHeaders.Data()
+			tx.auditLogResponse(&al.Transaction_).Headers_ = tx.variables.responseHeaders.Data()
 		case types.AuditLogPartAuditLogTrailer:
 			auditLogPartAuditLogTrailerSet = true
 			al.Transaction_.Producer_ = &auditlog.TransactionProducer{
@@ -1573,62 +1584,100 @@ func (tx *Transaction) AuditLog() *auditlog.Log {
 			}
 		case types.AuditLogPartRulesMatched:
 			auditLogPartRulesMatchedSet = true
-			for _, mr := range tx.matchedRules {
-				// Audit flag controls whether a matched rule appears in the audit log.
-				// This aligns with ModSecurity behavior where:
-				// - log: sets both Log and Audit (appears in error log AND audit log)
-				// - nolog: clears both (appears in neither)
-				// - nolog,auditlog: Log=false, Audit=true (audit log only)
-				// - log,noauditlog: Log=true, Audit=false (error log only)
-				mrWithlog, ok := mr.(*corazarules.MatchedRule)
-				if ok && mrWithlog.Audit() {
-					r := mr.Rule()
-					for _, matchData := range mr.MatchedDatas() {
-						newAlEntry := auditlog.Message{
-							Actionset_: strings.Join(tx.WAF.ComponentNames, " "),
-							Message_:   matchData.Message(),
-							Data_: &auditlog.MessageData{
-								File_:     mr.Rule().File(),
-								Line_:     mr.Rule().Line(),
-								ID_:       r.ID(),
-								Rev_:      r.Revision(),
-								Msg_:      matchData.Message(),
-								Data_:     matchData.Data(),
-								Severity_: r.Severity(),
-								Ver_:      r.Version(),
-								Maturity_: r.Maturity(),
-								Accuracy_: r.Accuracy(),
-								Tags_:     r.Tags(),
-								Raw_:      r.Raw(),
-							},
-						}
-						// If AuditLogPartAuditLogTrailer (H) is set, we expect to log the error messages emitted by the rules
-						// in the audit log
-						if auditLogPartAuditLogTrailerSet {
-							newAlEntry.ErrorMessage_ = mr.ErrorLog()
-						}
-						al.Messages_ = append(al.Messages_, newAlEntry)
-					}
-				}
-			}
 		}
 	}
 
-	// If AuditLogPartRulesMatched (K) is not set, but AuditLogPartAuditLogTrailer (H) is set, we still expect to
-	// log the error messages emitted by the rules (if the rule has Audit set to true)
-	if !auditLogPartRulesMatchedSet && auditLogPartAuditLogTrailerSet {
-		for _, mr := range tx.matchedRules {
-			mrWithlog, ok := mr.(*corazarules.MatchedRule)
-			if ok && mrWithlog.Audit() {
-				al.Messages_ = append(al.Messages_, auditlog.Message{
-					ErrorMessage_: mr.ErrorLog(),
-				})
-			}
-		}
-
+	if auditLogPartAuditLogTrailerSet || auditLogPartRulesMatchedSet {
+		al.Messages_ = tx.auditLogMessages(auditLogPartAuditLogTrailerSet)
 	}
 
 	return al
+}
+
+// auditLogResponse returns the response object, creating it from transaction state when needed.
+func (tx *Transaction) auditLogResponse(transaction *auditlog.Transaction) *auditlog.TransactionResponse {
+	if transaction.Response_ == nil {
+		status, _ := strconv.Atoi(tx.variables.responseStatus.Get())
+		transaction.Response_ = &auditlog.TransactionResponse{
+			Protocol_: tx.variables.responseProtocol.Get(),
+			Status_:   status,
+		}
+	}
+
+	return transaction.Response_
+}
+
+// auditLogMatchData exposes optional structured match data carried by rule matches.
+type auditLogMatchData interface {
+	Match() string
+	Reference() string
+}
+
+// auditLogMessages builds structured audit messages for matched rules marked for auditing.
+func (tx *Transaction) auditLogMessages(includeErrorMessage bool) []plugintypes.AuditLogMessage {
+	var messages []plugintypes.AuditLogMessage
+	actionset := strings.Join(tx.WAF.ComponentNames, " ")
+
+	for _, mr := range tx.matchedRules {
+		// Audit flag controls whether a matched rule appears in the audit log.
+		// This aligns with ModSecurity behavior where:
+		// - log: sets both Log and Audit (appears in error log AND audit log)
+		// - nolog: clears both (appears in neither)
+		// - nolog,auditlog: Log=false, Audit=true (audit log only)
+		// - log,noauditlog: Log=true, Audit=false (error log only)
+		mrWithLog, ok := mr.(*corazarules.MatchedRule)
+		if !ok || !mrWithLog.Audit() {
+			continue
+		}
+
+		matchedDatas := mr.MatchedDatas()
+		if len(matchedDatas) == 0 {
+			continue
+		}
+
+		errorMessage := ""
+		if includeErrorMessage {
+			errorMessage = mr.ErrorLog()
+		}
+
+		r := mr.Rule()
+		for i, matchData := range matchedDatas {
+			messageError := ""
+			if i == 0 {
+				messageError = errorMessage
+			}
+
+			match, reference := "", ""
+			if details, ok := matchData.(auditLogMatchData); ok {
+				match = details.Match()
+				reference = details.Reference()
+			}
+
+			messages = append(messages, auditlog.Message{
+				Actionset_:    actionset,
+				Message_:      matchData.Message(),
+				ErrorMessage_: messageError,
+				Data_: &auditlog.MessageData{
+					File_:      r.File(),
+					Line_:      r.Line(),
+					ID_:        r.ID(),
+					Rev_:       r.Revision(),
+					Msg_:       matchData.Message(),
+					Data_:      matchData.Data(),
+					Severity_:  r.Severity(),
+					Ver_:       r.Version(),
+					Maturity_:  r.Maturity(),
+					Accuracy_:  r.Accuracy(),
+					Tags_:      r.Tags(),
+					Raw_:       r.Raw(),
+					Match_:     match,
+					Reference_: reference,
+				},
+			})
+		}
+	}
+
+	return messages
 }
 
 // auditLogCollectFiles collects uploaded file metadata from transaction variables

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -839,6 +839,107 @@ func TestAuditLogFields(t *testing.T) {
 	}
 }
 
+// TestAuditLogTrailerIncludesStructuredMessages verifies H-only logs retain structured rule data.
+func TestAuditLogTrailerIncludesStructuredMessages(t *testing.T) {
+	tx := makeTransaction(t)
+	defer closeTransaction(t, tx)
+	tx.AuditLogParts = types.AuditLogParts("ABCHZ")
+	tx.ProcessResponseHeaders(http.StatusForbidden, "HTTP/1.1")
+
+	rule := NewRule()
+	rule.ID_ = 131
+	rule.Log = true
+	rule.Audit = true
+	rule.SetOperator(&dummyEqOperator{}, "@eq", "matched")
+	tx.MatchRule(rule, []types.MatchData{
+		&corazarules.MatchData{
+			Variable_: variables.UniqueID,
+			Value_:    "matched",
+			Message_:  "matched request",
+			Data_:     "matched data",
+		},
+	})
+
+	al := tx.AuditLog()
+	if got := al.Transaction().Request().HTTPVersion(); got != "HTTP/1.1" {
+		t.Fatalf("expected request HTTP version HTTP/1.1, got %q", got)
+	}
+	if got := al.Transaction().Response().Protocol(); got != "HTTP/1.1" {
+		t.Fatalf("expected response protocol HTTP/1.1, got %q", got)
+	}
+	if got := al.Transaction().Response().Status(); got != http.StatusForbidden {
+		t.Fatalf("expected response status %d, got %d", http.StatusForbidden, got)
+	}
+
+	if len(al.Messages()) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(al.Messages()))
+	}
+	if got := al.Messages()[0].Message(); got != "matched request" {
+		t.Fatalf("expected message %q, got %q", "matched request", got)
+	}
+	if got := al.Messages()[0].Data().ID(); got != rule.ID_ {
+		t.Fatalf("expected message rule ID %d, got %d", rule.ID_, got)
+	}
+	if got := al.Messages()[0].Data().Data(); got != "matched data" {
+		t.Fatalf("expected message data %q, got %q", "matched data", got)
+	}
+	if got := al.Messages()[0].Data().(interface{ Match() string }).Match(); got == "" {
+		t.Fatal("expected structured message match detail")
+	}
+}
+
+// TestAuditLogMatchDetailsUseOriginatingRuleForChain verifies chained matches use their source rules.
+func TestAuditLogMatchDetailsUseOriginatingRuleForChain(t *testing.T) {
+	parent := NewRule()
+	parent.ID_ = 132
+	parent.LogID_ = "132"
+	parent.Log = true
+	parent.Audit = true
+	parent.HasChain = true
+	if err := parent.AddVariable(variables.RequestURI, "", false); err != nil {
+		t.Fatal(err)
+	}
+	parent.SetOperator(&dummyEqOperator{}, "@eq", "parent")
+
+	child := NewRule()
+	child.ID_ = noID
+	child.ParentID_ = parent.ID_
+	child.LogID_ = parent.LogID_
+	if err := child.AddVariable(variables.ArgsGet, "", false); err != nil {
+		t.Fatal(err)
+	}
+	child.SetOperator(&dummyEqOperator{}, "@eq", "child")
+	parent.Chain = child
+
+	tx := NewWAF().NewTransaction()
+	defer closeTransaction(t, tx)
+	tx.AuditLogParts = types.AuditLogParts("H")
+	tx.ProcessURI("0", "GET", "HTTP/1.1")
+	tx.AddGetRequestArgument("child", "0")
+
+	var matchedValues []types.MatchData
+	parent.doEvaluate(debuglog.Noop(), types.PhaseRequestHeaders, tx, &matchedValues, 0, tx.transformationCache)
+
+	al := tx.AuditLog()
+	if len(al.Messages()) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(al.Messages()))
+	}
+
+	expected := []string{
+		"Matched \"Operator `Eq' with parameter `parent' against variable `REQUEST_URI' (Value: `0' )\"",
+		"Matched \"Operator `Eq' with parameter `child' against variable `ARGS_GET:child' (Value: `0' )\"",
+	}
+	for i, want := range expected {
+		details, ok := al.Messages()[i].Data().(auditLogMatchData)
+		if !ok {
+			t.Fatalf("expected message %d to expose match details", i)
+		}
+		if got := details.Match(); got != want {
+			t.Fatalf("expected message %d match %q, got %q", i, want, got)
+		}
+	}
+}
+
 func TestAuditLogMessageFiltering(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -1829,6 +1930,14 @@ func makeTransaction(t testing.TB) *Transaction {
 		panic(err)
 	}
 	return tx
+}
+
+// closeTransaction closes a transaction and reports cleanup failures to the test.
+func closeTransaction(t testing.TB, tx *Transaction) {
+	t.Helper()
+	if err := tx.Close(); err != nil {
+		t.Errorf("Failed to close transaction: %s", err.Error())
+	}
 }
 
 func makeTransactionTimestamped(t testing.TB) *Transaction {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -758,8 +758,9 @@ func directiveSecAuditLogType(options *DirectiveOptions) error {
 }
 
 // Description: Select the output format of the AuditLogs. The format can be
-// the native AuditLogs format, JSON, or OCSF (Open CyberSecurity Schema Framework).
-// Syntax: SecAuditLogFormat JSON|JsonLegacy|Native|OCSF
+// the native AuditLogs format, JSON, libmodsecurity v3 JSON, or OCSF
+// (Open CyberSecurity Schema Framework).
+// Syntax: SecAuditLogFormat JSON|ModSecurityV3|JsonLegacy|Native|OCSF
 // Default: Native
 func directiveSecAuditLogFormat(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {


### PR DESCRIPTION
Closes: #856 

I added a new `JSONV3` audit log formatter that emits the libmodsecurity v3 JSON schema and kept the existing `JSON` and `JSONLEGACY` formatters unchanged. The `SecAuditLogFomrat JSONV3` is registered and H-only audit logs retain structured match-rule data so `messages` can be emitted in the v3 format. Best-effort `match` details are populated for rule messages.

I am new to this codebase, so let me know what I can improve. Hope this helps!

- [X] My code includes positive and negative tests.
- [X] I have an appropriate description with correct grammar.
- [X] I have read the [Contribution guidelines](https://github.com/corazawaf/coraza/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/corazawaf/coraza/blob/main/CODE_OF_CONDUCT.md).
- [X] My code is properly linted and passes pre-commit tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `JSONV3` (libModSecurity v3) audit log format, registered as `modsecurityv3`.
  * Produces a v3-compatible JSON structure with HTTP version normalization, producer metadata, and structured per-message match/reference when enabled.
* **Bug Fixes**
  * Improved robustness for optional message data and structured match/reference fields.
  * Refined audit-trailer generation, including correct handling of chained-rule attribution and audit-part gating.
* **Documentation**
  * Updated `SecAuditLogFormat` directive docs to include `JSONV3`.
* **Tests**
  * Added JSONV3 formatter and audit-part coverage, plus unit tests validating trailer structured messages and chain attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->