### PR TITLE
fix: reset detectionOnlyInterruption on transaction pool reuse

### DIFF
--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -201,6 +201,7 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 	tx.context = opts.Context
 	tx.matchedRules = []types.MatchedRule{}
 	tx.interruption = nil
+	tx.detectionOnlyInterruption = nil
 	tx.Logdata = "" // Deprecated, this variable is not used. Logdata for each matched rule is stored in the MatchData field.
 	tx.SkipAfter = ""
 	tx.AuditEngine = w.AuditEngine

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -41,6 +41,27 @@ func TestNewTransaction(t *testing.T) {
 	}
 }
 
+func TestNewTransactionResetsDetectionOnlyInterruption(t *testing.T) {
+	waf := NewWAF()
+
+	// A transaction that recorded a detection-only interruption, then returned
+	// to the pool via Close().
+	tx := waf.NewTransaction()
+	tx.detectionOnlyInterruption = &types.Interruption{Status: 403}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A subsequent transaction reuses the pooled object and must not inherit it.
+	reused := waf.NewTransaction()
+	if reused.IsDetectionOnlyInterrupted() {
+		t.Error("detectionOnlyInterruption leaked from a pooled transaction into a reused one")
+	}
+	if err := reused.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSetDebugLogPath(t *testing.T) {
 	tests := map[string]struct {
 		path string


### PR DESCRIPTION
Fixes #1640

`newTransaction()` resets `interruption` but not `detectionOnlyInterruption`, so a pooled transaction can carry a stale would-be-block status from a previous request. Under `RelevantOnly` + `DetectionOnly` this causes audit logs for non-relevant requests (empty `messages`).

Fix: reset `detectionOnlyInterruption` in `newTransaction()`, next to the existing `interruption` reset.

Added `TestNewTransactionResetsDetectionOnlyInterruption - it fails without the change and passes with it. The positive case (field set when it should be) is already covered by `TestMatchRuleDisruptiveActionPopulated`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction reuse so detection-only interruptions no longer carry over to subsequent transactions.
  * Ensures each new transaction starts with a clean interruption state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->