### PR TITLE
fix: strip Windows trailing dots/spaces and ADS suffixes in normalisePathWin

### DIFF
--- a/internal/transformations/normalise_path_win.go
+++ b/internal/transformations/normalise_path_win.go
@@ -44,6 +44,14 @@ func stripWindowsADS(data string) string {
 		prefix, data = data[:2], data[2:]
 	}
 
+	// normalisePath preserves a trailing separator, which would otherwise
+	// push the ADS-bearing component out of "last segment" position and
+	// leave the colon-truncation below looking at an empty final segment.
+	trailingSlash := ""
+	if len(data) > 0 && data[len(data)-1] == '/' {
+		trailingSlash, data = "/", data[:len(data)-1]
+	}
+
 	if idx := strings.LastIndexByte(data, '/'); idx >= 0 {
 		if colon := strings.IndexByte(data[idx+1:], ':'); colon >= 0 {
 			data = data[:idx+1+colon]
@@ -52,7 +60,7 @@ func stripWindowsADS(data string) string {
 		data = data[:colon]
 	}
 
-	return prefix + data
+	return prefix + data + trailingSlash
 }
 
 // stripWindowsTrailingDotsAndSpaces mimics the Windows API (CreateFile et
@@ -60,16 +68,63 @@ func stripWindowsADS(data string) string {
 // component before resolving it. A component that is entirely dots (".",
 // "..", a leading ".." that filepath.Clean couldn't resolve further, or an
 // empty component from a repeated "/") is left untouched -- those are
-// navigation syntax, not a filename to canonicalize.
+// navigation syntax, not a filename to canonicalize. A component that
+// trims down to nothing (e.g. " ") is dropped entirely, matching how
+// Windows resolves it, rather than left as an empty component.
 func stripWindowsTrailingDotsAndSpaces(data string) string {
-	segments := strings.Split(data, "/")
-	for i, seg := range segments {
-		if isAllDots(seg) {
+	if !hasTrimmableComponent(data) {
+		return data
+	}
+
+	var buf strings.Builder
+	buf.Grow(len(data))
+	start := 0
+	wroteAny := false
+	for i := 0; i <= len(data); i++ {
+		if i != len(data) && data[i] != '/' {
 			continue
 		}
-		segments[i] = strings.TrimRight(seg, ". ")
+		seg := data[start:i]
+		start = i + 1
+
+		if !isAllDots(seg) {
+			trimmed := strings.TrimRight(seg, ". ")
+			if trimmed == "" {
+				// The component was entirely dots/spaces (but not so
+				// uniformly dots that isAllDots caught it, e.g. " "):
+				// Windows drops it rather than resolving to an empty
+				// component, which would otherwise surface as "//".
+				continue
+			}
+			seg = trimmed
+		}
+
+		if wroteAny {
+			buf.WriteByte('/')
+		}
+		buf.WriteString(seg)
+		wroteAny = true
 	}
-	return strings.Join(segments, "/")
+	return buf.String()
+}
+
+// hasTrimmableComponent reports whether any path component in data ends in
+// '.' or ' ' and isn't itself all dots, without allocating.
+func hasTrimmableComponent(data string) bool {
+	start := 0
+	for i := 0; i <= len(data); i++ {
+		if i != len(data) && data[i] != '/' {
+			continue
+		}
+		seg := data[start:i]
+		if !isAllDots(seg) {
+			if last := seg[len(seg)-1]; last == '.' || last == ' ' {
+				return true
+			}
+		}
+		start = i + 1
+	}
+	return false
 }
 
 func isAllDots(s string) bool {

--- a/internal/transformations/normalise_path_win.go
+++ b/internal/transformations/normalise_path_win.go
@@ -8,10 +8,79 @@ import (
 )
 
 func normalisePathWin(data string) (string, bool, error) {
-	leng := len(data)
-	if leng < 1 {
+	if len(data) < 1 {
 		return data, false, nil
 	}
-	data = strings.ReplaceAll(data, "\\", "/")
-	return normalisePath(data)
+	original := data
+
+	clean, _, err := normalisePath(strings.ReplaceAll(data, "\\", "/"))
+	if err != nil {
+		return clean, false, err
+	}
+
+	// Windows resolves an NTFS Alternate Data Stream suffix ("file:stream",
+	// "file::$DATA") against the base file, and silently strips trailing
+	// dots and spaces from every path component before resolving it
+	// ("file.txt.", "file.txt " both open "file.txt"). Neither is a no-op
+	// for a WAF: a rule matching a blocklisted filename/extension against
+	// the normalized path can be defeated by appending either, while
+	// Windows/IIS still resolves the request to the exact blocked resource.
+	stripped := stripWindowsTrailingDotsAndSpaces(stripWindowsADS(clean))
+
+	// Compare against the true original input rather than reusing
+	// normalisePath's own changed flag, which only sees the
+	// already-slash-converted string and so misses a pure backslash-only
+	// path (no other change needed) as "unchanged".
+	return stripped, original != stripped, nil
+}
+
+// stripWindowsADS truncates the final path segment at its first ':',
+// mirroring how Windows resolves an Alternate Data Stream suffix
+// ("file.txt::$DATA" or "file.txt:hidden" both open "file.txt"'s data). A
+// leading drive letter ("C:/...") is left untouched.
+func stripWindowsADS(data string) string {
+	prefix := ""
+	if len(data) >= 2 && data[1] == ':' && isASCIILetter(data[0]) {
+		prefix, data = data[:2], data[2:]
+	}
+
+	if idx := strings.LastIndexByte(data, '/'); idx >= 0 {
+		if colon := strings.IndexByte(data[idx+1:], ':'); colon >= 0 {
+			data = data[:idx+1+colon]
+		}
+	} else if colon := strings.IndexByte(data, ':'); colon >= 0 {
+		data = data[:colon]
+	}
+
+	return prefix + data
+}
+
+// stripWindowsTrailingDotsAndSpaces mimics the Windows API (CreateFile et
+// al.), which silently strips trailing '.' and ' ' from every path
+// component before resolving it. A component that is entirely dots (".",
+// "..", a leading ".." that filepath.Clean couldn't resolve further, or an
+// empty component from a repeated "/") is left untouched -- those are
+// navigation syntax, not a filename to canonicalize.
+func stripWindowsTrailingDotsAndSpaces(data string) string {
+	segments := strings.Split(data, "/")
+	for i, seg := range segments {
+		if isAllDots(seg) {
+			continue
+		}
+		segments[i] = strings.TrimRight(seg, ". ")
+	}
+	return strings.Join(segments, "/")
+}
+
+func isAllDots(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/internal/transformations/normalise_path_win_test.go
+++ b/internal/transformations/normalise_path_win_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package transformations
+
+import "testing"
+
+func TestNormalisePathWin(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "",
+			want:  "",
+		},
+		{
+			input: `C:\inetpub\wwwroot\index.html`,
+			want:  "C:/inetpub/wwwroot/index.html",
+		},
+		{
+			input: `..\..\etc\passwd`,
+			want:  "../../etc/passwd",
+		},
+		{
+			input: `foo\..\bar`,
+			want:  "bar",
+		},
+		// Windows silently strips trailing dots and spaces from every path
+		// component before resolving it, and resolves an NTFS Alternate
+		// Data Stream suffix ("file:stream", "file::$DATA") against the
+		// base file. Neither was stripped, so a rule matching a
+		// blocklisted filename/extension against the normalized path could
+		// be defeated by appending either. See
+		// https://github.com/corazawaf/coraza/issues/1656.
+		{
+			input: `C:\inetpub\wwwroot\web.config.`,
+			want:  "C:/inetpub/wwwroot/web.config",
+		},
+		{
+			input: `C:\inetpub\wwwroot\web.config `,
+			want:  "C:/inetpub/wwwroot/web.config",
+		},
+		{
+			input: `C:\inetpub\wwwroot\web.config::$DATA`,
+			want:  "C:/inetpub/wwwroot/web.config",
+		},
+		{
+			input: `C:\inetpub\wwwroot\web.config:hidden`,
+			want:  "C:/inetpub/wwwroot/web.config",
+		},
+		{
+			// A leading ".." run that filepath.Clean can't resolve further
+			// must not be mistaken for a trailing-dot filename and
+			// stripped away.
+			input: `..\..\web.config.`,
+			want:  "../../web.config",
+		},
+		{
+			// A drive letter alone must not be misread as an ADS-suffixed
+			// filename.
+			input: `C:`,
+			want:  "C:",
+		},
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		t.Run(tt.input, func(t *testing.T) {
+			have, changed, err := normalisePathWin(tt.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantChanged := tt.input != tt.want
+			if changed != wantChanged {
+				t.Errorf("input %q: changed = %t, want %t (have %q)", tt.input, changed, wantChanged, have)
+			}
+			if have != tt.want {
+				t.Errorf("have %q, want %q", have, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkNormalisePathWin(b *testing.B) {
+	tests := []string{
+		"",
+		`C:\inetpub\wwwroot\index.html`,
+		`..\..\etc\passwd`,
+		`C:\inetpub\wwwroot\web.config.`,
+		`C:\inetpub\wwwroot\web.config::$DATA`,
+	}
+
+	for _, tc := range tests {
+		tt := tc
+		b.Run(tt, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				if _, _, err := normalisePathWin(tt); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/transformations/normalise_path_win_test.go
+++ b/internal/transformations/normalise_path_win_test.go
@@ -62,6 +62,20 @@ func TestNormalisePathWin(t *testing.T) {
 			input: `C:`,
 			want:  "C:",
 		},
+		{
+			// A trailing separator after an ADS suffix must not push the
+			// ADS-bearing component out of "last segment" position and
+			// bypass the colon truncation.
+			input: `C:\path\web.config:$DATA\`,
+			want:  "C:/path/web.config/",
+		},
+		{
+			// A component that is entirely spaces trims down to nothing;
+			// Windows drops it rather than resolving through an empty
+			// component, which would otherwise surface as "//".
+			input: `C:\ \file.txt`,
+			want:  "C:/file.txt",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- `normalisePathWin` only converted backslashes to slashes and delegated to the POSIX-style `normalisePath` (`filepath.Clean`). It didn't replicate two Windows-specific filesystem behaviors that are classic WAF-evasion vectors:
  - `CreateFile` et al. silently strip trailing dots and spaces from every path component before resolving it (`web.config.` and `web.config ` both open `web.config`).
  - Windows resolves NTFS Alternate Data Stream syntax (`file:stream`, `file::$DATA`) against the base file.
- Neither was stripped, so a rule matching a blocklisted filename/extension against the normalized path could be defeated by appending either, while Windows/IIS still resolves the request to the exact blocked resource.
- `stripWindowsTrailingDotsAndSpaces` leaves a component that's entirely dots (`.`, `..`, an unresolved leading `..` run, or an empty component from a repeated `/`) untouched — those are navigation syntax, not a filename to canonicalize, and trimming them would otherwise collapse `..` into an empty segment.
- Also fixes the `changed` flag, which only ever compared the already-slash-converted string against `filepath.Clean`'s output, so a pure backslash-only path (no further change needed) was reported as `changed=false` even though the output differs from the true original input.

Fixes #1656.

## Test plan

- [x] Added `normalise_path_win_test.go` (none existed before): trailing dot/space, `::$DATA` and `:stream` ADS suffixes, a leading unresolved `..` run staying intact, a bare drive letter not being misread as an ADS suffix, and the corrected `changed` flag on a pure backslash path
- [x] `go test ./...`, `go vet ./...`, `golangci-lint run` all pass

## Benchmark (`BenchmarkNormalisePathWin`, Apple M2, `benchtime=1s`)

| case | main | this branch |
|---|---|---|
| empty string | 1.95-1.97 ns/op | 1.97-2.02 ns/op |
| `C:\inetpub\wwwroot\index.html` | 99-103 ns/op, 32 B/op, 1 alloc | 232-244 ns/op, 160 B/op, 4 allocs |
| `..\..\etc\passwd` | 82-84 ns/op, 16 B/op, 1 alloc | 188-193 ns/op, 96 B/op, 3 allocs |
| `C:\inetpub\wwwroot\web.config.` | 100-103 ns/op, 32 B/op, 1 alloc | 232-250 ns/op, 160 B/op, 4 allocs |
| `C:\inetpub\wwwroot\web.config::$DATA` | 110-113 ns/op, 48 B/op, 1 alloc | 256-258 ns/op, 176 B/op, 4 allocs |

More allocations than before (the per-component `strings.Split`/`Join` for trailing-dot stripping, plus the ADS scan), roughly 2-3x CPU time — the cost of actually replicating Windows' filename-resolution rules instead of skipping them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows path normalization for consistent handling of backslashes, `..` segments, and Windows-specific cleanup.
  * Strip trailing dots and spaces from applicable path components.
  * Remove Windows NTFS alternate data stream suffixes from normalized paths.
  * Preserve valid dot-navigation segments and correctly handle leading traversal paths.
  * Propagate normalization errors and accurately report whether the original path changed.
* **Tests**
  * Added comprehensive coverage and benchmarks for Windows path normalization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->