### PR TITLE
fix: decode ES2015+ \u{...} extended unicode escapes in jsDecode

### DIFF
--- a/internal/transformations/js_decode.go
+++ b/internal/transformations/js_decode.go
@@ -33,16 +33,23 @@ func doJsDecode(input string, pos int) (string, bool) {
 		if input[i] == '\\' {
 			/* Character is an escape. */
 
+			/* Measured once here rather than in the case guard below, which
+			 * would otherwise have to repeat the scan to recover the length. */
+			extLen := 0
+			if (i+2 < inputLen) && (input[i+1] == 'u') && (input[i+2] == '{') {
+				extLen = jsExtendedUnicodeEscapeLen(input, i+3)
+			}
+
 			switch {
 
-			case (i+2 < inputLen) && (input[i+1] == 'u') && (input[i+2] == '{') && jsExtendedUnicodeEscapeLen(input, i+3) > 0:
+			case extLen > 0:
 				/* \u{H...H} - ES2015+ extended Unicode code point escape
 				 * (1-6 hex digits). Handled the same way as \uHHHH below:
 				 * lower byte of the value, with the same full-width-ASCII
 				 * fold -- checked against the fully resolved value, not a
 				 * fixed digit count, so a leading-zero encoding (e.g.
 				 * \u{0ff01}) folds the same as \u{ff01}. */
-				j := jsExtendedUnicodeEscapeLen(input, i+3)
+				j := extLen
 
 				var code rune
 				for k := 0; k < j; k++ {

--- a/internal/transformations/js_decode.go
+++ b/internal/transformations/js_decode.go
@@ -35,6 +35,29 @@ func doJsDecode(input string, pos int) (string, bool) {
 
 			switch {
 
+			case (i+2 < inputLen) && (input[i+1] == 'u') && (input[i+2] == '{') && jsExtendedUnicodeEscapeLen(input, i+3) > 0:
+				/* \u{H...H} - ES2015+ extended Unicode code point escape
+				 * (1-6 hex digits). Handled the same way as \uHHHH below:
+				 * lower byte of the value, with the same full-width-ASCII
+				 * fold. */
+				j := jsExtendedUnicodeEscapeLen(input, i+3)
+
+				/* Use only the lower byte. */
+				if j == 1 {
+					d[c] = xsingle2c(input[i+3])
+				} else {
+					d[c] = utils.X2c(input[i+3+j-2:])
+				}
+				changed = true
+
+				/* Full width ASCII (ff01 - ff5e) needs 0x20 added */
+				if (j == 4) && (d[c] > 0x00) && (d[c] < 0x5f) && ((input[i+3] == 'f') || (input[i+3] == 'F')) && ((input[i+4] == 'f') || (input[i+4] == 'F')) {
+					d[c] += 0x20
+				}
+
+				c++
+				i += j + 4 // '\', 'u', '{', j hex digits, '}'
+
 			case (i+5 < inputLen) && (input[i+1] == 'u') && (utils.ValidHex(input[i+2])) && (utils.ValidHex(input[i+3])) && (utils.ValidHex(input[i+4])) && (utils.ValidHex(input[i+5])):
 				/* \uHHHH */
 
@@ -130,4 +153,19 @@ func doJsDecode(input string, pos int) (string, bool) {
 
 func isodigit(x byte) bool {
 	return (x >= '0') && (x <= '7')
+}
+
+// jsExtendedUnicodeEscapeLen returns the number of hex digits (1-6) in a
+// \u{H...H} escape whose first hex digit is at pos, or 0 if the escape is
+// malformed (no digits, more than 6 digits, or missing the closing '}').
+func jsExtendedUnicodeEscapeLen(input string, pos int) int {
+	inputLen := len(input)
+	j := 0
+	for (j < 6) && (pos+j < inputLen) && utils.ValidHex(input[pos+j]) {
+		j++
+	}
+	if (j == 0) || (pos+j >= inputLen) || (input[pos+j] != '}') {
+		return 0
+	}
+	return j
 }

--- a/internal/transformations/js_decode.go
+++ b/internal/transformations/js_decode.go
@@ -39,19 +39,22 @@ func doJsDecode(input string, pos int) (string, bool) {
 				/* \u{H...H} - ES2015+ extended Unicode code point escape
 				 * (1-6 hex digits). Handled the same way as \uHHHH below:
 				 * lower byte of the value, with the same full-width-ASCII
-				 * fold. */
+				 * fold -- checked against the fully resolved value, not a
+				 * fixed digit count, so a leading-zero encoding (e.g.
+				 * \u{0ff01}) folds the same as \u{ff01}. */
 				j := jsExtendedUnicodeEscapeLen(input, i+3)
 
-				/* Use only the lower byte. */
-				if j == 1 {
-					d[c] = xsingle2c(input[i+3])
-				} else {
-					d[c] = utils.X2c(input[i+3+j-2:])
+				var code rune
+				for k := 0; k < j; k++ {
+					code = code<<4 | rune(xsingle2c(input[i+3+k]))
 				}
+
+				/* Use only the lower byte. */
+				d[c] = byte(code)
 				changed = true
 
 				/* Full width ASCII (ff01 - ff5e) needs 0x20 added */
-				if (j == 4) && (d[c] > 0x00) && (d[c] < 0x5f) && ((input[i+3] == 'f') || (input[i+3] == 'F')) && ((input[i+4] == 'f') || (input[i+4] == 'F')) {
+				if (code >= 0xff01) && (code <= 0xff5e) {
 					d[c] += 0x20
 				}
 

--- a/internal/transformations/js_decode_test.go
+++ b/internal/transformations/js_decode_test.go
@@ -60,6 +60,31 @@ func TestCJSDecode(t *testing.T) {
 			input: "\\u{zz}",
 			want:  "u{zz}",
 		},
+		// The full-width-ASCII fold must key off the fully resolved value,
+		// not a fixed 4-digit count -- a leading-zero encoding of the same
+		// value (5 or 6 digits) must fold identically to the 4-digit form.
+		{
+			input: "\\u{0ff01}",
+			want:  "!",
+		},
+		{
+			input: "\\u{00ff01}",
+			want:  "!",
+		},
+		{
+			input: "\\u{0ff5e}",
+			want:  "~",
+		},
+		{
+			input: "\\u{000061}",
+			want:  "a",
+		},
+		{
+			// 7 hex digits exceeds the 6-digit maximum: malformed, falls
+			// through to the generic escape handling unchanged.
+			input: "\\u{1234567}",
+			want:  "u{1234567}",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/transformations/js_decode_test.go
+++ b/internal/transformations/js_decode_test.go
@@ -26,6 +26,40 @@ func TestCJSDecode(t *testing.T) {
 			input: "\\",
 			want:  "\\",
 		},
+		// \u{H...H} is the ES2015+ extended Unicode code point escape (1-6
+		// hex digits in braces), used by every modern JS engine. Before
+		// recognizing it, doJsDecode fell through to the generic \C branch,
+		// dropping the backslash and keeping a literal "u" while copying the
+		// rest through unchanged -- silently failing to decode the escape at
+		// all. See https://github.com/corazawaf/coraza/issues/1653.
+		{
+			input: "\\u{61}\\u{6c}\\u{65}\\u{72}\\u{74}",
+			want:  "alert",
+		},
+		{
+			input: "\\u{ff01}",
+			want:  "!",
+		},
+		{
+			input: "\\u{1}",
+			want:  "\x01",
+		},
+		{
+			input: "\\u{41}",
+			want:  "A",
+		},
+		{
+			input: "\\u{",
+			want:  "u{",
+		},
+		{
+			input: "\\u{41",
+			want:  "u{41",
+		},
+		{
+			input: "\\u{zz}",
+			want:  "u{zz}",
+		},
 	}
 
 	for _, tc := range tests {
@@ -50,6 +84,7 @@ func BenchmarkJSDecode(b *testing.B) {
 		"",
 		"hello world",
 		"\\a\\b\\f\\n\\r\\t\\v\\u0000\\?\\'\\\"\\0\\12\\123\\x00\\xff",
+		"\\u{61}\\u{6c}\\u{65}\\u{72}\\u{74}",
 	}
 
 	for _, tc := range tests {

--- a/internal/transformations/js_decode_test.go
+++ b/internal/transformations/js_decode_test.go
@@ -85,6 +85,31 @@ func TestCJSDecode(t *testing.T) {
 			input: "\\u{1234567}",
 			want:  "u{1234567}",
 		},
+		{
+			// Hex digits are case-insensitive, including in a leading-zero
+			// form that still has to fold.
+			input: "\\u{0FF5e}",
+			want:  "~",
+		},
+		{
+			// Empty braces: no hex digits, so not a valid extended escape.
+			// Falls through to generic escape handling, dropping the
+			// backslash and leaving the braces literal.
+			input: "\\u{}",
+			want:  "u{}",
+		},
+		{
+			// A well-formed escape for U+0000 decodes to a NUL byte rather
+			// than being treated as malformed.
+			input: "\\u{0}",
+			want:  "\x00",
+		},
+		{
+			// Extended and classic 4-digit escapes must decode in the same
+			// pass without the extended form consuming the one after it.
+			input: "\\u{41}\\u0042",
+			want:  "AB",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- `doJsDecode` only recognized `\uHHHH` (exactly 4 hex digits). The `\u{H...H}` extended code point escape (1-6 hex digits in braces), supported by every modern JS engine since ES2015, fell through to the generic escape branch — the backslash was dropped and the literal `u` kept, leaving `{H...H}` uncorrected in the output.
- Added a case recognizing `\u{H...H}`, handled the same way as the existing `\uHHHH` case: lower byte of the resolved value, with the same full-width-ASCII fold.
- Malformed escapes (no digits, more than 6 digits, missing closing `}`) fall through to the existing generic-escape handling unchanged.

Fixes #1653.

## Test plan

- [x] Added regression tests: `\u{61}\u{6c}\u{65}\u{72}\u{74}` → `alert` (the reported bypass), single/double hex digit cases, full-width-ASCII fold (`\u{ff01}` → `!`), and malformed-escape fallback cases
- [x] `go test ./...`, `go vet ./...`, `golangci-lint run` all pass

## Benchmark (`BenchmarkJSDecode`, Apple M2, `benchtime=1s`)

| case | main | this branch |
|---|---|---|
| empty string | 2.14-2.28 ns/op | 2.31-2.73 ns/op |
| `hello world` | 3.29-4.30 ns/op | 2.80-2.99 ns/op |
| existing mixed-escape case | 162-166 ns/op, 152 B/op, 7 allocs | 168-247 ns/op, 152 B/op, 7 allocs |
| `\u{61}\u{6c}\u{65}\u{72}\u{74}` (new) | n/a (not decoded before) | 65-73 ns/op, 32 B/op, 1 alloc |

No allocation-count change on any pre-existing case; the new switch-case adds a few cheap byte comparisons per backslash encountered, within run-to-run noise on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for decoding JavaScript ES2015+ extended Unicode escapes in the format `\u{...}` with 1–6 hexadecimal digits.
  * Supports case-insensitive hexadecimal values and preserves compatibility with existing escape formats.
  * Applies full-width ASCII normalization when applicable.
* **Bug Fixes**
  * Improved handling of malformed, incomplete, or oversized escapes so they remain unchanged.
* **Tests**
  * Expanded coverage for valid, malformed, control-character, and mixed escape sequences.
  * Updated benchmarks to include extended Unicode escapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->