### PR TITLE
fix(corazawaf): reset the transformation cache when a transaction leaves the pool

### DIFF
--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -253,6 +253,16 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 
 		tx.variables = *NewTransactionVariables()
 		tx.transformationCache = map[transformationKey]transformationValue{}
+	} else {
+		// The transformation cache is scoped to a single transaction: rulegroup.go
+		// keys it by unsafe.StringData(argKey), which is only sound "as the strings
+		// will be alive throughout the phase". Allocating it inside the branch above
+		// means a transaction coming back from txPool keeps every entry it ever
+		// cached, and each *byte key keeps its backing array reachable, so the map
+		// grows monotonically with the number of requests served. Entries can never
+		// be reused across transactions either: the key holds a fresh string pointer
+		// on every request, so a stale entry can only ever miss.
+		clear(tx.transformationCache)
 	}
 
 	// set capture variables

--- a/internal/corazawaf/waf_test.go
+++ b/internal/corazawaf/waf_test.go
@@ -62,6 +62,57 @@ func TestNewTransactionResetsDetectionOnlyInterruption(t *testing.T) {
 	}
 }
 
+func TestNewTransactionResetsTransformationCache(t *testing.T) {
+	waf := NewWAF()
+
+	tx := waf.NewTransaction()
+	argKey := []byte("ARGS:leaked")
+	tx.transformationCache[transformationKey{argKey: &argKey[0], argIndex: 1}] =
+		transformationValue{arg: "transformed"}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A subsequent transaction reuses the pooled object. The cache is scoped to a
+	// single transaction, so it must come back empty.
+	reused := waf.NewTransaction()
+	if got := len(reused.transformationCache); got != 0 {
+		t.Errorf("reused transaction inherited %d transformation cache entries, want 0", got)
+	}
+	if err := reused.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTransformationCacheDoesNotGrowAcrossTransactions(t *testing.T) {
+	waf := NewWAF()
+
+	// Each round writes one distinct key, mirroring transformArg: the key holds
+	// unsafe.StringData(argKey), a fresh pointer on every request, so entries can
+	// never be reused across transactions — they can only accumulate.
+	const rounds = 200
+	maxSeen := 0
+	for i := 0; i < rounds; i++ {
+		tx := waf.NewTransaction()
+		argKey := []byte("ARGS:round")
+		tx.transformationCache[transformationKey{argKey: &argKey[0], argIndex: i}] =
+			transformationValue{arg: "transformed"}
+		if n := len(tx.transformationCache); n > maxSeen {
+			maxSeen = n
+		}
+		if err := tx.Close(); err != nil {
+			t.Fatalf("round %d: %v", i, err)
+		}
+	}
+
+	// One entry per round is the entry that round just wrote. Anything above that
+	// is a previous round that was never released.
+	if maxSeen > 1 {
+		t.Errorf("transformation cache accumulated across transactions: saw up to %d entries over %d rounds, want 1",
+			maxSeen, rounds)
+	}
+}
+
 func TestSetDebugLogPath(t *testing.T) {
 	tests := map[string]struct {
 		path string


### PR DESCRIPTION
## Summary

`Transaction.transformationCache` is allocated inside the `if tx.requestBodyBuffer == nil` branch of `newTransaction()` ([`waf.go`](https://github.com/corazawaf/coraza/blob/main/internal/corazawaf/waf.go#L234-L256)). That branch is only taken for a genuinely new object, so a transaction coming back from `txPool` keeps every entry it has ever cached. The map grows monotonically with the number of requests served, for the lifetime of the process.

`grep -rn transformationCache internal/` on `main` returns exactly two hits — the field declaration and that one allocation. Nothing ever clears it.

## This is not #1515 / #1516 — it is the one case that rule does not cover

@fzipi closed #1516 with, and I think correctly:

> `newTransaction()` (`waf.go:188–269`) already resets **every single one** of these fields when pulling from the pool. The standard Go `sync.Pool` pattern is "initialize on Get, not on Put" — Coraza already follows it correctly.

That is exactly right for the seven fields in that PR, and this change deliberately **follows** that rule instead of contradicting it: the reset is on the Get path, in `newTransaction()`, not in `Close()`.

The difference is that `transformationCache` is the one pooled field `newTransaction()` does **not** reset, because its initialisation is guarded by `tx.requestBodyBuffer == nil` — false on every reuse. So this is not defensive hardening against a hypothetical future divergence; it is a live retention path today.

The second review point on #1516 was:

> The test doesn't validate what it claims. […] so the test passes **with or without** the `Close()` changes.

Addressed head-on. On `main`, with the `waf.go` change reverted and only the tests applied:

```
=== RUN   TestNewTransactionResetsTransformationCache
    waf_test.go:80: reused transaction inherited 1 transformation cache entries, want 0
--- FAIL: TestNewTransactionResetsTransformationCache (0.00s)
=== RUN   TestTransformationCacheDoesNotGrowAcrossTransactions
    waf_test.go:111: transformation cache accumulated across transactions: saw up to 200 entries over 200 rounds, want 1
--- FAIL: TestTransformationCacheDoesNotGrowAcrossTransactions (0.00s)
FAIL
```

200 rounds, 200 surviving entries — one per transaction, none released. With the change both pass.

## Why the surviving entries are not even useful

[`rulegroup.go`](https://github.com/corazawaf/coraza/blob/main/internal/corazawaf/rulegroup.go#L290-L302) keys the cache by `unsafe.StringData(argKey)`, a `*byte`, and states the invariant that makes it sound:

> we know that the arg key string is populated once per transaction phase […] **as the strings will be alive throughout the phase**

The cache is scoped to a transaction by design. Across transactions the pointer is fresh on every request, so a surviving entry can only ever *miss* — it is pure retention, never a hit. And because the key is a real pointer, each stale entry also keeps its backing array reachable, so the retained bytes are not just the cached strings.

## Impact observed

A production reverse proxy (`coraza-caddy` + OWASP CRS 4.25.0, ~30 WAF instances), live heap measured with `pprof` after a forced GC:

| | live heap | top contributor |
|---|---|---|
| before | 1931 MiB | `(*Rule).transformArg` — 94.8% |
| after | 34 MiB | `transformArg` absent from the profile |

The process was being OOM-killed roughly every 40 minutes at about 1 req/s, which is what sent me looking. Retention measured at ~1.3 MiB per request served through the WAF.

## Test plan

- [x] `TestNewTransactionResetsTransformationCache` — mirrors the existing `TestNewTransactionResetsDetectionOnlyInterruption` in the same file
- [x] `TestTransformationCacheDoesNotGrowAcrossTransactions` — 200 rounds, asserts the cache never holds more than the entry the current round wrote
- [x] Both **fail on `main`** and pass with the change (output above)
- [x] `go run mage.go check` passes
- [x] `go test ./...` — 25 packages, 0 failures
- [x] `gofmt`/`go vet` clean; **`go.mod` and `go.sum` untouched**

One note for reviewers: `clear()` is the project's first use of that builtin. TinyGo has supported it for maps since it moved to Go 1.21, well before the `0.40.1` pinned in `tinygo.yml`, but the TinyGo job on this PR is the real check — happy to switch to a `for k := range m { delete(m, k) }` loop if it objects.

---

*Prepared with assistance from Claude (Anthropic); the analysis, the failing-test verification and the production measurements were carried out and checked by me.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction reuse to prevent stale transformation data from carrying over between requests.
  * Prevented transformation cache entries from accumulating during repeated transactions, supporting more consistent performance and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->