### PR TITLE
Fix invalid gomodTidyAll postUpdateOptions value

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
     "github>corazawaf/renovate-config"
   ],
   "postUpdateOptions": [
-    "gomodTidyAll"
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
`renovate.json` sets `"postUpdateOptions": ["gomodTidyAll"]`. That is not a Renovate option, so it has been silently ignored and `go mod tidy` has not been running from this repo's own config.

## Confirmation

`gomodTidyAll` appears nowhere in renovate 43.84.2. The complete gomod set in the option's `allowedValues` is:

```
gomodMassage, gomodTidy, gomodTidy1.17, gomodTidyE,
gomodUpdateImportPaths, gomodSkipVendor, gomodVendor
```

Renovate matches these by exact string in the gomod artifacts handler:

```js
config.postUpdateOptions?.includes("gomodTidy") === true || ...
```

Nothing reported it because `renovate-config-validator` does not check `allowedValues` for this option — it accepts `totallyBogusValue` without complaint. corazawaf/renovate-config#6 adds a guardrail test for that class of typo in the shared config.

## Why not just drop it and inherit the preset

The `"All"` looks aimed at this repo's three `go.mod` files (root, `examples/http-server`, `testing/coreruleset`). Renovate already covers that: it derives `-modfile` per package file and runs artifacts for each module as that module is updated, so plain `gomodTidy` tidies all three.

Keeping it top-level rather than relying on the shared preset is deliberate. `postUpdateOptions` is `mergeable: true`, so the top-level value merges with the preset's package rule instead of conflicting:

```
top-level ['gomodTidy'] + preset rule  ->  non-major gomod: [gomodTidy, gomodUpdateImportPaths, gomodTidy]
top-level ['gomodTidy'] + no rule      ->  major gomod:     [gomodTidy]
no top-level            + no rule      ->  major gomod:     undefined
```

The preset's `go modules` rule matches only `[minor, patch, pin, digest]`, and the `all major dependencies` rule sets no `postUpdateOptions`. So dropping the top-level entry would leave major Go module updates with no tidy at all — precisely when the module graph is most likely to need it.

## Validation

```console
$ npx renovate-config-validator
 INFO: Validating renovate.json
 INFO: Config validated successfully against 1 file(s)
```

Related: corazawaf/renovate-config#6 fixes the same class of bug (`goModTidy` -> `gomodTidy`) in the shared config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance to use the current Go module tidy option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->