### PR TITLE
docs(adr): add ADR directory, template and format check

### DIFF
--- a/.github/workflows/adr.yml
+++ b/.github/workflows/adr.yml
@@ -1,0 +1,37 @@
+name: ADR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/adr/**"
+      - "magefile_adr.go"
+      - ".github/workflows/adr.yml"
+  pull_request:
+    paths:
+      - "docs/adr/**"
+      - "magefile_adr.go"
+      - ".github/workflows/adr.yml"
+
+permissions: {}
+
+concurrency:
+  group: adr-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  adr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
+        with:
+          go-version: 1.25.x
+          cache: true
+      - run: go run mage.go adr

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,73 @@
+# ADR-NNNN: <short decision title>
+
+- **Status:** accepted
+- **Date:** YYYY-MM-DD (PR merge date)
+- **Version:** vX.Y.Z
+- **PR:** [#NNNN](https://github.com/corazawaf/coraza/pull/NNNN)
+- **Issue(s):** [#MMMM](https://github.com/corazawaf/coraza/issues/MMMM) — or "No linked issue"
+- **Deciders:** @author, @reviewer1, @reviewer2
+- **Category:** Feature | Parity | Perf | Refactor
+
+## Context and Problem
+
+Why the change was needed. Quote from the issue or PR body where possible.
+
+## Decision Drivers
+
+- driver 1
+- driver 2
+
+## Considered Options
+
+- option A
+- option B
+
+## Decision Outcome
+
+Chosen: **<option>**, because <reason grounded in PR discussion>.
+
+## Technical Discussion
+
+Summary of the substantive thread. Every ADR must contain **either** at least one
+quoted comment with a direct permalink **or** a line opening with "No substantive
+technical discussion recorded" (see the last bullet below for how to finish it).
+
+Quotes are a record of what a named person actually wrote, so:
+
+- **Verbatim only.** Do not fix typos, reword, or tidy grammar. Preserve the original
+  spelling even where it looks wrong.
+- **Mark every omission** with a bracketed ellipsis `[…]`. A quote that stops early
+  must not change what the author was saying — check the sentence you cut.
+- **One comment per blockquote.** Never join text from two comments into one quote,
+  even by the same author on the same PR. Split them into two blockquotes, each with
+  its own permalink.
+- **Never invent discussion.** If there was none, start a line with "No substantive
+  technical discussion recorded" and finish the sentence however fits — "…on the PR
+  thread.", "…beyond the benchmark data." Say where you looked; the tail is yours.
+
+Formatting the source faithfully is fine: keep code blocks as code blocks and nested
+quotes as nested quotes inside the blockquote. Rendering a bare URL as a markdown link
+is fine. Changing the words is not.
+
+Representative quote(s):
+
+> "<quote>"
+> — @user ([comment](https://github.com/corazawaf/coraza/pull/NNNN#issuecomment-XXXXX))
+
+## Participants
+
+- @author — author
+- @reviewer1 — review
+- @reviewer2 — review comments
+- @commenter3 — issue thread
+
+## Consequences
+
+- **Positive:** …
+- **Negative / follow-up:** …
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/NNNN
+- Issue: https://github.com/corazawaf/coraza/issues/MMMM
+- Related ADRs: ADR-XXXX

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,72 @@
+# Architecture Decision Records
+
+An ADR records a structural decision — what was decided, what the alternatives were,
+and why one was chosen — at the time it was made. It is not a changelog entry and not
+a design document: `CHANGELOG.md` says what changed, an ADR says why that shape and
+not another.
+
+## When to write one
+
+Write an ADR when a change alters the shape of Coraza:
+
+- a new directive, operator, action, transformation, variable or collection
+- a new subsystem, or a new plugin / experimental surface
+- a breaking change to a public API
+- an algorithmic or allocation change that shifts performance characteristics
+- an internal refactor that changes how a subsystem is structured
+
+Skip it for bugfixes, documentation, CI, chores and dependency bumps. If a reviewer
+has to ask "why this way?", that is the signal.
+
+The ADR belongs in the PR that makes the change, so the reasoning is captured while
+the alternatives are still live. Reconstructing one months later recovers only what
+happened to reach GitHub.
+
+## How to write one
+
+1. Copy [`0000-template.md`](0000-template.md) to `NNNN-short-slug.md`, taking the
+   next free number.
+2. Fill in every header field — `Status`, `Date`, `Version`, `PR`, `Issue(s)`,
+   `Deciders`, `Category`. Use "No linked issue" rather than dropping `Issue(s)`.
+   `Category` must be exactly one of **Feature**, **Parity**, **Perf** or
+   **Refactor**, optionally followed by a single parenthetical qualifier and
+   nothing else (`Parity (ModSecurity parity)`). One record counts under one
+   category — if a change feels like two, name the one that drove it.
+   `Performance` is not a spelling of `Perf`.
+3. Write the body. Keep `Considered Options` honest: if there was only ever one
+   option, say so rather than inventing rivals for it.
+4. Quote the discussion **inside** `## Technical Discussion`, following the quoting
+   rules in the template — verbatim, one comment per blockquote, `[…]` for every
+   omission. A quote elsewhere in the document does not count: that section is where
+   a reader looks for the evidence. If there was no substantive discussion, use the
+   marker sentence. That is a normal outcome, not a gap to paper over.
+5. Add a row to the index below.
+
+Run `go run mage.go adr` to check the format before pushing. CI runs the same check
+on any PR touching `docs/adr/`.
+
+## What the check does and does not cover
+
+`mage adr` validates structure offline: filenames, the header block (all seven fields,
+read only from above the first section so a stray line further down cannot stand in for
+a missing one), the `Status` and `Category` vocabularies, that the `## Technical
+Discussion` section itself carries either a permalinked quote or the marker, that quote
+permalinks point at this repository, and that the index below matches the files on disk.
+
+It cannot verify that a quote matches what the person actually wrote. That is a
+reviewer's job — open the permalink and read it. A quote is the one part of an ADR
+that puts words in someone else's mouth, so it is the part worth checking by hand.
+
+## Status values
+
+`proposed` · `accepted` · `superseded by ADR-NNNN` · `deprecated`
+
+Superseding does not delete the old record. Set its status and let the history stand.
+
+## Index
+
+| ADR | PR | Merged | Version | Cat. | Title |
+|-----|----|--------|---------|------|-------|
+| _no records yet_ | | | | | |
+
+Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor

--- a/magefile_adr.go
+++ b/magefile_adr.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build mage
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const adrDir = "docs/adr"
+
+var (
+	adrFileRe       = regexp.MustCompile(`^(\d{4})-[a-z0-9]+(?:-[a-z0-9]+)*\.md$`)
+	adrTitleRe      = regexp.MustCompile(`(?m)^# ADR-(\d{4}): \S`)
+	adrFieldRe      = regexp.MustCompile(`(?m)^- \*\*([^*]+):\*\* *(.*)$`)
+	adrQuoteRe      = regexp.MustCompile(`(?m)^> — @[A-Za-z0-9_+.-]+ .*?\(\[[^\]]+\]\(([^)]+)\)\)`)
+	adrPermalink    = regexp.MustCompile(`^https://github\.com/corazawaf/coraza/(?:pull|issues)/\d+#(?:discussion_r|issuecomment-)\d+$`)
+	adrIndexRowRe   = regexp.MustCompile(`(?m)^\| *\[?(?:ADR-)?(\d{4})[\]|(]`)
+	adrSupersededRe = regexp.MustCompile(`^superseded by ADR-\d{4}$`)
+	// A bare category, or one followed by a single parenthetical qualifier
+	// ("Parity (ModSecurity parity)"). The delimiter stops "Performance"
+	// passing as "Perf"; allowing nothing after the qualifier keeps each
+	// record countable under exactly one category.
+	adrMarkerRe   = regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(adrNoDiscussion))
+	adrCategoryRe = regexp.MustCompile(`^(?:` + strings.Join(adrCategories, "|") + `)(?: \([^)]+\))?$`)
+)
+
+var (
+	adrStatuses     = []string{"proposed", "accepted", "deprecated"}
+	adrCategories   = []string{"Feature", "Parity", "Perf", "Refactor"}
+	adrNoDiscussion = "No substantive technical discussion recorded"
+)
+
+// Adr validates the Architecture Decision Records under docs/adr.
+//
+// Structure only: it cannot tell whether a quote matches what the person
+// actually wrote. Reviewers must open the permalinks and read them.
+func Adr() error {
+	entries, err := os.ReadDir(adrDir)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", adrDir, err)
+	}
+
+	var problems []string
+	seen := map[string]string{}
+	var numbers []string
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".md") || name == "README.md" {
+			continue
+		}
+		m := adrFileRe.FindStringSubmatch(name)
+		if m == nil {
+			problems = append(problems, fmt.Sprintf("%s: filename must be NNNN-lower-kebab-slug.md", name))
+			continue
+		}
+		num := m[1]
+		if prev, dup := seen[num]; dup {
+			problems = append(problems, fmt.Sprintf("%s: duplicate ADR number %s (also %s)", name, num, prev))
+		}
+		seen[num] = name
+
+		body, err := os.ReadFile(filepath.Join(adrDir, name))
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", name, err)
+		}
+		if num == "0000" {
+			continue // the template is exempt: it carries placeholders by design
+		}
+		numbers = append(numbers, num)
+		problems = append(problems, checkADR(name, num, string(body))...)
+	}
+
+	if len(seen) == 0 {
+		return errors.New(adrDir + ": no ADR files found")
+	}
+	problems = append(problems, checkADRIndex(numbers)...)
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		for _, p := range problems {
+			fmt.Fprintln(os.Stderr, "  "+p)
+		}
+		return fmt.Errorf("%d ADR problem(s)", len(problems))
+	}
+	fmt.Printf("%s: %d record(s) OK\n", adrDir, len(numbers))
+	return nil
+}
+
+func checkADR(name, num, body string) []string {
+	var out []string
+	bad := func(format string, args ...any) {
+		out = append(out, name+": "+fmt.Sprintf(format, args...))
+	}
+
+	// Only the document's own title counts: a later heading, or one inside an
+	// example, must not stand in for a missing or misnumbered title.
+	title := ""
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "# ") {
+			title = line
+			break
+		}
+	}
+	if m := adrTitleRe.FindStringSubmatch(title); m == nil {
+		bad("missing '# ADR-%s: <title>' heading", num)
+	} else if m[1] != num {
+		bad("heading says ADR-%s but the filename says %s", m[1], num)
+	}
+
+	// Only the block above the first section counts: a "- **Status:** ..." line
+	// further down the document must not stand in for a missing header field.
+	fields := map[string]string{}
+	for _, m := range adrFieldRe.FindAllStringSubmatch(adrHeaderBlock(body), -1) {
+		fields[m[1]] = strings.TrimSpace(m[2])
+	}
+	for _, want := range []string{"Status", "Date", "Version", "PR", "Issue(s)", "Deciders", "Category"} {
+		if fields[want] == "" {
+			bad("missing or empty '- **%s:**' header field", want)
+		}
+	}
+
+	if s := fields["Status"]; s != "" && !containsString(adrStatuses, s) && !adrSupersededRe.MatchString(s) {
+		bad("Status %q must be one of %v or 'superseded by ADR-NNNN'", s, adrStatuses)
+	}
+	if c := fields["Category"]; c != "" && !adrCategoryRe.MatchString(c) {
+		bad("Category %q must be one of %v, optionally followed by a parenthetical qualifier", c, adrCategories)
+	}
+
+	// The evidence has to be in the Technical Discussion section itself: a quote
+	// elsewhere in the document does not make an empty section acceptable.
+	discussion, ok := adrSection(body, "## Technical Discussion")
+	if !ok {
+		bad("missing '## Technical Discussion' section")
+	} else if len(adrQuotedComments(discussion)) == 0 && !adrMarkerRe.MatchString(discussion) {
+		bad("Technical Discussion needs an attributed quote with a permalink, or the marker %q", adrNoDiscussion)
+	}
+
+	for _, q := range adrQuoteRe.FindAllStringSubmatch(body, -1) {
+		if !adrPermalink.MatchString(q[1]) {
+			bad("quote attribution links to %q, want a corazawaf/coraza comment permalink", q[1])
+		}
+	}
+	return out
+}
+
+func checkADRIndex(numbers []string) []string {
+	body, err := os.ReadFile(filepath.Join(adrDir, "README.md"))
+	if err != nil {
+		return []string{"README.md: " + err.Error()}
+	}
+	indexed := map[string]int{}
+	for _, m := range adrIndexRowRe.FindAllStringSubmatch(string(body), -1) {
+		indexed[m[1]]++
+	}
+	var out []string
+	for _, n := range numbers {
+		switch rows := indexed[n]; {
+		case rows == 0:
+			out = append(out, fmt.Sprintf("README.md: ADR-%s is not listed in the index", n))
+		case rows > 1:
+			out = append(out, fmt.Sprintf("README.md: ADR-%s is listed %d times in the index", n, rows))
+		}
+		delete(indexed, n)
+	}
+	for n := range indexed {
+		out = append(out, fmt.Sprintf("README.md: index lists ADR-%s but no such file exists", n))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// adrQuotedComments returns the attributions in a section that actually have
+// quoted text above them. A bare "> — @user ([comment](...))" cites a source
+// for nothing, so it does not count as discussion.
+func adrQuotedComments(section string) []string {
+	var links []string
+	quoted := false
+	for _, line := range strings.Split(section, "\n") {
+		switch {
+		case !strings.HasPrefix(line, ">"):
+			quoted = false
+		case adrQuoteRe.MatchString(line):
+			if m := adrQuoteRe.FindStringSubmatch(line); quoted && m != nil {
+				links = append(links, m[1])
+			}
+			quoted = false
+		case strings.TrimSpace(strings.TrimPrefix(line, ">")) != "":
+			quoted = true
+		}
+	}
+	return links
+}
+
+// adrHeaderBlock returns the part of an ADR above its first "## " section.
+func adrHeaderBlock(body string) string {
+	if i := strings.Index(body, "\n## "); i >= 0 {
+		return body[:i]
+	}
+	return body
+}
+
+// adrSection returns the body of one "## " section, up to the next one.
+func adrSection(body, heading string) (string, bool) {
+	i := strings.Index(body, "\n"+heading+"\n")
+	if i < 0 {
+		return "", false
+	}
+	rest := body[i+len(heading)+1:]
+	if j := strings.Index(rest, "\n## "); j >= 0 {
+		rest = rest[:j]
+	}
+	return rest, true
+}
+
+func containsString(haystack []string, s string) bool {
+	for _, h := range haystack {
+		if h == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds `docs/adr/` so structural decisions can be recorded in the PR that makes them, while the alternatives are still live.

This is the process only — README, template, and a format check. No records. Backfilling the v3.x history is a much larger review and is kept separate (#1614).

## What's here

- **`docs/adr/README.md`** — when an ADR is warranted (new directive / operator / action / transformation / variable / collection, new subsystem or plugin surface, breaking public API change, algorithmic shift, structural refactor) and when it isn't (bugfix, docs, CI, chore, dependency bump). Numbering, index, status values.
- **`docs/adr/0000-template.md`** — MADR-3.0 shaped, with a mandatory `Technical Discussion` section.
- **`magefile_adr.go`** — `go run mage.go adr`. Go and mage, so no new toolchain, and build-tagged so it never ships in the module.
- **`.github/workflows/adr.yml`** — runs the check on any PR touching `docs/adr/`.

The workflow is needed because `lint.yml` carries `paths-ignore: "**/*.md"`, so a documentation-only PR gets no CI at all today.

## Quoting rules in the template

An ADR quotes people. That is the one part of it that puts words in someone else's mouth, so the template is explicit: verbatim including typos, one comment per blockquote (never join two comments under one permalink), a bracketed ellipsis for every omission, and the explicit no-discussion marker when there was no substantive thread rather than narrating one that didn't happen.

These aren't hypothetical failure modes — every one of them turned up while reviewing #1614.

## What the check covers

`mage adr` validates structure offline:

| Check | |
|---|---|
| Filename is `NNNN-lower-kebab-slug.md` | ✓ |
| ADR number is unique and matches the `# ADR-NNNN:` heading | ✓ |
| `Status`, `Date`, `PR`, `Deciders`, `Category` present | ✓ |
| `Status` ∈ proposed / accepted / deprecated / superseded by ADR-NNNN | ✓ |
| `Category` starts with Feature / Parity / Perf / Refactor | ✓ |
| `## Technical Discussion` section exists | ✓ |
| Each record has a permalinked quote **or** the no-discussion marker | ✓ |
| Quote permalinks point at this repository | ✓ |
| README index and the files on disk agree | ✓ |

`Category` matches on prefix, so a qualifier after it is fine — `Parity (ModSecurity parity)` passes — which keeps the vocabulary countable without forcing every record into four bare words.

## What it deliberately does not cover

It does not verify that a quote matches what the person actually wrote. That needs the GitHub API, a token, and judgement about what counts as a difference — rendering a bare URL as a markdown link is not a change to the words; dropping the clause where the author names a tradeoff is. A first pass at automating it produced false positives on legitimate editorial practice, and a check that cries wolf gets ignored.

So the README says plainly that verifying quotes is a reviewer's job: open the permalink and read it.

## Test plan

- `go run mage.go adr` → `docs/adr: 0 record(s) OK` on this branch.
- Same check against the 54 records in #1614 → `docs/adr: 54 record(s) OK`.
- Each of the ten checks was verified by breaking a record and confirming the specific failure fires.
- `actionlint` and `zizmor` clean on the new workflow.

## Ordering note

If this merges first, #1614 becomes subject to `mage adr`. It passes as of its current head — worth being deliberate about the order rather than discovering it in CI.

---

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read the Contribution guidelines and Code of Conduct.
- [x] My code is properly linted and passes pre-commit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Architecture Decision Record (ADR) documentation with authoring guidance, templates, metadata, statuses, categories, discussion references, and indexing.
  - Added validation for ADR filenames, numbering, required sections, formatting, links, and index consistency.

- **Chores**
  - Added automated ADR validation for relevant documentation changes in pull requests and updates to the main branch.
  - Validation reports sorted errors and confirms the number of valid records when checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->