### PR TITLE
fix: accept base64url alphabet in base64DecodeExt

### DIFF
--- a/internal/transformations/base64decode.go
+++ b/internal/transformations/base64decode.go
@@ -64,6 +64,20 @@ func doBase64decode(src string, ext bool) string {
 			break
 		}
 
+		// The base64url alphabet (RFC 4648 §5) substitutes '-' and '_' for
+		// '+' and '/'. Accepting both here lets t:base64DecodeExt decode
+		// base64url tokens (e.g. JWT segments) instead of dropping those
+		// characters and misaligning everything after them, which would
+		// otherwise let an attacker hide a match target past that point.
+		if ext {
+			switch currChar {
+			case '-':
+				currChar = '+'
+			case '_':
+				currChar = '/'
+			}
+		}
+
 		decodedChar := byte(127)
 		if currChar <= 127 {
 			decodedChar = base64DecMap[currChar]

--- a/internal/transformations/base64decodeext_test.go
+++ b/internal/transformations/base64decodeext_test.go
@@ -78,6 +78,25 @@ var b64DecodeExtTests = []struct {
 		input:    "dz!BzV==",
 		expected: "w0s",
 	},
+	// base64url (RFC 4648 §5) substitutes '-'/'_' for '+'/'/', as used by
+	// JWT segments. Treated as out-of-alphabet bytes, both characters are
+	// skipped by the forgiving decoder, misaligning every quad after them.
+	// See https://github.com/coreruleset/coreruleset/pull/4663.
+	{
+		name:     "base64url '-' in place of '+'",
+		input:    "-w==",
+		expected: string([]byte{0xfb}),
+	},
+	{
+		name:     "base64url '_' in place of '/'",
+		input:    "_w==",
+		expected: string([]byte{0xff}),
+	},
+	{
+		name:     "base64url JWT header: '-'/'_' before the match target must not corrupt the decode",
+		input:    "eyJwIjoieHh-IiwiYWxnIjoibm9uZSIsInR5cCI6IkpXVCJ9",
+		expected: `{"p":"xx~","alg":"none","typ":"JWT"}`,
+	},
 }
 
 func TestBase64DecodeExt(t *testing.T) {


### PR DESCRIPTION
## Summary

- `t:base64DecodeExt` treated `-`/`_` (RFC 4648 §5's base64url substitutes for `+`/`/`) as invalid characters, so `doBase64decode` stopped decoding at the first one it saw.
- Any base64url-encoded token (e.g. a JWT segment) containing `-` or `_` before a rule's match target had everything past it silently dropped from the decoded output.
- `doBase64decode`, when `ext` is set, now maps `-`→`+` and `_`→`/` before the existing lookup table, so `base64decodeext` decodes the base64url alphabet fully instead of truncating. Scoped to the `ext` path only — the strict `base64decode` transform is unchanged.

Fixes #1651.

Surfaced while reviewing [coreruleset/coreruleset#4663](https://github.com/coreruleset/coreruleset/pull/4663), which adds a JWT `alg:none` detection rule using `t:base64DecodeExt`.

## Test plan

- [x] Added regression tests reproducing the exact JWT PoC from the CRS PR thread (`eyJwIjoieHh-Iiwi...` decodes fully, including `"alg":"none"`)
- [x] Added `-w==`/`_w==` single-character base64url alphabet checks
- [x] Verified strict `base64decode` still rejects `-`/`_` (unchanged behavior)
- [x] `go test ./...`, `go vet ./...`, `golangci-lint run` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lenient Base64 decoding to properly accept Base64URL characters (`-` and `_`), aligning output with expected results.
  * Fixed scenarios where Base64URL content could be mishandled, leading to incorrect decoding or premature termination.
* **Tests**
  * Added additional Base64URL-focused coverage for the lenient decoder to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->