### PR TITLE
docs(adr): records for the v3.0.x releases (1 of 8)

### DIFF
--- a/docs/adr/0001-response-args-collection.md
+++ b/docs/adr/0001-response-args-collection.md
@@ -1,0 +1,69 @@
+# ADR-0001: Enable RESPONSE_ARGS collection
+
+- **Status:** accepted
+- **Date:** 2023-06-12
+- **Version:** v3.0.1
+- **PR:** [#811](https://github.com/corazawaf/coraza/pull/811)
+- **Issue(s):** No linked issue
+- **Deciders:** @jptosso, @M4tteoP, @fzipi
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+ModSecurity exposes a `RESPONSE_ARGS` collection so rules can inspect arguments
+parsed from the response body (for example JSON response fields). Coraza v3.0.0
+had the scaffolding but the collection was not wired up end-to-end — there was
+no way to write response-phase argument matching rules.
+
+## Decision Drivers
+
+- Parity with ModSecurity behaviour for rules that inspect response bodies.
+- Symmetry with the existing `ARGS_GET`/`ARGS_POST` request-phase infrastructure.
+
+## Considered Options
+
+- Build a brand-new response-argument pipeline.
+- Reuse the existing request-side body processors and simply enable the
+  response-arg collection on the transaction.
+
+## Decision Outcome
+
+Chosen: **reuse the existing body processors** to populate a response-arg
+collection. The PR is minimal, surfacing the feature rather than introducing a
+new subsystem.
+
+## Technical Discussion
+
+The PR itself ships without a written description. Review feedback focused on
+housekeeping rather than design, and follow-up work was explicitly deferred.
+
+> "Can we move this TODO to a proper issue so someone might implement it?"
+> — @fzipi ([review comment](https://github.com/corazawaf/coraza/pull/811#discussion_r1226569095))
+
+> "There is a work in progress around it: …" — @M4tteoP, pointing at the
+> in-progress response-arg discussion on OWASP Slack
+> ([review comment](https://github.com/corazawaf/coraza/pull/811#discussion_r1227294607))
+
+No substantive architectural debate took place on the PR thread itself; the
+design was discussed out-of-band (OWASP Slack) and the code change was merged
+with two approvals.
+
+## Participants
+
+- @jptosso — author
+- @M4tteoP — review, Slack discussion pointer
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Response-phase rules can now match on parsed body arguments,
+  closing a compatibility gap with ModSecurity.
+- **Negative / follow-up:** Response-body argument parsing uses the same
+  processors as requests, so any parser limitations (JSON depth, etc.) apply
+  symmetrically. Later limits such as `SecArgumentsLimit` (ADR-0002) were added
+  to keep this surface bounded.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/811
+- Related ADRs: ADR-0002 (SecArgumentsLimit directive)

--- a/docs/adr/0001-response-args-collection.md
+++ b/docs/adr/0001-response-args-collection.md
@@ -40,9 +40,11 @@ housekeeping rather than design, and follow-up work was explicitly deferred.
 > "Can we move this TODO to a proper issue so someone might implement it?"
 > — @fzipi ([review comment](https://github.com/corazawaf/coraza/pull/811#discussion_r1226569095))
 
-> "There is a work in progress around it: …" — @M4tteoP, pointing at the
-> in-progress response-arg discussion on OWASP Slack
-> ([review comment](https://github.com/corazawaf/coraza/pull/811#discussion_r1227294607))
+The answer pointed at a discussion held on OWASP Slack rather than on the PR:
+
+> "There is a work in progress around it:
+> https://owasp.slack.com/archives/C02BXH135AT/p1686540685548419 🚀"
+> — @M4tteoP ([review comment](https://github.com/corazawaf/coraza/pull/811#discussion_r1227294607))
 
 No substantive architectural debate took place on the PR thread itself; the
 design was discussed out-of-band (OWASP Slack) and the code change was merged

--- a/docs/adr/0002-secargumentslimit-directive.md
+++ b/docs/adr/0002-secargumentslimit-directive.md
@@ -1,0 +1,90 @@
+# ADR-0002: `SecArgumentsLimit` directive
+
+- **Status:** accepted
+- **Date:** 2023-06-14
+- **Version:** v3.0.2
+- **PR:** [#812](https://github.com/corazawaf/coraza/pull/812)
+- **Issue(s):** No linked issue
+- **Deciders:** @potats0, @jptosso, @jcchavezs, @fzipi, @M4tteoP, @anuraaga, @airween, @theseion
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+Coraza accepted unbounded numbers of parsed arguments, leaving it open to
+parameter-pollution and resource-exhaustion attacks. ModSecurity documents a
+`SecArgumentsLimit` directive (default 1000) for this; Coraza had none.
+
+## Decision Drivers
+
+- ModSecurity parity — the directive already exists in the reference
+  implementation.
+- Hard bound on argument count to protect against DoS.
+- Keep the cost of enforcement close to the public entrypoint rather than
+  duplicating it in every body processor.
+
+## Considered Options
+
+- Enforce the limit inside every body processor (JSON, urlencoded, XML, …).
+- Enforce the limit only on the public `addArguments` helper that feeds the
+  `ARGS_GET`/`ARGS_POST` collections, and leave body-processor-internal writes
+  for a follow-up.
+- Implement a new bounded collection type that self-enforces the cap.
+
+## Decision Outcome
+
+Chosen: **enforce on the public helper that wraps `ARGS_GET` / `ARGS_POST`**,
+default 1000, documented as a known gap for body-processor writes. A helper
+function was introduced so the check is not duplicated across the three writer
+call sites.
+
+## Technical Discussion
+
+Extensive review (30+ inline comments). Three themes drove the final shape.
+
+**1. Scope of enforcement.** @jptosso flagged early that body processors bypass
+the helper and therefore the limit:
+
+> "Internally coraza doesn't consume this functions, as we directly write into
+> de collections, so even with this implementation we would still get unlimited
+> arguments from body processors. It will only apply for ArgsGet and ArgsPath.
+> My idea would be to create a new collection that implements Map, and add a
+> validation." — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/812#issuecomment-1588401916))
+
+@jcchavezs accepted the narrower scope to unblock the merge:
+
+> "I believe we can accept this PR as it is now and tackle the lack of internal
+> validation in a next PR."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/812#issuecomment-1589536399))
+
+**2. Default value.** @jptosso asked for the missing default of 1000 per
+ModSecurity docs; the PR was updated to match.
+
+**3. API shape.** A `Len()` method was added to the collection. @jptosso noted
+idiomatic Go:
+
+> "`Len() int` is the standard for Length in golang"
+> — @jptosso ([review comment](https://github.com/corazawaf/coraza/pull/812#discussion_r1227428689))
+
+`Length` was renamed to `Len` accordingly, and a helper was extracted so the
+check is not duplicated across the three writer call sites.
+
+## Participants
+
+- @potats0 — author
+- @jptosso — review, drove scope clarification and API naming
+- @jcchavezs — review, approved narrower scope, asked for `0` validation
+- @fzipi — review, suggestion edits on `Len()` call sites
+- @M4tteoP, @anuraaga, @airween, @theseion — review
+
+## Consequences
+
+- **Positive:** Public argument intake is bounded by default; `ARGS_GET` and
+  `ARGS_POST` cannot grow unboundedly from attacker-supplied inputs.
+- **Negative / follow-up:** Body-processor-internal writes are still unbounded
+  until a bounded `Map` collection lands. This was explicitly deferred.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/812
+- ModSecurity reference: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#secargumentslimit
+- Related ADRs: ADR-0001 (RESPONSE_ARGS collection)

--- a/docs/adr/0002-secargumentslimit-directive.md
+++ b/docs/adr/0002-secargumentslimit-directive.md
@@ -78,8 +78,11 @@ check is not duplicated across the three writer call sites.
 
 ## Consequences
 
-- **Positive:** Public argument intake is bounded by default; `ARGS_GET` and
-  `ARGS_POST` cannot grow unboundedly from attacker-supplied inputs.
+- **Positive:** Argument intake through `AddGetRequestArgument` /
+  `AddPostRequestArgument` / `AddPathRequestArgument` is bounded by default, so
+  query strings and form fields arriving through those helpers cannot grow
+  `ARGS_GET` or `ARGS_POST` without limit. The guarantee stops at the helpers:
+  body processors write to the collections directly and are not covered.
 - **Negative / follow-up:** Body-processor-internal writes are still unbounded
   until a bounded `Map` collection lands. This was explicitly deferred.
 

--- a/docs/adr/0002-secargumentslimit-directive.md
+++ b/docs/adr/0002-secargumentslimit-directive.md
@@ -78,11 +78,12 @@ check is not duplicated across the three writer call sites.
 
 ## Consequences
 
-- **Positive:** Argument intake through `AddGetRequestArgument` /
-  `AddPostRequestArgument` / `AddPathRequestArgument` is bounded by default, so
-  query strings and form fields arriving through those helpers cannot grow
-  `ARGS_GET` or `ARGS_POST` without limit. The guarantee stops at the helpers:
-  body processors write to the collections directly and are not covered.
+- **Positive:** Argument intake through the three request helpers is bounded by
+  default, each capping its own collection: `AddGetRequestArgument` bounds
+  `ARGS_GET` (query string), `AddPostRequestArgument` bounds `ARGS_POST` (POST
+  body arguments), and `AddPathRequestArgument` bounds `ARGS_PATH` (URL path
+  components). The guarantee stops at the helpers: body processors write to the
+  collections directly and are not covered.
 - **Negative / follow-up:** Body-processor-internal writes are still unbounded
   until a bounded `Map` collection lands. This was explicitly deferred.
 

--- a/docs/adr/0003-https-audit-log-writer.md
+++ b/docs/adr/0003-https-audit-log-writer.md
@@ -1,0 +1,103 @@
+# ADR-0003: HTTPS audit log writer
+
+- **Status:** accepted
+- **Date:** 2023-07-11
+- **Version:** v3.0.3
+- **PR:** [#826](https://github.com/corazawaf/coraza/pull/826)
+- **Issue(s):** Discussion [#813](https://github.com/corazawaf/coraza/issues/813)
+- **Deciders:** @jptosso, @jcchavezs, @anuraaga
+- **Category:** Feature
+
+## Context and Problem
+
+Prior to v3.0.3 Coraza could write audit logs to disk but had no pluggable way
+to ship them over HTTP(S) to a remote collector. ModSecurity had a similar
+feature via MLOGC; modern deployments want TLS-capable remote audit streaming
+without MLOGC-era constraints.
+
+## Decision Drivers
+
+- Enable cloud-native audit shipping (TLS, HTTP-based SIEM ingestion).
+- Intentionally drop MLOGC compatibility — it is a v2-era protocol.
+- Honour the formatter's MIME type so remote collectors can decode correctly.
+
+## Considered Options
+
+- Batched remote writes (accumulate N records, flush on timer).
+- Per-record HTTP writes, no batching, accept the loss of efficiency for v3.
+- Ship a full pluggable exporter subsystem now.
+
+## Decision Outcome
+
+Chosen: **per-record HTTP writes now; defer batching to v4** because Coraza
+v3 has no `WAF.Close()` method, so buffered records cannot be safely flushed
+on shutdown.
+
+> "Unfortunatelly we can't do bathing as we can't close the exporter (WAF does
+> not support close method and hence when terminating the APP the batched
+> requests will be lost). I think it is a good idea to add a Close method now
+> but not to force people to use it and maybe the exporter can listen to
+> termination signal"
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/826#issuecomment-1607190436))
+
+MIME-type awareness was introduced alongside this PR via the formatter
+interface refactor in [ADR-0005](0005-auditlogformatter-interface.md).
+
+## Technical Discussion
+
+Substantive review focused on lifecycle, transport hygiene, and future-proofing.
+
+**Lifecycle / Close:** the missing `WAF.Close()` blocked batching and shaped
+the whole design. The v3 compromise was "send one request per audit record,
+revisit in v4". That revisit eventually landed in v3.5.0 as
+[ADR-0043](0043-waf-close-per-owner-memoize.md).
+
+**Transport hygiene.** @jcchavezs flagged two concrete HTTP-client issues:
+
+> "I think any 2xx should be accepted. Restricting to OK feels mistaken as 201
+> and 204 are also valid status codes."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/826#discussion_r1241901929))
+
+> "Please drain the body before closing it using something like
+> `io.Copy(io.Discard, res.Body)` to be able to reuse the connection."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/826#discussion_r1241902417))
+
+Both were applied.
+
+**Content type.** @jcchavezs noted the missing Content-Type plumbing, which
+led directly to the formatter-interface refactor:
+
+> "One thing missing here is the content type support. We could add it to
+> formatters (yet not to the interface) and do interface assertion ok init and
+> record the value to be added to the requests."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/826#issuecomment-1630021852))
+
+Out-of-band decision-making is called out explicitly on the PR:
+
+> "Decisions we made during meeting
+> https://owasp.slack.com/archives/C02BXH135AT/p1687955362171029"
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/826#issuecomment-1612492704))
+
+The Slack thread itself is not visible to outside readers.
+
+## Participants
+
+- @jptosso — author
+- @jcchavezs — review (lifecycle, transport, content-type)
+- @anuraaga — review
+
+## Consequences
+
+- **Positive:** First-party HTTPS audit forwarding; MIME-aware so JSON,
+  native, and OCSF formatters can share the writer.
+- **Negative / follow-up:** No batching, no retry, no backoff — a record per
+  HTTP request. Higher-level reliability is left to the operator (SIEM-side
+  buffering). Batching awaits `WAF.Close()` (shipped in v3.5.0 —
+  [ADR-0043](0043-waf-close-per-owner-memoize.md)).
+- Drops MLOGC compatibility by design.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/826
+- Related ADRs: ADR-0005 (AuditLogFormatter interface), ADR-0028 (syslog
+  audit writer), ADR-0043 (`WAF.Close()`)

--- a/docs/adr/0003-https-audit-log-writer.md
+++ b/docs/adr/0003-https-audit-log-writer.md
@@ -58,6 +58,8 @@ revisit in v4". That revisit eventually landed in v3.5.0 as
 > and 204 are also valid status codes."
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/826#discussion_r1241901929))
 
+A second review comment covered connection reuse:
+
 > "Please drain the body before closing it using something like
 > `io.Copy(io.Discard, res.Body)` to be able to reuse the connection."
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/826#discussion_r1241902417))

--- a/docs/adr/0004-matchedrule-log-method.md
+++ b/docs/adr/0004-matchedrule-log-method.md
@@ -1,0 +1,94 @@
+# ADR-0004: Expose `MatchedRule.Log()` via optional interface
+
+- **Status:** accepted
+- **Date:** 2023-07-25
+- **Version:** v3.0.3
+- **PR:** [#848](https://github.com/corazawaf/coraza/pull/848)
+- **Issue(s):** [#839](https://github.com/corazawaf/coraza/issues/839); supersedes PR [#840](https://github.com/corazawaf/coraza/pull/840)
+- **Deciders:** @M4tteoP, @jcchavezs, @anuraaga, @jptosso
+- **Category:** Feature
+
+## Context and Problem
+
+Consumers wanted to filter matched rules to only those the rule author
+intended to audit-log. Users were approximating this via `Rule().Severity()`,
+which is not the correct signal — audit-log eligibility depends on the rule's
+`log`/`nolog` actions, not its severity. Audit logs were also coming up empty
+for some rules marked `log` because the information was not reachable.
+
+## Decision Drivers
+
+- Fix the empty-audit-log bug for `log`-marked rules (root cause).
+- Give consumers a reliable way to filter matches for logging.
+- Avoid breaking the public `types.MatchedRule` interface in v3.
+
+## Considered Options
+
+- **A.** Add `Log() bool` to the public `types.MatchedRule` interface
+  (breaking for anyone implementing the interface).
+- **B.** Ship a separate `RuleLogger` interface and let callers do a type
+  assertion (non-breaking).
+- **C.** Do not expose the method publicly at all; let callers cast to the
+  internal struct.
+
+## Decision Outcome
+
+Chosen: **option B** for v3 — a `RuleLogger` assertion-style interface — with
+a note that a cleaner v4 will promote the method onto the main interface.
+
+> "one easy way to avoid the breaking change is to not to add `Log` method to
+> the interface and do the assertion here with a `RuleLogger` interface … with
+> a comment so breaking change can be added in v4."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/848#discussion_r1269792282))
+
+@anuraaga initially pushed toward option C:
+
+> "Can we just cast to the struct? We do that a few places I think"
+> — @anuraaga ([review](https://github.com/corazawaf/coraza/pull/848#discussion_r1271236131))
+
+…and later hardened the position on keeping the public surface small:
+
+> "Let's remove the whole change in this file, it looks like the best it can
+> do is provide confusion rather than clarity. If there's no public method,
+> there's no public method"
+> — @anuraaga ([review](https://github.com/corazawaf/coraza/pull/848#discussion_r1271236246))
+
+The outcome followed @jcchavezs's compromise: the assertion interface shipped,
+and the v4-aligned interface promotion is tracked separately.
+
+## Technical Discussion
+
+Discussion revolved almost entirely around API surface hygiene in v3.
+
+@jcchavezs also flagged the risk of the workaround interface leaking into the
+long-term API:
+
+> "I'd rather not to expose this interface. Doing so we will be increasing the
+> API surface and also this interface is just a workaround and very likely to
+> be removed in v4. Also, go interface implementation is implicit so anyone
+> can declare an interface and do the same assertion."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/848#discussion_r1270918803))
+
+Two supersession links are on the record: PR #840 was replaced by this one,
+and issue #839 was the user-reported symptom.
+
+## Participants
+
+- @M4tteoP — author
+- @jcchavezs — review (API surface, v4 plan)
+- @anuraaga — review (structural casting alternative)
+- @joshi-mohit — original reporter (quoted in PR body)
+
+## Consequences
+
+- **Positive:** Audit-log filtering works correctly; `log` action is respected;
+  no v3 API break.
+- **Negative / follow-up:** Two ways exist to inspect the logging intent (the
+  optional interface, the internal struct). v4 is expected to clean this up by
+  promoting the method to `types.MatchedRule`.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/848
+- Issue: https://github.com/corazawaf/coraza/issues/839
+- Superseded PR: https://github.com/corazawaf/coraza/pull/840

--- a/docs/adr/0005-auditlogformatter-interface.md
+++ b/docs/adr/0005-auditlogformatter-interface.md
@@ -1,0 +1,89 @@
+# ADR-0005: `AuditLogFormatter` becomes an interface
+
+- **Status:** accepted
+- **Date:** 2023-08-06
+- **Version:** v3.0.3
+- **PR:** [#850](https://github.com/corazawaf/coraza/pull/850)
+- **Issue(s):** No linked issue (follows PR [#826](https://github.com/corazawaf/coraza/pull/826))
+- **Deciders:** @jptosso, @anuraaga, @jcchavezs
+- **Category:** Refactor (breaking within experimental plugin surface)
+
+## Context and Problem
+
+The HTTPS audit log writer ([ADR-0003](0003-https-audit-log-writer.md))
+needed to set a `Content-Type` per formatter. The existing formatter API was a
+bare function type:
+
+```go
+type AuditLogFormatter func(plugintypes.AuditLog) ([]byte, error)
+```
+
+A function cannot carry a MIME type. The formatter needed to become
+self-describing.
+
+## Decision Drivers
+
+- The HTTPS writer must know the formatter's content type.
+- The formatter plugin API is still experimental, so a breaking shape change
+  is acceptable now — cheaper than later.
+- Keep plugin implementation effort minimal (two methods per formatter).
+
+## Considered Options
+
+- Keep the function type and ship a parallel lookup table for MIME types.
+- Replace the function type with an interface carrying `Format()` + `MIME()`.
+- Attach metadata via a wrapper struct that still embeds the function.
+
+## Decision Outcome
+
+Chosen: **replace the function type with an interface.** `anuraaga` proposed
+it directly; `jcchavezs` accepted in one line.
+
+> "I think content type should be on the formatter, not https writer. Since
+> it's still experimental API, we can change formatter, how about making it an
+> actual type with `Format()` and `ContentType()` methods?"
+> — @anuraaga ([review](https://github.com/corazawaf/coraza/pull/850#discussion_r1274245227))
+
+> "Brilliant. Let's do it."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/850#discussion_r1275034260))
+
+The PR renamed `ContentType()` to `MIME()` during iteration. All built-in
+formatters (`nativeFormatter`, `jsonFormatter`, `legacyJSONFormatter`, and the
+test formatter) implement the interface. Compile-time assertions were added.
+
+## Technical Discussion
+
+@jcchavezs argued against permissive matching on the writer side:
+
+> "Is HasPrefix accurate? Can't we do direct comparison equality?"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/850#discussion_r1274124841))
+
+@jptosso defended prefix matching for parameterised content types:
+
+> "Im most cases yes, but at some point it would be right to use
+> `application/json;encoding=utf-8`, like the automatic mime detection does"
+> — @jptosso ([review](https://github.com/corazawaf/coraza/pull/850#discussion_r1274134624))
+
+Prefix matching on MIME was kept; strict equality would have misfired on
+parameterised content types.
+
+## Participants
+
+- @jptosso — author
+- @anuraaga — review (proposed the interface shape)
+- @jcchavezs — review (many formatter conformance suggestions)
+
+## Consequences
+
+- **Positive:** Formatters are self-describing for MIME type; new transport
+  writers (HTTPS now, syslog later — [ADR-0028](0028-syslog-audit-log-writer.md))
+  can decide framing from the formatter alone.
+- **Negative:** One-time breaking change for out-of-tree formatter plugins —
+  they must grow a `MIME()` method. Acceptable because the plugin API is
+  declared experimental.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/850
+- Related ADRs: ADR-0003 (HTTPS audit log writer), ADR-0028 (syslog audit
+  writer), ADR-0018 (OCSF audit log format)

--- a/docs/adr/0006-regex-ahocorasick-memoize.md
+++ b/docs/adr/0006-regex-ahocorasick-memoize.md
@@ -1,0 +1,99 @@
+# ADR-0006: Memoize cache for regexes and Aho-Corasick tables
+
+- **Status:** accepted
+- **Date:** 2023-08-06
+- **Version:** v3.0.3 (opt-in, behind `coraza.memoize_builders` build tag)
+- **PR:** [#836](https://github.com/corazawaf/coraza/pull/836)
+- **Issue(s):** [coraza-caddy#76](https://github.com/corazawaf/coraza-caddy/issues/76)
+- **Deciders:** @jcchavezs, @anuraaga, @jptosso, @M4tteoP
+- **Category:** Perf
+
+## Context and Problem
+
+Every WAF instance compiled every regex and Aho-Corasick table afresh. When
+the same ruleset is mounted into many WAFs (the Caddy connector pattern
+reported in coraza-caddy#76), the same regular expressions get compiled
+hundreds of times, wasting CPU at boot and RSS forever after.
+
+## Decision Drivers
+
+- Dramatically reduce memory / compile-time in multi-WAF deployments.
+- Stay opt-in so embedders that instantiate one WAF per process see no
+  behaviour change.
+- Avoid adding a `Close()` method to the `WAF` interface in v3 — adding one
+  would be a break.
+
+## Considered Options
+
+- Per-WAF cache.
+- Process-global cache, opt-in via build tag, exposed via `experimental`.
+- Add `WAF.Close()` now and bind the cache to the WAF lifetime.
+
+## Decision Outcome
+
+Chosen: **process-global cache, opt-in via build tag, exposed via
+`experimental`**, because the cache is inherently global (many WAFs share one
+process) and adding `WAF.Close()` was considered too large an API move for v3.
+The global `Close()` helper lives in `experimental` so anyone worried about
+leaks can clear on reload.
+
+> "We should include a flush or reset function so we can delete everything
+> after a web server reload. That function must be exported. I would include
+> it in `experimental/coraza`"
+> — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/836#issuecomment-1622448598))
+
+> "Waf close is not coming in v3 as we cannot break the api, we should just
+> export all helpers in experimental until we can merge them. But closing
+> cache is different, as this is global and no per-WAF"
+> — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/836#issuecomment-1622462418))
+
+@anuraaga agreed per-WAF close would not help here:
+
+> "For this PR though, I don't see how a WAF close method would help though
+> since IIUC the cache is global, not per waf. Having a global method in
+> experimental for now seems ok."
+> — @anuraaga ([comment](https://github.com/corazawaf/coraza/pull/836#issuecomment-1622687655))
+
+## Technical Discussion
+
+@anuraaga pushed on the concurrency primitive:
+
+> "This is ok but this file looks like an obvious mutex guarded map, not sure
+> it's worth referencing anything. Anyways it looks like a `sync.Map` should
+> be much faster for this, it's docs specifically mention the write once read
+> many case of a cache"
+> — @anuraaga ([review](https://github.com/corazawaf/coraza/pull/836#discussion_r1253758317))
+
+Error-handling philosophy briefly debated — @jptosso objected to panics,
+@jcchavezs chose to match `MustCompile`:
+
+> "Agree, however this should be fixed in `main`, I am just reproducing the
+> `MustCompile` behaviour."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/836#discussion_r1269182547))
+
+The cache was shipped as opt-in (build tag) in v3.0.3, later became the default
+in v3.5.0 once per-WAF tracking was available
+([ADR-0042](0042-regex-memoize-default-on.md),
+[ADR-0043](0043-waf-close-per-owner-memoize.md)).
+
+## Participants
+
+- @jcchavezs — author
+- @anuraaga — review (sync.Map suggestion, lifecycle sanity check)
+- @jptosso — review (drove the "global + experimental reset" design)
+- @M4tteoP — review (docs/readme nit)
+
+## Consequences
+
+- **Positive:** Large multi-WAF deployments (Caddy, proxy-wasm ambient
+  authorities) drop boot-time compile cost dramatically.
+- **Negative / follow-up:** The global cache is process-lifetime — embedders
+  reloading rulesets in-place must call the experimental reset. A cleaner
+  per-WAF lifecycle awaits `WAF.Close()` (ADR-0043) and the default-on
+  decision (ADR-0042).
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/836
+- Related ADRs: ADR-0042 (memoize default on), ADR-0043 (`WAF.Close()`)
+- Upstream motivating issue: https://github.com/corazawaf/coraza-caddy/issues/76

--- a/docs/adr/0006-regex-ahocorasick-memoize.md
+++ b/docs/adr/0006-regex-ahocorasick-memoize.md
@@ -2,7 +2,7 @@
 
 - **Status:** accepted
 - **Date:** 2023-08-06
-- **Version:** v3.0.3 (opt-in, behind `coraza.memoize_builders` build tag)
+- **Version:** v3.0.3 (opt-in, behind the `memoize_builders` build tag)
 - **PR:** [#836](https://github.com/corazawaf/coraza/pull/836)
 - **Issue(s):** [coraza-caddy#76](https://github.com/corazawaf/coraza-caddy/issues/76)
 - **Deciders:** @jcchavezs, @anuraaga, @jptosso, @M4tteoP
@@ -34,13 +34,17 @@ hundreds of times, wasting CPU at boot and RSS forever after.
 Chosen: **process-global cache, opt-in via build tag, exposed via
 `experimental`**, because the cache is inherently global (many WAFs share one
 process) and adding `WAF.Close()` was considered too large an API move for v3.
-The global `Close()` helper lives in `experimental` so anyone worried about
-leaks can clear on reload.
+
+Exporting a reset helper was asked for on the thread but did not ship in
+v3.0.3: the cache is process-global and entries live until the process exits.
+Per-WAF cleanup arrived later with `WAF.Close()` (ADR-0043).
 
 > "We should include a flush or reset function so we can delete everything
 > after a web server reload. That function must be exported. I would include
 > it in `experimental/coraza`"
 > — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/836#issuecomment-1622448598))
+
+He then set out why the cache's lifetime is not the WAF's:
 
 > "Waf close is not coming in v3 as we cannot break the api, we should just
 > export all helpers in experimental until we can merge them. But closing
@@ -87,10 +91,10 @@ in v3.5.0 once per-WAF tracking was available
 
 - **Positive:** Large multi-WAF deployments (Caddy, proxy-wasm ambient
   authorities) drop boot-time compile cost dramatically.
-- **Negative / follow-up:** The global cache is process-lifetime — embedders
-  reloading rulesets in-place must call the experimental reset. A cleaner
-  per-WAF lifecycle awaits `WAF.Close()` (ADR-0043) and the default-on
-  decision (ADR-0042).
+- **Negative / follow-up:** The global cache is process-lifetime, with no
+  exported way to clear it in v3.0.3 — embedders reloading rulesets in-place
+  keep the old entries until the process exits. A per-WAF lifecycle arrived
+  with `WAF.Close()` (ADR-0043), alongside the default-on decision (ADR-0042).
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,11 @@ Superseding does not delete the old record. Set its status and let the history s
 
 | ADR | PR | Merged | Version | Cat. | Title |
 |-----|----|--------|---------|------|-------|
-| _no records yet_ | | | | | |
+| [0001](0001-response-args-collection.md) | [#811](https://github.com/corazawaf/coraza/pull/811) | 2023-06-12 | v3.0.1 | P | RESPONSE_ARGS collection |
+| [0002](0002-secargumentslimit-directive.md) | [#812](https://github.com/corazawaf/coraza/pull/812) | 2023-06-14 | v3.0.2 | P | SecArgumentsLimit directive |
+| [0003](0003-https-audit-log-writer.md) | [#826](https://github.com/corazawaf/coraza/pull/826) | 2023-07-11 | v3.0.3 | F | HTTPS audit log writer |
+| [0004](0004-matchedrule-log-method.md) | [#848](https://github.com/corazawaf/coraza/pull/848) | 2023-07-25 | v3.0.3 | F | `MatchedRule.Log()` method |
+| [0005](0005-auditlogformatter-interface.md) | [#850](https://github.com/corazawaf/coraza/pull/850) | 2023-08-06 | v3.0.3 | R | `AuditLogFormatter` interface |
+| [0006](0006-regex-ahocorasick-memoize.md) | [#836](https://github.com/corazawaf/coraza/pull/836) | 2023-08-06 | v3.0.3 | ⚡ | Regex & Aho-Corasick memoize cache |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **1 of 8** splitting #1614 into reviewable pieces. Six records covering the structural changes in v3.0.1 → v3.0.3.

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0001 | #811 | Parity | Enable `RESPONSE_ARGS` collection |
| 0002 | #812 | Parity | `SecArgumentsLimit` directive |
| 0003 | #826 | Feature | HTTPS audit log writer |
| 0004 | #848 | Feature | Expose `MatchedRule.Log()` via optional interface |
| 0005 | #850 | Refactor | `AuditLogFormatter` becomes an interface |
| 0006 | #836 | Perf | Memoize cache for regexes and Aho-Corasick tables |

## What to check

The format is machine-checked — `mage adr` passes on this branch (6 records) and CI runs it. What the checker cannot do is the review that matters here:

- **Are the quotes representative?** Every quote in this batch was verified to appear verbatim in the comment it cites, and no permalink is fabricated. Nobody has checked whether the quoted line is a fair summary of what the thread actually concluded.
- **Is the classification right?** Particularly the Feature-vs-Parity line, and whether ADR-0005 is fairly called Refactor given it changed an experimental plugin surface.
- **Is anything missing or misattributed?** Deciders and Participants lists came from thread archaeology and are the most likely thing to be wrong about a colleague.

## Merge order

All eight batches replace the same `_no records yet_ ` placeholder row in `docs/adr/README.md`, so they merge in sequence: once this lands, batch 2 needs a rebase that keeps both row sets. Batch 2 is up at the same time so the shape is visible; batches 3–8 will follow as these land.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 6 record(s) OK`
- [x] Every quote checked against the GitHub API: appears verbatim in the cited comment, author matches, permalink resolves
- [x] Records 0001–0006 appear in no other batch

---

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read the Contribution guidelines and Code of Conduct.
- [x] My code is properly linted and passes pre-commit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added six architecture decision records covering response argument collection, argument limits, HTTPS audit logging, matched-rule logging, audit log formatting, and regex/table caching.
  * Updated the architecture decision index with record details, versions, categories, and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->