### PR TITLE
docs(adr): records for the v3.3.x releases (4 of 8)

### DIFF
--- a/docs/adr/0017-multipart-strict-error.md
+++ b/docs/adr/0017-multipart-strict-error.md
@@ -1,0 +1,73 @@
+# ADR-0017: Set `MULTIPART_STRICT_ERROR` on multipart parse failure
+
+- **Status:** accepted
+- **Date:** 2024-07-18
+- **Version:** v3.3.0
+- **PR:** [#1098](https://github.com/corazawaf/coraza/pull/1098)
+- **Issue(s):** No linked issue
+- **Deciders:** @fzipi, @M4tteoP
+- **Category:** Parity (ModSecurity variable parity + recommended-config alignment)
+
+## Context and Problem
+
+`coraza.conf-recommended` referenced `MULTIPART_STRICT_ERROR` to detect
+multipart evasions, but Coraza never actually set it — the variable was dead,
+so any rule using it was silently inert. Coraza's multipart parser also does
+not implement every ModSecurity sub-variable, so a single "something went
+wrong" signal was needed as a replacement.
+
+## Decision Drivers
+
+- The recommended config must actually work out of the box.
+- Provide a single global failure signal when the parser cannot fully trust
+  a multipart body, regardless of which sub-variable fired in ModSecurity.
+
+## Considered Options
+
+- Implement every ModSecurity multipart sub-variable (large effort).
+- Set a single `MULTIPART_STRICT_ERROR=1` on any parse failure; rewrite the
+  recommended config rules to use it.
+
+## Decision Outcome
+
+Chosen: **single global failure signal + rewrite recommended rules**.
+@M4tteoP pushed for the recommended config to show only variables Coraza
+actually supports, so operators are not misled:
+
+> "I would also make the rule output more aligned to Coraza removing all
+> these variables that can confuse a user without the context of where this
+> rule is coming from."
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1098#issuecomment-2236872455))
+
+> "We are also recommending this rule: `SecRule MULTIPART_UNMATCHED_BOUNDARY
+> \"@eq 1\" …` But that variable is never set, so that rule cannot be
+> triggered by any means."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1098#issuecomment-2236896425))
+
+> "Updated the coraza.conf-recommended to a more realistic one."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1098#issuecomment-2237381208))
+
+## Technical Discussion
+
+Follow-up for an engine-level regression test was captured for a future PR:
+
+> "Eventually for a follow-up PR, would be great to also have an engine test
+> (under `testing/engine`) that triggers this rule, for an e2e-like test of
+> the feature"
+> — @M4tteoP ([review](https://github.com/corazawaf/coraza/pull/1098#discussion_r1683405673))
+
+## Participants
+
+- @fzipi — author
+- @M4tteoP — review (pushed for recommended-config realism)
+
+## Consequences
+
+- **Positive:** Multipart evasion detection in the recommended config
+  actually works; operators get a truthful config out of the box.
+- **Negative / follow-up:** ModSecurity sub-variables remain unimplemented;
+  the single signal is coarse by design.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1098

--- a/docs/adr/0017-multipart-strict-error.md
+++ b/docs/adr/0017-multipart-strict-error.md
@@ -25,7 +25,7 @@ wrong" signal was needed as a replacement.
 ## Considered Options
 
 - Implement every ModSecurity multipart sub-variable (large effort).
-- Set a single `MULTIPART_STRICT_ERROR=1` on any parse failure; rewrite the
+- Set a single `MULTIPART_STRICT_ERROR=1` on parse failure; rewrite the
   recommended config rules to use it.
 
 ## Decision Outcome
@@ -66,7 +66,10 @@ Follow-up for an engine-level regression test was captured for a future PR:
 - **Positive:** Multipart evasion detection in the recommended config
   actually works; operators get a truthful config out of the box.
 - **Negative / follow-up:** ModSecurity sub-variables remain unimplemented;
-  the single signal is coarse by design.
+  the single signal is coarse by design. A truncated part (`io.ErrUnexpectedEOF`
+  from the underlying reader) does not set `MULTIPART_STRICT_ERROR` — parsing
+  simply stops and `ProcessRequest` returns `nil`, undocumented at the time of
+  writing.
 
 ## References
 

--- a/docs/adr/0018-ocsf-audit-log.md
+++ b/docs/adr/0018-ocsf-audit-log.md
@@ -1,0 +1,111 @@
+# ADR-0018: OCSF (v1.2.0) audit log format
+
+- **Status:** accepted
+- **Date:** 2024-09-17
+- **Version:** v3.3.0
+- **PR:** [#1089](https://github.com/corazawaf/coraza/pull/1089)
+- **Issue(s):** No linked issue (adopts OCSF schema)
+- **Deciders:** @durg78, @jcchavezs, @fzipi, @M4tteoP, @jptosso
+- **Category:** Feature
+
+## Context and Problem
+
+Modern SIEM tooling converges on OCSF (Open Cybersecurity Schema Framework).
+Coraza shipped with a native text format and a JSON format, neither of which
+maps cleanly into OCSF-aligned pipelines. Downstream consumers had to rebuild
+the OCSF record themselves.
+
+## Decision Drivers
+
+- Fit cleanly into OCSF-based observability stacks (SIEMs, XDRs).
+- Reuse an upstream schema library (`github.com/valllabh/ocsf-schema-golang`)
+  rather than hand-roll field mappings.
+- Keep the native/JSON formats as the default — OCSF is opt-in.
+
+## Considered Options
+
+- Add an OCSF wrapper around the existing JSON formatter.
+- Adopt OCSF v1.2.0 directly as a new formatter plugin.
+- Defer until OCSF adoption stabilises.
+
+## Decision Outcome
+
+Chosen: **OCSF v1.2.0 as a new formatter plugin**, opt-in. Native and JSON
+formatters stay the defaults.
+
+> "I think this is great. Being a existing format honestly feels this is
+> better than our JSON format or the modsec one which I am not 100% sure fits
+> in modern tooling. My only request here is that we should avoid changing
+> the transaction to support a format. Audit log formats are pluggable and
+> we should be able to either do everything with what we have or extend what
+> we have to support new use cases but that does not include changing the
+> internal API."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1089#issuecomment-2189072268))
+
+> "I don't think we want to recommend this by default as this feels like a
+> breaking change."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1652872889))
+
+> "Audit log is pluggable hence users might define their own, I don't think
+> we can support a strict type for this."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1652879947))
+
+> "Agreed. We should keep the native as default for now."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1652910194))
+
+## Technical Discussion
+
+Two cross-cutting issues surfaced during review.
+
+**1. Go version bump.** OCSF dependency forced Go 1.22, and
+`reflect.StringHeader` got deprecated in 1.21 along the way:
+
+> "reflect.StringHeader was deprecated in go 1.21, this was causing the lint
+> check to fail. I wasn't sure how best to handle that other than adding an
+> exception for now."
+> — @durg78 ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1652986174))
+
+> "We can also use inline linter nochecks"
+> — @jptosso ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1653127458))
+
+The real fix landed separately as PR #1162 — see
+[ADR-0019](0019-unsafe-stringdata-refactor.md).
+
+**2. Respect the plugin boundary.** @jcchavezs specifically rejected any
+change to the internal `Transaction` type to accommodate OCSF-specific
+fields:
+
+> "I doubt the internal transaction has to know about all these fields. I
+> wonder if this could happen in the internal/auditlog#Transaction type."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1089#discussion_r1652885811))
+
+The implementation was restructured to stay within the formatter package.
+
+**3. Rebase + TinyGo.** @M4tteoP asked for a rebase to pick up TinyGo
+updates (PR #1148). After the rebase:
+
+> "Checks are passing now! 🎉"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1089#issuecomment-2342227609))
+
+## Participants
+
+- @durg78 — author
+- @jcchavezs — review (drove plugin-boundary discipline, Go-version policy)
+- @fzipi — review (merge sign-off, default-format guidance)
+- @M4tteoP — review (TinyGo rebase)
+- @jptosso — review (linter-exception suggestion)
+
+## Consequences
+
+- **Positive:** Modern SIEM ingestion without downstream re-mapping; a clean
+  validation that the formatter plugin boundary holds for non-trivial
+  schemas.
+- **Negative / follow-up:** Coraza's Go minimum version moved forward;
+  `reflect.StringHeader` deprecation surfaced (fixed in ADR-0019).
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1089
+- OCSF schema lib: https://github.com/valllabh/ocsf-schema-golang
+- Related ADRs: ADR-0005 (formatter interface), ADR-0019 (unsafe.StringData),
+  ADR-0028 (syslog writer)

--- a/docs/adr/0018-ocsf-audit-log.md
+++ b/docs/adr/0018-ocsf-audit-log.md
@@ -102,6 +102,10 @@ updates (PR #1148). After the rebase:
   schemas.
 - **Negative / follow-up:** Coraza's Go minimum version moved forward;
   `reflect.StringHeader` deprecation surfaced (fixed in ADR-0019).
+  `ocsfFormatter.Format` calls `Transaction.Request()`/`Response()`
+  unconditionally without checking `HasRequest()`/`HasResponse()`; a
+  transaction missing either causes a nil-interface panic, an undocumented
+  precondition that needs hardening.
 
 ## References
 

--- a/docs/adr/0019-unsafe-stringdata-refactor.md
+++ b/docs/adr/0019-unsafe-stringdata-refactor.md
@@ -1,0 +1,70 @@
+# ADR-0019: `reflect.StringHeader` → `unsafe.StringData`
+
+- **Status:** accepted
+- **Date:** 2024-10-04
+- **Version:** v3.3.0
+- **PR:** [#1162](https://github.com/corazawaf/coraza/pull/1162)
+- **Issue(s):** [#1147](https://github.com/corazawaf/coraza/issues/1147)
+- **Deciders:** @Juneezee, @jcchavezs, @fzipi
+- **Category:** Refactor
+
+## Context and Problem
+
+`internal/corazawaf/rule.go` used `reflect.StringHeader` for zero-copy
+string/byte reinterpretation. Go 1.20 introduced `unsafe.StringData`, and
+`reflect.StringHeader` was officially deprecated in Go 1.21. The lint
+exception carried over from the OCSF Go-version bump
+([ADR-0018](0018-ocsf-audit-log.md)) was a temporary band-aid.
+
+## Decision Drivers
+
+- Correctness: `reflect.StringHeader` is deprecated and its Godoc explicitly
+  warns about GC-unsafe pointer handling.
+- Remove the lint-exception debt left behind in PR #1089.
+- Keep performance identical — the replacement is the GC-safe pointer
+  accessor.
+
+## Considered Options
+
+- Keep the `StringHeader` pattern with a permanent lint exception.
+- Port to `unsafe.StringData` as the upstream proposal suggests.
+
+## Decision Outcome
+
+Chosen: **port to `unsafe.StringData`.** The PR body cites the Godoc warnings
+directly:
+
+> "The Godoc of `reflect.StringHeader` states: 'the Data field is not
+> sufficient to guarantee the data it references will not be garbage
+> collected, so programs must keep a separate, correctly typed pointer to
+> the underlying data.' … The replacement `unsafe.StringData` is a more
+> correct way to get the pointer to the string data. The original proposal
+> can be seen in golang/go#53003."
+> — @Juneezee (PR body)
+
+## Technical Discussion
+
+No substantive architectural debate on the thread. One-line approval from
+the reviewer:
+
+> "The change looks very reasonable to me."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1162#issuecomment-2389453051))
+
+## Participants
+
+- @Juneezee — author
+- @jcchavezs — review (approval)
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Removes a deprecated API usage; GC-safe string/byte
+  reinterpretation; lint exception deleted.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1162
+- Issue: https://github.com/corazawaf/coraza/issues/1147
+- Upstream proposal: https://github.com/golang/go/issues/53003
+- Related ADRs: ADR-0018 (OCSF audit log)

--- a/docs/adr/0019-unsafe-stringdata-refactor.md
+++ b/docs/adr/0019-unsafe-stringdata-refactor.md
@@ -58,8 +58,11 @@ the reviewer:
 
 ## Consequences
 
-- **Positive:** Removes a deprecated API usage; GC-safe string/byte
-  reinterpretation; lint exception deleted.
+- **Positive:** Removes a deprecated API usage; `rule.go` uses
+  `unsafe.StringData(argKey)` only to obtain a `*byte` for the transformation
+  cache key (`transformationKey.argKey`), not general string/byte
+  reinterpretation — the bytes referenced by that pointer must not be
+  modified; lint exception deleted.
 - **Negative:** None.
 
 ## References

--- a/docs/adr/0020-secruleupdateactionbyid.md
+++ b/docs/adr/0020-secruleupdateactionbyid.md
@@ -1,0 +1,73 @@
+# ADR-0020: `SecRuleUpdateActionById` directive
+
+- **Status:** accepted
+- **Date:** 2024-10-31
+- **Version:** v3.3.0
+- **PR:** [#1071](https://github.com/corazawaf/coraza/pull/1071)
+- **Issue(s):** [#929](https://github.com/corazawaf/coraza/issues/929)
+- **Deciders:** @fzipi, @jcchavezs
+- **Category:** Parity (ModSecurity / CRS parity)
+
+## Context and Problem
+
+Operators using CRS needed a way to mutate a rule's action list by ID without
+reloading or editing upstream rule files. ModSecurity ships
+`SecRuleUpdateActionById` for exactly this; Coraza had the target-mutating
+directives but not the action-mutating one.
+
+## Decision Drivers
+
+- CRS tuning parity.
+- Minimal surface growth — mirror the shape of the existing
+  `SecRuleUpdateTargetById` implementation.
+
+## Considered Options
+
+- Extend existing `SecRuleUpdateTargetById` to also cover actions.
+- Ship a distinct `SecRuleUpdateActionById` directive.
+
+## Decision Outcome
+
+Chosen: **distinct directive, mirroring ModSecurity**. This keeps the CRS
+migration path straightforward.
+
+## Technical Discussion
+
+Two minor style requests were the entire review:
+
+> "nit: use `idsOrRangesLen` to avoid generic variable names"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1071#discussion_r1823795090))
+
+> "nit: flip the conditional to avoid indentation."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1071#discussion_r1823800325))
+
+The author had earlier flagged a separate blocker — tests were failing on an
+unrelated bug that was fixed in PR #1183:
+
+> "After finding why my tests didn't worked (#1183), now this is ready to
+> go."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1071#issuecomment-2448645235))
+
+No architectural debate took place — the directive's shape followed the
+existing pattern and was uncontroversial.
+
+## Participants
+
+- @fzipi — author
+- @jcchavezs — review (nits)
+
+## Consequences
+
+- **Positive:** Operators can tune CRS rule actions in-place (e.g. turn a
+  `deny` into `pass` for a specific rule) without re-generating ruleset
+  files.
+- **Negative / follow-up:** A later fix (PR #1471) was needed to ensure the
+  directive correctly replaces disruptive actions rather than appending.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1071
+- Issue: https://github.com/corazawaf/coraza/issues/929
+- Test-blocker: https://github.com/corazawaf/coraza/pull/1183
+- Follow-up: https://github.com/corazawaf/coraza/pull/1471
+- Related ADRs: ADR-0012 (`SecRuleUpdateTargetByTag`)

--- a/docs/adr/0021-square-brackets-in-variables.md
+++ b/docs/adr/0021-square-brackets-in-variables.md
@@ -1,0 +1,66 @@
+# ADR-0021: Square brackets in macro-expanded variable names
+
+- **Status:** accepted
+- **Date:** 2024-11-21
+- **Version:** v3.3.0
+- **PR:** [#1226](https://github.com/corazawaf/coraza/pull/1226)
+- **Issue(s):** No linked issue
+- **Deciders:** @geoolekom, @M4tteoP, @jcchavezs
+- **Category:** Parity (framework parameter conventions)
+
+## Context and Problem
+
+PHP and jQuery conventions produce parameter names containing square
+brackets (`ARGS.fields[]`, `fields[name]`). Coraza's macro-expansion parser
+rejected these names, breaking macros like
+`%{ARGS.db-reset-tables[]}` in rule messages and forcing users to rewrite
+otherwise-standard rules.
+
+## Decision Drivers
+
+- Compatibility with web-framework parameter conventions.
+- No behaviour change for variable lookups that already worked — only the
+  macro-expansion parser needed widening.
+
+## Considered Options
+
+- Teach every rule-parsing entrypoint to accept brackets.
+- Widen only the macro-expansion parser, which is where the breakage was.
+
+## Decision Outcome
+
+Chosen: **widen only the macro-expansion parser**, matching the narrow scope
+of the observed bug.
+
+## Technical Discussion
+
+The review's substantive thread was about scoping the change correctly.
+
+> "I just wish to double-check the scope of the PR, because the description
+> seems not fully aligned with the code. I tested the following rules, and
+> they actually worked as expected. `SecRule ARGS:key[] …` … What does this
+> PR fixes?"
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1226#issuecomment-2491006691))
+
+> "oh, yes. Indeed, I meant the variables in macro. I missed a `msg` part in
+> my example, my bad."
+> — @geoolekom ([comment](https://github.com/corazawaf/coraza/pull/1226#issuecomment-2491029430))
+
+> "Ok, great, thanks for confirming it!"
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1226#issuecomment-2491685710))
+
+## Participants
+
+- @geoolekom — author
+- @M4tteoP — review (scope clarification)
+- @jcchavezs — review
+
+## Consequences
+
+- **Positive:** CRS and downstream rulesets with PHP/jQuery-style parameter
+  names can use macros referencing them without workarounds.
+- **Negative / follow-up:** None — the change is additive in the parser.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1226

--- a/docs/adr/0022-time-variables.md
+++ b/docs/adr/0022-time-variables.md
@@ -1,0 +1,123 @@
+# ADR-0022: `TIME_*` variables support
+
+- **Status:** accepted
+- **Date:** 2024-12-09
+- **Version:** v3.3.0
+- **PR:** [#1223](https://github.com/corazawaf/coraza/pull/1223)
+- **Issue(s):** [#1220](https://github.com/corazawaf/coraza/issues/1220)
+- **Deciders:** @geoolekom, @jcchavezs, @M4tteoP, @fzipi, @jptosso
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+ModSecurity exposes `TIME`, `TIME_DAY`, `TIME_EPOCH`, `TIME_HOUR`,
+`TIME_MIN`, `TIME_MON`, `TIME_SEC`, `TIME_WDAY`, `TIME_YEAR`. Popular
+rulesets (Imunify360 was cited) use them heavily for time-window rules and
+for enriching `msg` / `logdata`. Coraza had none.
+
+## Decision Drivers
+
+- ModSecurity compatibility.
+- Support real-world ruleset patterns like "measure duration between two
+  phases" (Imunify360's filescan rules).
+- Pick a single, sensible TIME_MON range (ModSecurity itself is
+  inconsistent: v2 uses 1-12, v3 uses 0-11).
+
+## Considered Options
+
+- Do not implement — push time handling into the embedder's logger.
+- Implement eagerly at transaction-creation time.
+- Implement lazily (fill on first access).
+- Implement eagerly with a precomputed `int → string` lookup table.
+
+## Decision Outcome
+
+Chosen: **eager population at transaction creation, with small perf
+optimisations** (follow-up #1242). Lazy collections were prototyped but did
+not pay off enough to justify the new concept.
+
+> "We merged this PR as it was and with a couple of performance improvements
+> in #1242 because lazy collections wasn't bringing enough improvements for
+> this particular use case that it did not feel right to land such a concept
+> for low benefit."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1223#issuecomment-2568873506))
+
+For `TIME_MON` the PR standardised on **1–12** to align with the
+ModSecurity v2→v3 reconciliation in owasp-modsecurity/ModSecurity#3306.
+
+> "There is already an open PR … that aligns v3 to use `1-12` range. So I
+> believe that we have pretty much agreed that `1-12` range is the one we
+> should stick with. Let's go with it"
+> — @M4tteoP ([review](https://github.com/corazawaf/coraza/pull/1223#discussion_r1853923001))
+
+## Technical Discussion
+
+**Initial resistance from @jcchavezs:**
+
+> "I am not fully convinced on the need of this. I believe the case you
+> point out is more like a logger concern as we are only interpolating the
+> variable to display the timestamp. **Interpolating a variable isn't cheap**,
+> nor it is allocating all the variables we allocated and converted by
+> default from int to string."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1223#issuecomment-2483103482))
+
+…countered with real-world rule examples (Imunify360 filescan duration
+rules), which moved the decision:
+
+> "Thanks @geoolekom! I think most of the points raised here make sense.
+> Let me do a couple of experiments as what I have in mind is that this a
+> good opportunity for trying lazy collections."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1223#issuecomment-2488002382))
+
+**TinyGo / Wasm consideration.** @jcchavezs noted Wasm environments can't
+cheaply call `time.Now()`, so lazy filling was attractive. The PoC lived at
+https://github.com/geoolekom/coraza/pull/1 ; it did not outperform the simple
+eager path enough to ship.
+
+**Perf optimisation.** @jcchavezs suggested a lookup table over `strconv.Itoa`:
+
+> "Sorry if I wasn't clear enough. I was advocating for having a map in
+> memory e.g.
+>
+> ```go
+> var hourConversion map[int]string = map[int]string{1: "1", 2: "2", ...}
+> ```
+>
+> instead of doing the `strconv.Itoa`."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1223#discussion_r1846662447))
+
+Landed in follow-up #1242.
+
+**Alternative shape considered.** @fzipi asked whether lazy/per-access
+population would be simpler end-to-end:
+
+> "Isn't better to just remove this call and generate the value for each
+> variable at access time instead? Kind of being more an *init* than *set*."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1223#discussion_r1868568426))
+
+## Participants
+
+- @geoolekom — author (provided the real-world rule examples that carried
+  the decision)
+- @jcchavezs — review (lazy-collection PoC, perf guidance)
+- @M4tteoP — review (drove the `TIME_MON` 1-12 decision)
+- @fzipi — review (shape alternatives)
+- @jptosso — review
+
+## Consequences
+
+- **Positive:** Time-aware rules (scan-duration logic, rate/hour correlation,
+  `msg`/`logdata` enrichment) work in Coraza; CRS and Imunify360 rules that
+  rely on `TIME_*` become usable.
+- **Negative / follow-up:** `time.Now()` is called for every transaction;
+  Wasm-scale deployments pay a cost. Lazy collections explored and declined.
+  Further perf tuning shipped in #1242.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1223
+- Issue: https://github.com/corazawaf/coraza/issues/1220
+- Follow-up perf PR: https://github.com/corazawaf/coraza/pull/1242
+- Lazy-collection PoC: https://github.com/geoolekom/coraza/pull/1
+- ModSecurity TIME_MON alignment: https://github.com/owasp-modsecurity/ModSecurity/issues/3305,
+  https://github.com/owasp-modsecurity/ModSecurity/pull/3306

--- a/docs/adr/0023-base64encode-transformation.md
+++ b/docs/adr/0023-base64encode-transformation.md
@@ -1,0 +1,64 @@
+# ADR-0023: `base64Encode` transformation
+
+- **Status:** accepted
+- **Date:** 2024-12-29
+- **Version:** v3.3.0
+- **PR:** [#1257](https://github.com/corazawaf/coraza/pull/1257)
+- **Issue(s):** [#1252](https://github.com/corazawaf/coraza/issues/1252)
+- **Deciders:** @tty2, @fzipi
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+ModSecurity's `base64Encode` transformation was missing from Coraza. Rulesets
+that use it to encode payloads for logging or indirect comparison did not
+work as written.
+
+## Decision Drivers
+
+- ModSecurity compatibility.
+- Minimal new code — `encoding/base64` stdlib suffices.
+- Test parity with other one-liner transformations (use existing
+  `testdata/base64encode.json`).
+
+## Considered Options
+
+- Hand-roll the encoding loop (no reason to).
+- Wrap `base64.StdEncoding.EncodeToString`.
+
+## Decision Outcome
+
+Chosen: **stdlib wrapper**, following the pattern used by other one-liner
+transformations in `internal/transformations`.
+
+## Technical Discussion
+
+Review was light — a couple of misunderstandings around where the tests
+lived, and a copyright-line suggestion:
+
+> "Ah, good catch! They are already there! Don't need to add them 😄"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1257#issuecomment-2554359814))
+
+> "```suggestion
+> // Copyright 2024 Juan Pablo Tosso and the OWASP Coraza contributors
+> ```"
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1257#discussion_r1892349843))
+
+No architectural discussion — the transformation is a one-liner around
+`encoding/base64`.
+
+## Participants
+
+- @tty2 — author
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Rulesets that `t:base64Encode` their payloads now work.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1257
+- Issue: https://github.com/corazawaf/coraza/issues/1252
+- ModSecurity reference: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#base64Encode

--- a/docs/adr/0024-hexdecode-transformation.md
+++ b/docs/adr/0024-hexdecode-transformation.md
@@ -1,0 +1,69 @@
+# ADR-0024: `hexDecode` transformation
+
+- **Status:** accepted
+- **Date:** 2025-01-24
+- **Version:** v3.3.2
+- **PR:** [#1275](https://github.com/corazawaf/coraza/pull/1275)
+- **Issue(s):** [#1253](https://github.com/corazawaf/coraza/issues/1253)
+- **Deciders:** @tty2, @fzipi, @jptosso
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+ModSecurity exposes a `hexDecode` transformation (reverse of hex/base-16
+encoding). Coraza had `hexEncode` but not its counterpart, which left a small
+parity gap.
+
+## Decision Drivers
+
+- ModSecurity parity.
+- Behaviour on malformed input — follow the existing "best-effort" precedent
+  set by other transformations.
+
+## Considered Options
+
+- Strict parse: reject on any non-hex character.
+- Best-effort: trim odd trailing nibbles, decode what's valid.
+
+## Decision Outcome
+
+Chosen: **best-effort decode**, following the existing pattern used by sibling
+transformations. This was a question explicitly raised and resolved in review.
+
+> "This PR is mostly based on assumptions cause I didn't get any reply here
+> [#1253]. The main assumption is that coraza wants to go 'best effort
+> approach'. This assumption is based on the tests … Relying on tests we
+> need to remove the last symbol."
+> — @tty2 ([review](https://github.com/corazawaf/coraza/pull/1275#discussion_r1905517040))
+
+## Technical Discussion
+
+The substantive discussion was about how to interpret an odd-length input
+(technically malformed per hex/base-16 encoding):
+
+> "What does this mean? Can you provide pointers? 'hex' enconding, in the
+> RFC you are mentioning, is just Base16 where each byte is represented as
+> two four bits. So, AFAIU, we are only removing the _last_ input to make an
+> effort to fix a broken input, right? Could the problem be the first
+> instead?"
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1275#discussion_r1905465117))
+
+The decision was to follow the precedent set by other transformations'
+existing test expectations (best-effort, trim trailing).
+
+## Participants
+
+- @tty2 — author
+- @fzipi — review (behaviour on malformed input)
+- @jptosso — review
+
+## Consequences
+
+- **Positive:** `t:hexDecode` works for ModSecurity-migrated rulesets.
+- **Negative:** The "best-effort" choice on malformed input matches existing
+  coraza behaviour but is not strictly RFC-correct. Documented inline.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1275
+- Issue: https://github.com/corazawaf/coraza/issues/1253

--- a/docs/adr/0024-hexdecode-transformation.md
+++ b/docs/adr/0024-hexdecode-transformation.md
@@ -27,8 +27,13 @@ parity gap.
 
 ## Decision Outcome
 
-Chosen: **best-effort decode**, following the existing pattern used by sibling
-transformations. This was a question explicitly raised and resolved in review.
+Chosen in review: **best-effort decode**, following the existing pattern used
+by sibling transformations. The shipped implementation diverges from that
+outcome — it delegates to `encoding/hex.DecodeString`, which returns an error
+for malformed input (odd length or non-hex characters) instead of trimming
+and decoding what's valid. `internal/transformations/hex_decode_test.go`
+asserts this strict behavior. This was a question explicitly raised and
+discussed in review.
 
 > "This PR is mostly based on assumptions cause I didn't get any reply here
 > [#1253]. The main assumption is that coraza wants to go 'best effort
@@ -60,8 +65,9 @@ existing test expectations (best-effort, trim trailing).
 ## Consequences
 
 - **Positive:** `t:hexDecode` works for ModSecurity-migrated rulesets.
-- **Negative:** The "best-effort" choice on malformed input matches existing
-  coraza behaviour but is not strictly RFC-correct. Documented inline.
+- **Negative:** Malformed input (odd length or non-hex characters) errors out
+  rather than best-effort decoding what's valid, diverging from the outcome
+  discussed in review and from sibling transformations' precedent.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,5 +83,13 @@ Superseding does not delete the old record. Set its status and let the history s
 | [0014](0014-base64decodeext-transformation.md) | [#1046](https://github.com/corazawaf/coraza/pull/1046) | 2024-04-24 | v3.2.0 | P | `base64DecodeExt` transformation |
 | [0015](0015-case-sensitive-maps.md) | [#1055](https://github.com/corazawaf/coraza/pull/1055) | 2024-05-01 | v3.2.0 | F | Case-sensitive maps |
 | [0016](0016-case-sensitive-args.md) | [#1059](https://github.com/corazawaf/coraza/pull/1059) | 2024-05-28 | v3.2.0 | P | Case-sensitive args support |
+| [0017](0017-multipart-strict-error.md) | [#1098](https://github.com/corazawaf/coraza/pull/1098) | 2024-07-18 | v3.3.0 | P | `MULTIPART_STRICT_ERROR` variable |
+| [0018](0018-ocsf-audit-log.md) | [#1089](https://github.com/corazawaf/coraza/pull/1089) | 2024-09-17 | v3.3.0 | F | OCSF audit log format |
+| [0019](0019-unsafe-stringdata-refactor.md) | [#1162](https://github.com/corazawaf/coraza/pull/1162) | 2024-10-04 | v3.3.0 | R | `reflect.StringHeader` → `unsafe.StringData` |
+| [0020](0020-secruleupdateactionbyid.md) | [#1071](https://github.com/corazawaf/coraza/pull/1071) | 2024-10-31 | v3.3.0 | P | `SecRuleUpdateActionById` directive |
+| [0021](0021-square-brackets-in-variables.md) | [#1226](https://github.com/corazawaf/coraza/pull/1226) | 2024-11-21 | v3.3.0 | P | Square brackets in macro variables |
+| [0022](0022-time-variables.md) | [#1223](https://github.com/corazawaf/coraza/pull/1223) | 2024-12-09 | v3.3.0 | P | `TIME_*` variables |
+| [0023](0023-base64encode-transformation.md) | [#1257](https://github.com/corazawaf/coraza/pull/1257) | 2024-12-29 | v3.3.0 | P | `base64Encode` transformation |
+| [0024](0024-hexdecode-transformation.md) | [#1275](https://github.com/corazawaf/coraza/pull/1275) | 2025-01-24 | v3.3.2 | P | `hexDecode` transformation |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **4 of 8** splitting #1614. Eight records covering the structural changes in v3.3.x.

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0017 | #1074 | Parity | `MULTIPART_STRICT_ERROR` |
| 0018 | #1084 | Feature | OCSF audit log format |
| 0019 | #1096 | Refactor | Unsafe `StringData` refactor |
| 0020 | #1071 | Parity | `SecRuleUpdateActionById` |
| 0021 | #1226 | Parity | Square brackets in variable names |
| 0022 | #1223 | Parity | `TIME_*` variables |
| 0023 | #1230 | Parity | `base64Encode` transformation |
| 0024 | #1275 | Parity | `hexDecode` transformation |

## Stacked behind #1692 and #1698

Neither batch 2 nor batch 3 has merged, so this is rebased on `main` with batch 1's rows only. Its index runs 0001–0006 then 0017–0024, with gaps where 0007–0010 and 0011–0016 will land. That is harmless — `mage adr` only requires the index and the files on disk to agree, and they do — but this branch will need a rebase as each of those merges. The resolution is mechanical: keep both row sets, ordered by number.

## What to check

Format is machine-checked; CI runs it. What a checker cannot reach:

- **Are the quotes representative?** All 29 attributed quotes here were verified to appear verbatim in the comment cited, with the author matching and the permalink resolving. Whether the quoted line fairly summarises the thread is the human half.
- **ADR-0024 is the one to read closely.** `hexDecode` was implemented against an explicitly stated assumption — @tty2 said so on the PR when no answer came on the issue — and the record quotes that reasoning rather than presenting the outcome as settled. If the assumption was wrong, this is where it is written down.
- **Three quotes carry editorial marks rather than raw text.** ADR-0020 shortens a full PR URL to `#1183`; ADR-0021 and ADR-0024 use `…` to elide long comments, and ADR-0024 also renders a bare issue URL as `[#1253]`. All conventional and visible, none changes wording — flagged so a reviewer running the same check is not surprised.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 14 record(s) OK` (batch 1 from `main` plus these eight)
- [x] Index rows and files on disk both count 14
- [x] Diff against `main` is eight records plus eight index rows, nothing else
- [x] All quotes re-verified against the GitHub API after the rebase
- [x] Each record checked byte-identical to the tracking branch, so no fix applied there has been lost

---

- [x] My code includes positive and negative tests.
- [x] I have an appropriate description with correct grammar.
- [x] I have read the Contribution guidelines and Code of Conduct.
- [x] My code is properly linted and passes pre-commit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision records covering multipart error handling, audit-log formatting, string processing, rule directives, variable syntax, time variables, and encoding transformations.
  * Documented compatibility decisions and implementation trade-offs for ModSecurity-aligned behavior.
  * Updated the architecture decision index with records 0017–0024.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->