### PR TITLE
[draft] fix(corazawaf): key the transformation cache by value identity

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -266,7 +266,7 @@ func (r *Rule) doEvaluate(logger debuglog.Logger, phase types.RulePhase, tx *Tra
 					args, errs = r.transformMultiMatchArg(arg)
 					argsLen = len(args)
 				} else {
-					args[0], errs = r.transformArg(arg, i, cache)
+					args[0], errs = r.transformArg(arg, i, cache, v.Count)
 					argsLen = 1
 				}
 				if len(errs) > 0 {
@@ -420,7 +420,7 @@ func (r *Rule) transformMultiMatchArg(arg types.MatchData) ([]string, []error) {
 	return r.executeTransformationsMultimatch(arg.Value())
 }
 
-func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]transformationValue) (string, []error) {
+func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transformationKey]transformationValue, isCount bool) (string, []error) {
 	switch {
 	case len(r.transformations) == 0:
 		return arg.Value(), nil
@@ -428,23 +428,29 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 		// no cache for TX
 		arg, errs := r.executeTransformations(arg.Value())
 		return arg, errs
+	case isCount:
+		// No cache for counts (&VARIABLE): the value is a short decimal string
+		// synthesized per call, so every transformation on it is a no-op and an
+		// entry would cost more than the work it saves.
+		arg, errs := r.executeTransformations(arg.Value())
+		return arg, errs
 	default:
 		// NOTE: See comment on transformationKey struct to understand this hacky code
-		argKey := arg.Key()
-		argKeyPtr := unsafe.StringData(argKey)
+		argValue := arg.Value()
+		argValuePtr := unsafe.StringData(argValue)
+		argValueLen := len(argValue)
 
 		// Search from longest prefix (full chain) backwards for a cache hit.
 		// Best case: full chain cached → single map lookup, done.
 		// Typical case: shared prefix cached → start computing from there.
 		startIdx := 0
-		value := arg.Value()
+		value := argValue
 		var errs []error
 
 		for i := len(r.transformationPrefixIDs) - 1; i >= 0; i-- {
 			key := transformationKey{
-				argKey:            argKeyPtr,
-				argIndex:          argIdx,
-				argVariable:       arg.Variable(),
+				argValue:          argValuePtr,
+				argValueLen:       argValueLen,
 				transformationsID: r.transformationPrefixIDs[i],
 			}
 			if cached, ok := cache[key]; ok {
@@ -470,9 +476,8 @@ func (r *Rule) transformArg(arg types.MatchData, argIdx int, cache map[transform
 			}
 
 			key := transformationKey{
-				argKey:            argKeyPtr,
-				argIndex:          argIdx,
-				argVariable:       arg.Variable(),
+				argValue:          argValuePtr,
+				argValueLen:       argValueLen,
 				transformationsID: r.transformationPrefixIDs[i],
 			}
 			cache[key] = transformationValue{arg: value, errs: errs}

--- a/internal/corazawaf/rule_test.go
+++ b/internal/corazawaf/rule_test.go
@@ -5,6 +5,7 @@ package corazawaf
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -622,7 +623,7 @@ func TestTransformArgSimple(t *testing.T) {
 	rule := NewRule()
 	_ = rule.AddTransformation("AppendA", transformationAppendA)
 	_ = rule.AddTransformation("AppendB", transformationAppendB)
-	arg, errs := rule.transformArg(md, 0, transformationCache)
+	arg, errs := rule.transformArg(md, 0, transformationCache, false)
 	if errs != nil {
 		t.Fatalf("Unexpected errors executing transformations: %v", errs)
 	}
@@ -634,7 +635,7 @@ func TestTransformArgSimple(t *testing.T) {
 		t.Errorf("Expected 2 transformations in cache (one per step), got %d", len(transformationCache))
 	}
 	// Repeating the same transformation, expecting still two elements in the cache (cache hit)
-	arg, errs = rule.transformArg(md, 0, transformationCache)
+	arg, errs = rule.transformArg(md, 0, transformationCache, false)
 	if errs != nil {
 		t.Fatalf("Unexpected errors executing transformations: %v", errs)
 	}
@@ -655,7 +656,7 @@ func TestTransformArgNoCacheForTXVariable(t *testing.T) {
 	}
 	rule := NewRule()
 	_ = rule.AddTransformation("AppendA", transformationAppendA)
-	arg, errs := rule.transformArg(md, 0, transformationCache)
+	arg, errs := rule.transformArg(md, 0, transformationCache, false)
 	if errs != nil {
 		t.Fatalf("Unexpected errors executing transformations: %v", errs)
 	}
@@ -685,7 +686,7 @@ func TestTransformArgPrefixSharing(t *testing.T) {
 	_ = rule2.AddTransformation("AppendB", transformationAppendB)
 
 	// Evaluate rule1 first — caches the AppendA intermediate
-	arg1, errs := rule1.transformArg(md, 0, transformationCache)
+	arg1, errs := rule1.transformArg(md, 0, transformationCache, false)
 	if errs != nil {
 		t.Fatalf("Unexpected errors: %v", errs)
 	}
@@ -697,7 +698,7 @@ func TestTransformArgPrefixSharing(t *testing.T) {
 	}
 
 	// Evaluate rule2 — should reuse the cached AppendA result and only compute AppendB
-	arg2, errs := rule2.transformArg(md, 0, transformationCache)
+	arg2, errs := rule2.transformArg(md, 0, transformationCache, false)
 	if errs != nil {
 		t.Fatalf("Unexpected errors: %v", errs)
 	}
@@ -729,8 +730,8 @@ func TestClearTransformationsResetsID(t *testing.T) {
 	_ = ruleB.AddTransformation("AppendA", transformationAppendA)
 	_ = ruleB.AddTransformation("AppendB", transformationAppendB)
 
-	argA, _ := ruleA.transformArg(md, 0, transformationCache)
-	argB, _ := ruleB.transformArg(md, 0, transformationCache)
+	argA, _ := ruleA.transformArg(md, 0, transformationCache, false)
+	argB, _ := ruleB.transformArg(md, 0, transformationCache, false)
 
 	if argA != "testB" {
 		t.Errorf("Rule A (t:none resets): expected \"testB\", got %q", argA)
@@ -742,6 +743,60 @@ func TestClearTransformationsResetsID(t *testing.T) {
 	// they'd collide in the cache and one would get the wrong result.
 	if argA == argB {
 		t.Error("Rule A and Rule B produced the same result — ClearTransformations likely didn't reset transformationsID")
+	}
+}
+
+// TestTransformationCacheSharedAcrossRules checks that rules sharing a target and
+// a transformation chain also share cache entries: the chain runs once per value
+// for the whole phase, however many rules ask for it. Map-backed collections return
+// FindAll() results in Go map iteration order, so a cache key that depends on an
+// argument's position within that result makes every rule miss and store duplicates.
+func TestTransformationCacheSharedAcrossRules(t *testing.T) {
+	const (
+		nRules = 10
+		nArgs  = 10
+	)
+
+	transformations := 0
+	waf := NewWAF()
+	waf.RuleEngine = types.RuleEngineOn
+
+	for i := 0; i < nRules; i++ {
+		r := NewRule()
+		r.ID_ = 1000 + i
+		r.LogID_ = strconv.Itoa(1000 + i)
+		r.Phase_ = types.PhaseRequestHeaders
+		if err := r.AddVariable(variables.ArgsGet, "", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.AddTransformation("countingAppendA", func(v string) (string, bool, error) {
+			transformations++
+			return v + "A", true, nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		// never matches, so evaluation always walks every argument
+		r.SetOperator(&dummyEqOperator{}, "@eq", "0")
+		if err := waf.Rules.Add(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tx := waf.NewTransaction()
+	for i := 0; i < nArgs; i++ {
+		tx.AddGetRequestArgument(fmt.Sprintf("arg%d", i), fmt.Sprintf("value-%d", i))
+	}
+	tx.ProcessRequestHeaders()
+
+	if transformations != nArgs {
+		t.Errorf("transformation executed %d times, want %d (once per argument, shared by all %d rules)",
+			transformations, nArgs, nRules)
+	}
+	if got := len(tx.transformationCache); got != nArgs {
+		t.Errorf("cache holds %d entries, want %d (one per argument)", got, nArgs)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -10,7 +10,6 @@ import (
 	"github.com/corazawaf/coraza/v3/internal/corazatypes"
 	utils "github.com/corazawaf/coraza/v3/internal/strings"
 	"github.com/corazawaf/coraza/v3/types"
-	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 // RuleGroup is a collection of rules
@@ -291,13 +290,17 @@ type transformationKey struct {
 	// TODO(anuraaga): This is a big hack to support performance on TinyGo. TinyGo
 	// cannot efficiently compute a hashcode for a struct if it has embedded non-fixed
 	// size fields, for example string as we'd prefer to use here. A pointer is usable,
-	// and it works for us since we know that the arg key string is populated once per
-	// transaction phase and we would never have different string pointers with the same
-	// content, or more problematically same pointer for different content, as the strings
-	// will be alive throughout the phase.
-	argKey            *byte
-	argIndex          int
-	argVariable       variables.RuleVariable
+	// and it works for us since the values we cache are owned by a collection and stay
+	// alive throughout the phase, so we never see different pointers with the same
+	// content, or more problematically the same pointer for different content.
+	//
+	// The identity is the value itself (data pointer + length), not the argument's key
+	// and position: collections backed by a map return FindAll() results in Go map
+	// iteration order, so an argument's position is not stable from one rule to the
+	// next within a phase. Values that are not collection-owned (TX, which mutates
+	// mid-phase, and &VARIABLE counts, which are synthesized per call) are not cached.
+	argValue          *byte
+	argValueLen       int
 	transformationsID int
 }
 


### PR DESCRIPTION
Proposed fix for #1681.

🤖 Note: AI Generated PR with human in the loop. Opening per visibility, I'll further validate and iterate on this.

The per-phase transformation cache would be keyed by the **value being transformed** — its data pointer and length — instead of by the argument's key pointer and its position in the `tx.GetField()` result.

```go
type transformationKey struct {
	argValue          *byte
	argValueLen       int
	transformationsID int
}
```

The position is the part that seems to have to change: map-backed collections return `FindAll()` results in Go map iteration order, so an argument's index differs from one rule to the next inside the same phase, and every rule misses the cache and stores its own duplicate. The value's address doesn't move, so rules converge on one entry.

Two collections would be excluded from the cache rather than keyed into it:

- `TX`, as before — it mutates mid-phase.
- `&VARIABLE` counts, new here. The value is a short decimal string synthesized per call by `strconv.Itoa`, so every transformation on it is a no-op and an entry costs more than the work it saves. On CRS this changes nothing measurable: instrumenting a 30-param POST through phases 1–2 gives 45 count-field evaluations, 0 of them on rules with transformations, so they never reached the cache anyway.

If that is right, the invariant the cache rests on becomes statable in one line:

> Cache only values that a collection owns for the duration of the phase.

`argVariable` is dropped from the key as well. As far as I can tell it is not protecting anything: the one real hazard is a value string being freed and its address reused within a phase, which is a lifetime property the variable doesn't guard against. Removing it takes the key from 32 to 24 bytes, worth roughly 130 KiB per pooled transaction on a 100-parameter request. This is the part I am least attached to — the change works fine with the field kept, and it costs exactly one entry on CRS.

## Why keying on the value is safe

- Transformations are `func(string) (string, bool, error)`. Neither the variable nor the argument name is an input, so neither should be able to affect the result.
- Equal `(pointer, length)` means the same bytes in the same memory, not "equal-looking text". Two arguments whose values are equal but separately allocated still get separate entries — I checked (3 args with equal content → 3 entries). So a hit should never be a guess that two similar strings behave alike.
- The key stays a fixed-size struct, so the TinyGo constraint from #553 ([tinygo#3354](https://github.com/tinygo-org/tinygo/issues/3354)) should still hold: no variable-length field, no interface conversion, no reflection. I could not verify this locally — see below.

Per-step prefix caching from #1544 is unchanged — `t:lowercase` and `t:lowercase,t:trim` remain distinct entries, so a rule still reuses another rule's shorter prefix and runs only the remaining steps.

## Measurements with CRS 4.25

Urlencoded POST with N parameters, entries counted after phase 2. "Retained" is `HeapAlloc` after `Close()` plus one forced GC, i.e. what the pooled transaction still pins. All measured on one laptop, so the timings especially are worth reproducing elsewhere.

| params | entries before (5 runs) | entries after (5 runs) | retained before | retained after |
|---|---|---|---|---|
| 10 | 2,291 – 2,564 | 843 every run | ~1.2 MiB | ~1.0 MiB |
| 30 | 10,287 – 10,590 | 2,423 every run | ~2.2 MiB | ~1.2 MiB |
| 100 | 46,269 – 50,778 | 7,953 every run | ~6.0 MiB | ~2.1 MiB |

Besides being 3–6× smaller, the cache becomes **deterministic**: byte-identical entry counts across five repetitions, where `main` wanders by about 5% run to run because the totals depend on how the map iteration order fell. Retained memory carries GC-timing noise and is quoted approximately; the entry counts are exact.

`BenchmarkCRSTransformationCache/LargePOST_30params`, 3 runs each — allocations drop about 4%, wall-clock is within noise on my machine. Most duplicated work was transformations returning their input unchanged, so the win lands on map entries rather than on time:

```
before: 36366430 ns/op  2058280 B/op  10689 allocs/op
        36772038 ns/op  2068672 B/op  10698 allocs/op
        36506442 ns/op  2022980 B/op  10672 allocs/op

after:  38435693 ns/op  1992099 B/op  10256 allocs/op
        35468578 ns/op  2016182 B/op  10259 allocs/op
        35224806 ns/op  1975441 B/op  10242 allocs/op
```

Rulesets where many rules share one transformation chain should gain more than CRS does, since the duplication scales with how much sharing there would otherwise be.

## Tests

`TestTransformationCacheSharedAcrossRules` asserts that 10 rules sharing a target and a chain execute the chain once per argument and leave one entry per argument.

The reproducer from the issue — 50 rules, 50 arguments, 10 requests — goes from a count that differs on every request to a constant:

```
before                                    after
request  1:  2300 transformations         request  1:   100 transformations
request  2:  3300 transformations         request  2:   100 transformations
request  3:  2700 transformations         request  3:   100 transformations
...                                       ...
request 10:  3400 transformations         request 10:   100 transformations
```

The existing cache tests (`TestTransformArgSimple`, `TestTransformArgPrefixSharing`, `TestTransformArgNoCacheForTXVariable`, `TestClearTransformationsResetsID`) pass unchanged apart from the added `transformArg` parameter. `go test ./...` is green across all packages; `gofmt` and `go vet` are clean.

## What I have not verified

- **TinyGo.** I have no TinyGo toolchain here, so the CI job on this PR is the real check for the key-shape question, exactly as it was for #553. If the wasm benchmark is unaffected, that closes the last risk I am aware of.
- **Other synthesized values.** Counts are the case I confirmed. Derived collections such as `ARGS` (concatenating GET and POST) and `ARGS_NAMES` (returning keys as values) appear to hand back collection-owned strings, but I checked those by reading the code rather than by test. A sweep of `collection.Collection` implementations would be worth doing before this merges.

## Context for reviewers

The cache has always been keyed by "which argument slot is this", and this would change it to "which string is this". The history explains the current shape: #537 introduced the key as a real `string`, where hashing costs O(len) and argument *values* are unbounded, so keying on the argument key rather than the value was the right call at the time. #553 then replaced the string with `unsafe.StringData(arg.Key())` to unblock TinyGo, which removed that constraint — a pointer into the value hashes just as cheaply as a pointer into the key — but it was a minimal fix and kept the original shape.  #1544 later multiplied each duplicate by the length of the transformation chain.