### PR TITLE
fix: treat CR, CRLF and FF as line continuations in cssDecode

### DIFF
--- a/internal/transformations/css_decode.go
+++ b/internal/transformations/css_decode.go
@@ -104,10 +104,20 @@ func cssDecodeInplace(input string, pos int) string {
 
 					/* Move over. */
 					i += j
-				case input[i] == '\n':
+				case input[i] == '\n', input[i] == '\f':
 					/* No hexadecimal digits after backslash */
-					/* A newline character following backslash is ignored. */
+					/* A newline character following backslash is ignored.
+					 * CSS treats CR and FF as newlines as well, both are
+					 * turned into LF before the escape is read. */
 					i++
+				case input[i] == '\r':
+					/* CR is a newline too, and CRLF is a single one, so the
+					 * LF has to go with it rather than being copied out as a
+					 * normal character. */
+					i++
+					if i < inputLen && input[i] == '\n' {
+						i++
+					}
 				default:
 					/* The character after backslash is not a hexadecimal digit,
 					 * nor a newline. */

--- a/internal/transformations/css_decode.go
+++ b/internal/transformations/css_decode.go
@@ -99,6 +99,9 @@ func cssDecodeInplace(input string, pos int) string {
 
 					/* We must ignore a single whitespace after a hex escape */
 					if (i+j < inputLen) && isspace(input[i+j]) {
+						if input[i+j] == '\r' && i+j+1 < inputLen && input[i+j+1] == '\n' {
+							j++
+						}
 						j++
 					}
 

--- a/internal/transformations/css_decode_test.go
+++ b/internal/transformations/css_decode_test.go
@@ -57,6 +57,12 @@ func TestCSSDecode(t *testing.T) {
 			input: "\\41\x19b",
 			want:  "A\x19b",
 		},
+		// CRLF is one CSS newline, so the pair is the single whitespace
+		// ignored after a hex escape.
+		{
+			input: "aler\\74\r\n(1)",
+			want:  "alert(1)",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/transformations/css_decode_test.go
+++ b/internal/transformations/css_decode_test.go
@@ -22,6 +22,30 @@ func TestCSSDecode(t *testing.T) {
 			input: "test\\a\\b\\f\\n\\r\\t\\v\\?\\'\\\"\\\u0000\\12\\123\\1234\\12345\\123456\\ff01\\ff5e\\\n\\\u0000  string",
 			want:  "test\n\u000b\u000fnrtv?'\"\u0000\u0012#4EV!~\u0000  string",
 		},
+		// A backslash before any CSS newline is a line continuation that
+		// produces nothing, so "aler\<newline>t(1)" has to fold back into
+		// "alert(1)" before a rule ever gets to look at it.
+		{
+			input: "aler\\\r\nt(1)",
+			want:  "alert(1)",
+		},
+		{
+			input: "aler\\\rt(1)",
+			want:  "alert(1)",
+		},
+		{
+			input: "aler\\\ft(1)",
+			want:  "alert(1)",
+		},
+		{
+			input: "aler\\\nt(1)",
+			want:  "alert(1)",
+		},
+		// A CR or FF that is not preceded by a backslash stays where it is.
+		{
+			input: "a\rb\fc\\x",
+			want:  "a\rb\fcx",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/transformations/css_decode_test.go
+++ b/internal/transformations/css_decode_test.go
@@ -46,6 +46,17 @@ func TestCSSDecode(t *testing.T) {
 			input: "a\rb\fc\\x",
 			want:  "a\rb\fcx",
 		},
+		// Only the four CSS newlines are continuations. An escaped control
+		// character that is not one of them still comes out as itself, and a
+		// hex escape is not terminated by one either.
+		{
+			input: "a\\\x19b",
+			want:  "a\x19b",
+		},
+		{
+			input: "\\41\x19b",
+			want:  "A\x19b",
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Fixes #1665

CSS treats CR, CRLF and FF as newlines, converting them to LF before escapes are read, and a backslash before a newline is a line continuation that produces nothing. `cssDecodeInplace` only folds LF. The other three fall through to the "use one character after backslash as is" branch:

```
aler\<CRLF>t(1)  ->  aler\r\nt(1)
aler\<CR>t(1)    ->  aler\rt(1)
aler\<FF>t(1)    ->  aler\ft(1)
```

A browser reads all three as `alert(1)`, so a rule matching `alert` misses them.

The change puts CR and FF alongside the existing LF case. CR also consumes a following LF, otherwise the second byte of a CRLF pair gets copied out as ordinary text.

This does go further than ModSecurity's `css_decode_inplace`, which only handles LF as well. I went with CSS behaviour over parity because the C original is bypassable here in a way browsers are not, and #1659 already broke parity in the same direction when it made `compressWhitespace` decode runes instead of indexing bytes.

Tests: one case per escaped newline, plus one checking an unescaped CR or FF still passes through, since this should not start eating stray control bytes. Three fail on main.

On the suite, I'm on Windows and a fair number of tests fail there for unrelated reasons, so I compared against a clean tree rather than trusting the raw output. `TestTransformations` fails 34 subtests both before and after, all `normalisePath`, all down to `filepath.Clean` handing back backslashes. Nothing outside `normalisePath` fails. `go build ./...` and `go vet` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS escape decoding for form-feed, carriage-return, and CRLF newline sequences.
  * Correctly handles escaped line continuations across supported newline formats.
  * Preserves unescaped carriage-return and form-feed characters as written.
  * Improved handling of escaped control characters and hexadecimal escapes followed by control characters.
  * Prevents unexpected characters when escaped newlines follow hexadecimal sequences.

* **Tests**
  * Added coverage for CSS decoding and line continuation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->