### PR TITLE
feat: register the accuracy rule action

### DIFF
--- a/internal/actions/accuracy.go
+++ b/internal/actions/accuracy.go
@@ -29,7 +29,7 @@ type accuracyFn struct{}
 func (a *accuracyFn) Init(r plugintypes.RuleMetadata, data string) error {
 	acc, err := strconv.Atoi(data)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid accuracy %q: %w", data, err)
 	}
 	if acc < 1 || acc > 9 {
 		return fmt.Errorf("invalid argument, %d should be between 1 and 9", acc)

--- a/internal/actions/accuracy.go
+++ b/internal/actions/accuracy.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+)
+
+// Action Group: Metadata
+//
+// Description:
+// Specifies the relative accuracy level of the rule related to the number of false positives and false negatives.
+// The value is a string based on a numeric scale (1-9 where 9 is extensively tested and 1 is a brand new experimental rule).
+//
+// Example:
+// ```
+//
+//	SecRule REQUEST_FILENAME|ARGS_NAMES|ARGS|XML:/* "\bgetparentfolder\b" \
+//		"phase:2,ver:'CRS/2.2.4',accuracy:'9',maturity:'9',capture,t:none,t:htmlEntityDecode,t:compressWhiteSpace,t:lowercase,ctl:auditLogParts=+E,block,msg:'Cross-site Scripting (XSS) Attack',id:'958016',tag:'WEB_ATTACK/XSS',severity:'2'"
+//
+// ```
+type accuracyFn struct{}
+
+func (a *accuracyFn) Init(r plugintypes.RuleMetadata, data string) error {
+	acc, err := strconv.Atoi(data)
+	if err != nil {
+		return err
+	}
+	if acc < 1 || acc > 9 {
+		return fmt.Errorf("invalid argument, %d should be between 1 and 9", acc)
+	}
+	r.(*corazawaf.Rule).Accuracy_ = acc
+	return nil
+}
+
+func (a *accuracyFn) Evaluate(_ plugintypes.RuleMetadata, _ plugintypes.TransactionState) {}
+
+func (a *accuracyFn) Type() plugintypes.ActionType {
+	return plugintypes.ActionTypeMetadata
+}
+
+func accuracy() plugintypes.Action {
+	return &accuracyFn{}
+}
+
+var (
+	_ plugintypes.Action = &accuracyFn{}
+	_ ruleActionWrapper  = accuracy
+)

--- a/internal/actions/accuracy_test.go
+++ b/internal/actions/accuracy_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Juan Pablo Tosso and the OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+)
+
+func TestAccuracyInit(t *testing.T) {
+	for _, test := range []struct {
+		data             string
+		expectedError    bool
+		expectedAccuracy int
+	}{
+		{"", true, 0},
+		{"abc", true, 0},
+		{"-10", true, 0},
+		{"0", true, 0},
+		{"5", false, 5},
+		{"10", true, 0},
+	} {
+		a := accuracy()
+		r := &corazawaf.Rule{}
+		err := a.Init(r, test.data)
+		if test.expectedError {
+			if err == nil {
+				t.Errorf("expected error")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error: %s", err.Error())
+			}
+
+			if want, have := test.expectedAccuracy, r.Accuracy_; want != have {
+				t.Errorf("unexpected accuracy value, want %d, have %d", want, have)
+			}
+		}
+	}
+}

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -94,6 +94,7 @@ func Register(name string, a func() plugintypes.Action) {
 }
 
 func init() {
+	Register("accuracy", accuracy)
 	Register("allow", allow)
 	Register("auditlog", auditlog)
 	Register("block", block)


### PR DESCRIPTION
The `accuracy` action is documented and there is already an `Accuracy_` field on the rule metadata that gets emitted to the audit log, but the action itself was never registered. So a rule using `accuracy` fails to parse with `invalid action "accuracy"` and the field always stays zero.

This registers it the same way as `maturity`: a metadata action that validates the 1 to 9 range and stores the value on the rule, with a matching unit test. Nothing else changes.

Closes #1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accuracy metadata setting for rules.
  * Supports accuracy values from 1 to 9.
  * Valid values are stored with the rule and reported as metadata.
  * Accuracy metadata does not perform transaction evaluation.

* **Bug Fixes**
  * Added validation and clear errors for missing, non-numeric, or out-of-range accuracy values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->