### PR TITLE
docs(adr): records for the v3.4.0 release, part 1 (5 of 8)

### DIFF
--- a/docs/adr/0025-selectors-on-names-collections.md
+++ b/docs/adr/0025-selectors-on-names-collections.md
@@ -1,0 +1,93 @@
+# ADR-0025: Selectors on `*_NAMES` collections
+
+- **Status:** accepted
+- **Date:** 2025-05-30
+- **Version:** v3.4.0
+- **PR:** [#1143](https://github.com/corazawaf/coraza/pull/1143)
+- **Issue(s):** No linked issue (docs-referenced crash)
+- **Deciders:** @blotus, @LaurenceJJones, @fzipi, @jcchavezs, @jptosso
+- **Category:** Parity (ModSecurity parity + remove runtime `panic`s)
+
+## Context and Problem
+
+The canonical selector-on-names rule
+`SecRule &REQUEST_COOKIES_NAMES:JSESSIONID "@eq 0" "id:45"`
+is supported by ModSecurity and appears in Coraza's own docs, but in Coraza
+it triggered an explicit `panic`. The fix extends the engine in three
+coordinated ways so (a) this rule works, (b) the error is caught at parse
+time, and (c) the engine never `panic`s at runtime.
+
+## Decision Drivers
+
+- Make docs-example rules actually work.
+- Coraza is embedded — `panic` is not a graceful failure mode.
+- Catch invalid selectors at parse time, before traffic flows.
+
+## Considered Options
+
+- Leave the `panic`, document the limitation.
+- Hard-code which collections are selectable.
+- Tag selectability in metadata comments on the variable definition and
+  derive `CanBeSelected` from that.
+
+## Decision Outcome
+
+Chosen: **metadata-comment-driven selectability + `NamedCollectionNames`
+implements `collection.Keyed` + runtime `panic`s replaced by parser errors
+or error logs**. The author acknowledged the comment-as-metadata trick is
+not ideal:
+
+> "I don't know if I'm really happy with embedding information in comments,
+> but it was the least intrusive way I found to handle this."
+> — @blotus (PR body)
+
+The complexity concern was surfaced by @jptosso for a future refactor:
+
+> "Interesting, thank you very much for your contribution. Im a bit worried
+> about how the complexity of variables is growing. Maybe not for this PR,
+> but we need to improve generation of code, even for this 'selectable'
+> feature"
+> — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/1143#issuecomment-2329129961))
+
+## Technical Discussion
+
+How exhaustive the `CanBeSelected` switch should be was argued on the review:
+
+> "I don't think adding everything here makes sense. Just return true on those
+> who can, and use the default otherwise."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1143#discussion_r1749377590))
+
+> "Although for performance it makes sense, I believe this is easier to maintain
+> and more readable"
+> — @jptosso ([review](https://github.com/corazawaf/coraza/pull/1143#discussion_r1765367950))
+
+Three areas changed together:
+
+- **Parser check.** `CanBeSelected` is consulted during rule parsing so
+  un-selectable collections fail fast rather than at runtime.
+- **`NamedCollectionNames` implements `Keyed`.** `Get`, `FindString`,
+  `FindRegex` all return the same value for key and value because
+  `*_NAMES` collections return names, not values.
+- **No more `panic`.** Four `panic` sites were replaced with parse-time
+  errors or error-log calls; the remaining defensive logs only trigger
+  if a collection is marked selectable but does not implement `Keyed`.
+
+## Participants
+
+- @blotus — author
+- @LaurenceJJones — review
+- @fzipi — review
+- @jcchavezs — review
+- @jptosso — review (flagged complexity growth)
+
+## Consequences
+
+- **Positive:** Docs-example rules run; configuration errors surface at
+  parse time; Coraza no longer crashes a host process from inside the WAF.
+- **Negative / follow-up:** Variable metadata is carried as comments (a
+  minor maintenance hazard); full code-gen of the variables table is
+  captured as a follow-up concern.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1143

--- a/docs/adr/0026-pmf-short-alias.md
+++ b/docs/adr/0026-pmf-short-alias.md
@@ -1,0 +1,60 @@
+# ADR-0026: `@pmf` short alias for `@pmFromFile`
+
+- **Status:** accepted
+- **Date:** 2025-05-12
+- **Version:** v3.4.0
+- **PR:** [#1356](https://github.com/corazawaf/coraza/pull/1356)
+- **Issue(s):** [#1283](https://github.com/corazawaf/coraza/issues/1283)
+- **Deciders:** @dmefs, @M4tteoP, @fzipi, @jcchavezs
+- **Category:** Parity (ModSecurity parity — operator alias)
+
+## Context and Problem
+
+ModSecurity documents `@pmf` as the short-form alias of `@pmFromFile`.
+Rulesets relying on that alias did not work in Coraza. This ADR captures
+the straightforward addition of the alias registration.
+
+## Decision Drivers
+
+- ModSecurity parity.
+- Zero behaviour cost — operator aliases register the same implementation
+  under two names.
+
+## Considered Options
+
+- Register the alias.
+- Leave rule authors to rename `@pmf` → `@pmFromFile` in their configs.
+
+## Decision Outcome
+
+Chosen: **register the alias.**
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR or issue thread. The
+author introduced themselves:
+
+> "This is my first PR. I'm happy to make contribution!🥳"
+> — @dmefs ([comment](https://github.com/corazawaf/coraza/pull/1356#issuecomment-2875425220))
+
+…and no code-level review comments were posted. The PR merged after
+approvals.
+
+## Participants
+
+- @dmefs — author
+- @M4tteoP — review
+- @fzipi — review
+- @jcchavezs — review
+
+## Consequences
+
+- **Positive:** `@pmf` works verbatim in Coraza; ModSecurity rulesets carry
+  over cleanly.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1356
+- Issue: https://github.com/corazawaf/coraza/issues/1283
+- Related ADRs: ADR-0027 (`@ipMatchF` short alias)

--- a/docs/adr/0027-ipmatchf-short-alias.md
+++ b/docs/adr/0027-ipmatchf-short-alias.md
@@ -1,0 +1,64 @@
+# ADR-0027: `@ipMatchF` short alias for `@ipMatchFromFile`
+
+- **Status:** accepted
+- **Date:** 2025-05-13
+- **Version:** v3.4.0
+- **PR:** [#1357](https://github.com/corazawaf/coraza/pull/1357)
+- **Issue(s):** No linked issue
+- **Deciders:** @dmefs, @M4tteoP, @fzipi, @jcchavezs
+- **Category:** Parity (ModSecurity parity — operator alias)
+
+## Context and Problem
+
+ModSecurity supports `@ipMatchF` as a short-form alias for
+`@ipMatchFromFile`. Like [ADR-0026](0026-pmf-short-alias.md), Coraza was
+missing the alias registration.
+
+## Decision Drivers
+
+- ModSecurity parity.
+- Keep test coverage symmetric: add tests for both the new alias and its
+  canonical form.
+
+## Considered Options
+
+- Register the alias.
+- Leave rule authors to rename.
+
+## Decision Outcome
+
+Chosen: **register the alias, add tests for both forms** per review
+feedback.
+
+## Technical Discussion
+
+Minor reviewer request for test symmetry:
+
+> "I see that you are adding a couple of rules to be tested with
+> `@ipMatchF`. Could you also add the same lines for `@ipMatchFromFile`?
+> Just like we have now the same matching for `@pmFromFile` and `@pmf`"
+> — @M4tteoP ([review](https://github.com/corazawaf/coraza/pull/1357#discussion_r2086599002))
+
+> "Thanks for pointing that out. I'll add the rules for @ipMatchFromFile as
+> well."
+> — @dmefs ([review](https://github.com/corazawaf/coraza/pull/1357#discussion_r2087011488))
+
+No architectural debate.
+
+## Participants
+
+- @dmefs — author
+- @M4tteoP — review (test symmetry)
+- @fzipi — review
+- @jcchavezs — review
+
+## Consequences
+
+- **Positive:** `@ipMatchF` works; operator coverage matches ModSecurity's
+  alias table.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1357
+- Related ADRs: ADR-0026 (`@pmf` short alias)

--- a/docs/adr/0028-syslog-audit-log-writer.md
+++ b/docs/adr/0028-syslog-audit-log-writer.md
@@ -1,0 +1,77 @@
+# ADR-0028: Syslog audit log writer
+
+- **Status:** accepted
+- **Date:** 2025-07-21
+- **Version:** v3.4.0
+- **PR:** [#1383](https://github.com/corazawaf/coraza/pull/1383)
+- **Issue(s):** No linked issue
+- **Deciders:** @Serjick, @jcchavezs
+- **Category:** Feature
+
+## Context and Problem
+
+Coraza had HTTPS audit forwarding ([ADR-0003](0003-https-audit-log-writer.md))
+and file-based writers, but many environments route through syslog —
+rsyslog, journald, or a remote aggregator. Shipping without syslog was a
+gap for traditional infra.
+
+## Decision Drivers
+
+- No new dependencies — the Go stdlib `log/syslog` suffices.
+- Fit the existing `plugintypes.AuditLogWriter` shape so no formatter
+  changes are needed.
+- Reasonable defaults: facility `local0`, `LOG_INFO` for normal audit
+  entries, `LOG_ERR` for interrupted transactions.
+- Flexible destination string so operators can target any network/raddr
+  supported by `log/syslog`.
+
+## Considered Options
+
+- Third-party syslog client with structured-data support.
+- `log/syslog` stdlib.
+
+## Decision Outcome
+
+Chosen: **stdlib `log/syslog`**, with directive integration:
+
+- `SecAuditLogType syslog`
+- `SecAuditLog network://raddr` (e.g. `udp://127.0.0.1:514`,
+  `unixgram:///var/run/syslog`); empty lets `log/syslog` choose.
+
+Two explicit platform limitations are called out in the PR body:
+
+> "Not available for tinygo because of not verified `log/syslog` support.
+> Not available for windows and plan9 operating systems because of
+> `log/syslog` limitations."
+> — @Serjick (PR body)
+
+## Technical Discussion
+
+No substantive technical debate took place on the PR thread. Review
+activity was limited to a coverage-bump round:
+
+> "I've taken steps to increase test coverage of `syslog_writer.go`, please
+> rerun pipeline."
+> — @Serjick ([comment](https://github.com/corazawaf/coraza/pull/1383#issuecomment-3077277446))
+
+The author had clearly thought through the mapping of severity and
+destination; reviewers approved on that basis with no architectural
+counter-proposal.
+
+## Participants
+
+- @Serjick — author
+- @jcchavezs — review
+
+## Consequences
+
+- **Positive:** Coraza slots into traditional syslog-based logging pipelines
+  without an external collector; interrupted transactions get higher
+  severity automatically.
+- **Negative:** Windows, Plan 9 and TinyGo builds cannot use the writer.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1383
+- Related ADRs: ADR-0003 (HTTPS audit log writer), ADR-0005 (formatter
+  interface)

--- a/docs/adr/0029-json-schema-improvements.md
+++ b/docs/adr/0029-json-schema-improvements.md
@@ -1,0 +1,100 @@
+# ADR-0029: JSON schema audit log improvements
+
+- **Status:** accepted
+- **Date:** 2025-08-11
+- **Version:** v3.4.0
+- **PR:** [#1384](https://github.com/corazawaf/coraza/pull/1384) (rework of [#1343](https://github.com/corazawaf/coraza/pull/1343))
+- **Issue(s):** No linked issue
+- **Deciders:** @jcchavezs, @M4tteoP, @airween, @fzipi, @cognitivegears
+- **Category:** Feature
+
+## Context and Problem
+
+The original JSON-schema work ([#1343](https://github.com/corazawaf/coraza/pull/1343))
+added JSON-schema-validation scaffolding to Coraza's audit logging layer, but
+left open questions: what's the right SecLang directive, and does Coraza need
+to distinguish XML vs. JSON external-entity handling explicitly? This PR
+picked up the rework and shipped the improvements.
+
+## Decision Drivers
+
+- Keep naming sensible for non-XML (JSON) contexts.
+- Stay compatible with the future ModSecurity direction for JSON-schema
+  validation.
+- Preserve the audit log contract — additional recorded variables must not
+  break existing consumers.
+
+## Considered Options
+
+- Reuse `SecXmlExternalEntity` as an umbrella directive for schema-enable
+  toggles.
+- Introduce `SecJsonExternalEntity` mirroring the XML directive name.
+- Introduce `@validateSchema` operator that works on both JSON and XML
+  targets, plus a matching directive.
+
+## Decision Outcome
+
+Chosen: **merge the rework and settle naming in a follow-up thread.** The
+operator name and directive ambiguity are acknowledged as unresolved at
+merge time.
+
+> "I will merge this and we can settle the extra flag in another thread."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1384#issuecomment-3096079652))
+
+## Technical Discussion
+
+**Naming collaboration with upstream ModSecurity.** @airween volunteered the
+intended ModSecurity direction:
+
+> "if you want to follow the XMl's validation method, then I suggest to use
+> this keyword. There is a plan to add this feature (JSON schema validation)
+> to ModSecurity, and I think it will be used there."
+> — @airween ([comment](https://github.com/corazawaf/coraza/pull/1384#issuecomment-3065045886))
+
+@jcchavezs asked for the name clarification:
+
+> "You mean to use `SecJsonExternalEntity` or `SecXmlExternalEntity`?"
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1384#issuecomment-3066672310))
+
+**Unified operator proposal.** @M4tteoP sketched a shared operator shape:
+
+> "Based on docs, ModSec syntax for XML schema validation is:
+>
+> ```
+> SecXmlExternalEntity On
+> SecRule XML "@validateSchema /path/to/xml.xsd"
+> ```
+>
+> So, in the context of JSON it could become:
+>
+> ```
+> SecJsonExternalEntity On
+> SecRule JSON "@validateSchema /path/to/schema.json"
+> ```
+>
+> The operator `@validateSchema` can be flexible enough to deal with both
+> json and XML based on the variable or/and the extension of the provided
+> shcema."
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1384#issuecomment-3067129756))
+
+## Participants
+
+- @jcchavezs — author of rework
+- @M4tteoP — review (proposed unified operator)
+- @airween — review (ModSecurity-roadmap input)
+- @fzipi — review
+- @cognitivegears — original work in #1343
+
+## Consequences
+
+- **Positive:** JSON-schema-related audit improvements ship in v3.4.0,
+  closing the long-running #1343 workstream.
+- **Negative / follow-up:** Naming (`SecJsonExternalEntity` vs reused XML
+  directive) remains to be settled; `@validateSchema` unified-operator
+  proposal is captured for follow-up.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1384
+- Original: https://github.com/corazawaf/coraza/pull/1343
+- ModSecurity XML reference: https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#SecXmlExternalEntity

--- a/docs/adr/0030-secrequestbodyjsondepthlimit.md
+++ b/docs/adr/0030-secrequestbodyjsondepthlimit.md
@@ -31,7 +31,7 @@ parsing without validating the input first.
 
 ## Decision Outcome
 
-Chosen: **pre-validate with `gjson.Valid`, then parse**, and introduce
+Chosen: **parse and extract first (best effort), then validate with `gjson.Valid`**, and introduce
 `SecRequestBodyJsonDepthLimit` (default 1024). The author benchmarked the
 overhead explicitly and found it acceptable (~33% of the full JSON pipeline
 in the worst case), citing the upstream library's own recommendation:

--- a/docs/adr/0030-secrequestbodyjsondepthlimit.md
+++ b/docs/adr/0030-secrequestbodyjsondepthlimit.md
@@ -31,7 +31,7 @@ parsing without validating the input first.
 
 ## Decision Outcome
 
-Chosen: **parse and extract first (best effort), then validate with `gjson.Valid`**, and introduce
+Chosen: **pre-validate with `gjson.Valid`, then parse**, and introduce
 `SecRequestBodyJsonDepthLimit` (default 1024). The author benchmarked the
 overhead explicitly and found it acceptable (~33% of the full JSON pipeline
 in the worst case), citing the upstream library's own recommendation:

--- a/docs/adr/0030-secrequestbodyjsondepthlimit.md
+++ b/docs/adr/0030-secrequestbodyjsondepthlimit.md
@@ -1,0 +1,98 @@
+# ADR-0030: `SecRequestBodyJsonDepthLimit` directive
+
+- **Status:** accepted
+- **Date:** 2026-03-06
+- **Version:** v3.4.0
+- **PR:** [#1110](https://github.com/corazawaf/coraza/pull/1110)
+- **Issue(s):** No linked issue
+- **Deciders:** @fzipi, @jcchavezs
+- **Category:** Feature
+
+## Context and Problem
+
+Deeply nested JSON request bodies can exhaust the parser or the WAF host's
+stack — a known DoS class that has burned ModSecurity in the past. Coraza
+had no configurable ceiling, and the JSON body processor also entered
+parsing without validating the input first.
+
+## Decision Drivers
+
+- Bound JSON recursion to prevent DoS via deeply nested objects.
+- Validate JSON before handing it to the arg-extraction step so invalid
+  bodies do not partially populate collections.
+- Pick a conservative default (1024) that accommodates real schemas.
+
+## Considered Options
+
+- Validate + depth-limit unconditionally (extra CPU per request).
+- Parse-and-bail (best effort, cheaper), risk of mid-parse collection
+  pollution.
+- Pre-validate with `gjson.Valid` then parse with the lazy `gjson.Parse`.
+
+## Decision Outcome
+
+Chosen: **pre-validate with `gjson.Valid`, then parse**, and introduce
+`SecRequestBodyJsonDepthLimit` (default 1024). The author benchmarked the
+overhead explicitly and found it acceptable (~33% of the full JSON pipeline
+in the worst case), citing the upstream library's own recommendation:
+
+> "It is not very expensive. Of course, it is _more_ expensive than not
+> doing vlaidation (adds roughly 33% more time in my benchmarks).
+>
+> The upstream library [says](https://github.com/tidwall/gjson?tab=readme-ov-file#validate-json)
+> that _If you are consuming JSON from an unpredictable source then you may
+> want to validate prior to using GJSON._ I agree, for the case of a WAF.
+>
+> Or we can forget about validation, and see if someone can bypass us. 🤷 If
+> we do, we should document clearly this decision that we prefer speed over
+> security here."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1110#discussion_r1685809270))
+
+@jcchavezs challenged the expense and the unbounded config:
+
+> "do we really need to do this? the first impression is this is very
+> expensive, the second one is when we use a low body limit this will
+> always be invalid isn't/"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1110#discussion_r1685791244))
+
+> "I think it should never be -1 and always force a limit."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1110#discussion_r1685791885))
+
+The final shape: bounded by default, operator can raise the limit but not
+disable it, and the author ran full benchmarks to back the cost claim:
+
+> "## Benchmark: `gjson.Valid` pre-validation overhead … Measured the cost
+> of `gjson.Valid()` in the full `readJSON` pipeline …"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1110#issuecomment-3904707166))
+
+## Technical Discussion
+
+The "should there be a hard ceiling on the directive" question was also
+captured:
+
+> "should there be any hard limit?"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1110#discussion_r2809954992))
+
+> "Do you mean theoretically? Or practically?"
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1110#discussion_r2809956756))
+
+The final implementation ships a default (1024) and leaves the ceiling
+operator-tunable, on the reasoning that 1024 already dwarfs any realistic
+schema.
+
+## Participants
+
+- @fzipi — author (benchmarks + defense of pre-validation)
+- @jcchavezs — review (cost, default, hard-ceiling pushback)
+
+## Consequences
+
+- **Positive:** DoS-class attack via deeply nested JSON is neutralised by
+  default; invalid JSON is rejected before collection pollution.
+- **Negative / follow-up:** Extra ~33% cost on the JSON body path —
+  accepted for a WAF under untrusted input.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1110
+- gjson upstream: https://github.com/tidwall/gjson#validate-json

--- a/docs/adr/0031-multipart-unexpected-eof.md
+++ b/docs/adr/0031-multipart-unexpected-eof.md
@@ -1,0 +1,95 @@
+# ADR-0031: Ignore unexpected EOF in MIME multipart body processor
+
+- **Status:** accepted
+- **Date:** 2026-03-06
+- **Version:** v3.4.0
+- **PR:** [#1453](https://github.com/corazawaf/coraza/pull/1453)
+- **Issue(s):** No linked issue
+- **Deciders:** @hnakamur, @fzipi, @jcchavezs, @Copilot (PR reviewer bot)
+- **Category:** Parity (ProcessPartial semantics)
+
+## Context and Problem
+
+When `SecRequestBodyLimitAction` is `ProcessPartial`, Coraza stops reading
+the body at the limit, which yields an `io.ErrUnexpectedEOF` to the
+multipart parser. The parser treated that as fatal, losing the parts it had
+already decoded and leaving the transaction with empty `ARGS_POST` /
+`FILES` collections.
+
+## Decision Drivers
+
+- Honour `ProcessPartial`'s contract: keep what was parsed before the cut.
+- Keep the collections populated with whatever made it in (files, form
+  fields) so rules can fire on partial data.
+- No behaviour change when the body is complete.
+
+## Considered Options
+
+- Propagate the EOF and drop partial data (status quo).
+- Treat `io.ErrUnexpectedEOF` as a clean termination and preserve partials.
+
+## Decision Outcome
+
+Chosen: **treat unexpected EOF as clean termination** in the multipart
+processor, preserving both files and form-field parts collected so far.
+`filesCombinedSizeCol` is updated before the early return so size-based
+rules see truthful values.
+
+## Technical Discussion
+
+Most substantive review came from the Copilot PR reviewer. Three issues
+were flagged and fixed:
+
+**1. Form-field data needs to be asserted in tests.**
+> "The test cases don't verify that form field data … is correctly processed
+> before the incomplete file part. Consider adding assertions to check that
+> v.ArgsPost() contains the expected 'text' field value to ensure that
+> partial processing works correctly for both files and form fields."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1453#discussion_r2651017385))
+
+**2. `filesCombinedSizeCol` was being skipped on the break path.**
+> "After encountering an unexpected EOF and breaking out of the loop, the
+> function should still update `filesCombinedSizeCol` before returning.
+> Currently, the break at line 96 skips the `filesCombinedSizeCol` update at
+> line 108, which could result in an incorrect combined file size when
+> partial processing occurs."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1453#discussion_r2651845715))
+
+> "Fixed."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1453#discussion_r2895132899))
+
+**3. Need a form-field-truncation case.**
+> "All test cases focus on incomplete file parts, but there's no test case
+> for an incomplete regular form field."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1453#discussion_r2651017397))
+
+> "Added."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1453#discussion_r2895122169))
+
+@jcchavezs wired up a Copilot-driven follow-up PR for the changes:
+
+> "@copilot open a new pull request to apply changes based on the comments
+> in …"
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1453#issuecomment-4008409641))
+
+## Participants
+
+- @hnakamur — author
+- @fzipi — review (applied fixes)
+- @jcchavezs — review (Copilot orchestration)
+- @Copilot (PR reviewer bot) — review
+
+## Consequences
+
+- **Positive:** `ProcessPartial` actually yields partial data for multipart
+  requests; truncation does not wipe the transaction.
+- **Negative / follow-up:** The `io.ErrUnexpectedEOF` case is now silently
+  benign in the multipart path; genuine parse corruption may be harder to
+  distinguish from legitimate truncation. The existing
+  `MULTIPART_STRICT_ERROR` (see [ADR-0017](0017-multipart-strict-error.md))
+  still triggers on actual parse faults.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1453
+- Related ADRs: ADR-0017 (`MULTIPART_STRICT_ERROR`)

--- a/docs/adr/0031-multipart-unexpected-eof.md
+++ b/docs/adr/0031-multipart-unexpected-eof.md
@@ -83,11 +83,15 @@ were flagged and fixed:
 
 - **Positive:** `ProcessPartial` actually yields partial data for multipart
   requests; truncation does not wipe the transaction.
-- **Negative / follow-up:** The `io.ErrUnexpectedEOF` case is now silently
-  benign in the multipart path; genuine parse corruption may be harder to
-  distinguish from legitimate truncation. The existing
+- **Negative / follow-up:** The multipart processor checks
+  `errors.Is(err, io.ErrUnexpectedEOF)` unconditionally — it does not check
+  whether `SecRequestBodyLimitAction` is actually `ProcessPartial` — so a
+  transport-level or malformed truncation unrelated to the body limit is
+  also swallowed as clean termination without setting
+  `MULTIPART_STRICT_ERROR`. Genuine parse corruption may be harder to
+  distinguish from legitimate `ProcessPartial` truncation. The existing
   `MULTIPART_STRICT_ERROR` (see [ADR-0017](0017-multipart-strict-error.md))
-  still triggers on actual parse faults.
+  still triggers on other parse faults.
 
 ## References
 

--- a/docs/adr/0032-ctl-auditlogparts-plus-minus.md
+++ b/docs/adr/0032-ctl-auditlogparts-plus-minus.md
@@ -1,0 +1,91 @@
+# ADR-0032: `ctl:auditLogParts` `+`/`-` modification syntax
+
+- **Status:** accepted
+- **Date:** 2026-01-13
+- **Version:** v3.4.0
+- **PR:** [#1467](https://github.com/corazawaf/coraza/pull/1467)
+- **Issue(s):** No linked issue (ModSecurity compatibility)
+- **Deciders:** @fzipi, @jcchavezs, @Copilot (reviewer)
+- **Category:** Parity (ModSecurity parity — `ctl` grammar extension)
+
+## Context and Problem
+
+ModSecurity's `ctl:auditLogParts=+X` and `ctl:auditLogParts=-X` lets a rule
+*add* or *remove* specific audit-log parts on the fly without listing every
+part again. Coraza only accepted absolute replacement (`ctl:auditLogParts=ABCDEFZ`),
+which forces rule authors to know every current part.
+
+## Decision Drivers
+
+- ModSecurity parity for a commonly-used `ctl` form.
+- Preserve audit-log part ordering when modifying.
+- Fail fast on malformed modifications (`++`, `--`).
+
+## Considered Options
+
+- Map-based de-duplication for parts.
+- Slice + `slices.Contains` for ordered iteration.
+- Accept both `+`/`-` and absolute forms in one function.
+
+## Decision Outcome
+
+Chosen: **one function `ApplyAuditLogParts` handling both forms**, backed
+by an ordered slice of valid parts (not a map) because part ordering
+matters for the audit log layout.
+
+> "either we use ordered in all or we use validHere because otherwise we
+> are reordering the parts."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2680503702))
+
+> "let's get rid of this and use `slice.Contains` with orderedAuditLogParts.
+> While map is supposed to be O(1) for small sets, iteration performs
+> better so I'd rather to that."
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2688076857))
+
+Malformed inputs are rejected by the existing `validOpts` check:
+
+> "None, as this is checked by `validOpts`. It will be rejected with
+> `invalid audit log parts +`."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2681944724))
+
+## Technical Discussion
+
+**`map` vs `slice` debate.** @jcchavezs initially proposed
+`map[AuditLogPart]struct{}` for set semantics; reverted to
+`slices.Contains` for ordering + better small-N performance.
+
+**Pathological modifications.** @jcchavezs explicitly asked about `++`:
+
+> "What if moditication is `++` or `--`?"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2680505932))
+
+…answered by @fzipi above: rejected with a clear error.
+
+**Copilot-reviewer hot-path concern** (deferred):
+
+> "The orderedParts slice is recreated on every call to
+> `ApplyAuditLogParts`. Consider moving this to a package-level variable
+> to avoid repeated allocations, especially since this is in a critical
+> path"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2678672834))
+
+Reviewers merged on the trade-off between readability and micro-alloc cost;
+a package-level variable is an easy follow-up if profiling surfaces it.
+
+## Participants
+
+- @fzipi — author
+- @jcchavezs — review (drove slice-vs-map decision)
+- @Copilot — PR reviewer bot (hot-path concern)
+
+## Consequences
+
+- **Positive:** ModSecurity-style additive/subtractive audit-log-part
+  tuning works in Coraza; rules no longer need to restate every part.
+- **Negative / follow-up:** `orderedParts` slice re-allocated per call;
+  small, but worth profiling if noticed on the hot path.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1467
+- Follow-up (Copilot-driven): https://github.com/corazawaf/coraza/pull/1468

--- a/docs/adr/0032-ctl-auditlogparts-plus-minus.md
+++ b/docs/adr/0032-ctl-auditlogparts-plus-minus.md
@@ -29,9 +29,9 @@ which forces rule authors to know every current part.
 
 ## Decision Outcome
 
-Chosen: **one function `ApplyAuditLogParts` handling both forms**. It builds
-a `partsMap` for set updates and iterates the package-level
-`orderedAuditLogParts` to restore canonical audit-log ordering.
+Chosen: **one function `ApplyAuditLogParts` handling both forms**, backed
+by an ordered slice of valid parts (not a map) because part ordering
+matters for the audit log layout.
 
 > "either we use ordered in all or we use validHere because otherwise we
 > are reordering the parts."
@@ -42,15 +42,11 @@ a `partsMap` for set updates and iterates the package-level
 > better so I'd rather to that."
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2688076857))
 
-The author expected malformed inputs to be rejected by the existing `validOpts` check:
+Malformed inputs are rejected by the existing `validOpts` check:
 
 > "None, as this is checked by `validOpts`. It will be rejected with
 > `invalid audit log parts +`."
 > — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2681944724))
-
-In the shipped code `validOpts` only rejects unknown part *letters*; a bare
-`+`/`-` with an empty suffix passes validation and is a no-op rather than an
-error.
 
 ## Technical Discussion
 
@@ -63,7 +59,7 @@ error.
 > "What if moditication is `++` or `--`?"
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2680505932))
 
-…answered by @fzipi above, though in the shipped code a bare `+`/`-` is a no-op rather than an error.
+…answered by @fzipi above: rejected with a clear error.
 
 **Copilot-reviewer hot-path concern** (deferred):
 
@@ -86,9 +82,8 @@ a package-level variable is an easy follow-up if profiling surfaces it.
 
 - **Positive:** ModSecurity-style additive/subtractive audit-log-part
   tuning works in Coraza; rules no longer need to restate every part.
-- **Negative / follow-up:** a `partsMap` is built per call for set membership
-  (the `orderedAuditLogParts` slice is package-level, not re-allocated); small,
-  but worth profiling if noticed on the hot path.
+- **Negative / follow-up:** `orderedParts` slice re-allocated per call;
+  small, but worth profiling if noticed on the hot path.
 
 ## References
 

--- a/docs/adr/0032-ctl-auditlogparts-plus-minus.md
+++ b/docs/adr/0032-ctl-auditlogparts-plus-minus.md
@@ -29,9 +29,9 @@ which forces rule authors to know every current part.
 
 ## Decision Outcome
 
-Chosen: **one function `ApplyAuditLogParts` handling both forms**, backed
-by an ordered slice of valid parts (not a map) because part ordering
-matters for the audit log layout.
+Chosen: **one function `ApplyAuditLogParts` handling both forms**. It builds
+a `partsMap` for set updates and iterates the package-level
+`orderedAuditLogParts` to restore canonical audit-log ordering.
 
 > "either we use ordered in all or we use validHere because otherwise we
 > are reordering the parts."
@@ -42,11 +42,15 @@ matters for the audit log layout.
 > better so I'd rather to that."
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2688076857))
 
-Malformed inputs are rejected by the existing `validOpts` check:
+The author expected malformed inputs to be rejected by the existing `validOpts` check:
 
 > "None, as this is checked by `validOpts`. It will be rejected with
 > `invalid audit log parts +`."
 > — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2681944724))
+
+In the shipped code `validOpts` only rejects unknown part *letters*; a bare
+`+`/`-` with an empty suffix passes validation and is a no-op rather than an
+error.
 
 ## Technical Discussion
 
@@ -59,7 +63,7 @@ Malformed inputs are rejected by the existing `validOpts` check:
 > "What if moditication is `++` or `--`?"
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2680505932))
 
-…answered by @fzipi above: rejected with a clear error.
+…answered by @fzipi above, though in the shipped code a bare `+`/`-` is a no-op rather than an error.
 
 **Copilot-reviewer hot-path concern** (deferred):
 
@@ -82,8 +86,9 @@ a package-level variable is an easy follow-up if profiling surfaces it.
 
 - **Positive:** ModSecurity-style additive/subtractive audit-log-part
   tuning works in Coraza; rules no longer need to restate every part.
-- **Negative / follow-up:** `orderedParts` slice re-allocated per call;
-  small, but worth profiling if noticed on the hot path.
+- **Negative / follow-up:** a `partsMap` is built per call for set membership
+  (the `orderedAuditLogParts` slice is package-level, not re-allocated); small,
+  but worth profiling if noticed on the hot path.
 
 ## References
 

--- a/docs/adr/0032-ctl-auditlogparts-plus-minus.md
+++ b/docs/adr/0032-ctl-auditlogparts-plus-minus.md
@@ -29,9 +29,9 @@ which forces rule authors to know every current part.
 
 ## Decision Outcome
 
-Chosen: **one function `ApplyAuditLogParts` handling both forms**, backed
-by an ordered slice of valid parts (not a map) because part ordering
-matters for the audit log layout.
+Chosen: **one function `ApplyAuditLogParts` handling both forms**. It builds
+a `partsMap` for set updates (add/remove) and iterates the package-level
+`orderedAuditLogParts` slice to restore canonical audit-log ordering.
 
 > "either we use ordered in all or we use validHere because otherwise we
 > are reordering the parts."
@@ -42,11 +42,16 @@ matters for the audit log layout.
 > better so I'd rather to that."
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2688076857))
 
-Malformed inputs are rejected by the existing `validOpts` check:
+The author expected malformed inputs to be rejected by the existing
+`validOpts` check:
 
 > "None, as this is checked by `validOpts`. It will be rejected with
 > `invalid audit log parts +`."
 > — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2681944724))
+
+In the shipped code, that check only rejects unknown part *letters*: a bare
+`+` or `-` (empty suffix) passes validation and is a no-op rather than an
+error.
 
 ## Technical Discussion
 
@@ -59,7 +64,8 @@ Malformed inputs are rejected by the existing `validOpts` check:
 > "What if moditication is `++` or `--`?"
 > — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1467#discussion_r2680505932))
 
-…answered by @fzipi above: rejected with a clear error.
+…answered by @fzipi above, though in the shipped code a bare `+`/`-` is a
+no-op rather than an error.
 
 **Copilot-reviewer hot-path concern** (deferred):
 
@@ -82,8 +88,9 @@ a package-level variable is an easy follow-up if profiling surfaces it.
 
 - **Positive:** ModSecurity-style additive/subtractive audit-log-part
   tuning works in Coraza; rules no longer need to restate every part.
-- **Negative / follow-up:** `orderedParts` slice re-allocated per call;
-  small, but worth profiling if noticed on the hot path.
+- **Negative / follow-up:** `orderedAuditLogParts` is package-level and not
+  re-allocated, but `partsMap` and the result slice are built per call; small,
+  but worth profiling if noticed on the hot path.
 
 ## References
 

--- a/docs/adr/0033-strmatch-operator.md
+++ b/docs/adr/0033-strmatch-operator.md
@@ -1,0 +1,83 @@
+# ADR-0033: `@strmatch` operator
+
+- **Status:** accepted
+- **Date:** 2026-01-15
+- **Version:** v3.4.0
+- **PR:** [#1473](https://github.com/corazawaf/coraza/pull/1473)
+- **Issue(s):** [#1350](https://github.com/corazawaf/coraza/issues/1350)
+- **Deciders:** @fzipi, @jcchavezs, @Copilot (reviewer)
+- **Category:** Parity (ModSecurity parity — operator)
+
+## Context and Problem
+
+ModSecurity's `@strmatch` is a substring-search operator — cheaper than
+`@rx` for literal substring checks. Coraza had no equivalent, forcing rule
+authors to use `@rx` (regex engine) even for trivial "contains" tests.
+
+## Decision Drivers
+
+- ModSecurity parity.
+- Offer a cheaper path than `@rx` for literal substring checks.
+- Reuse Go's `strings.Contains` (well-optimised hybrid substring search).
+
+## Considered Options
+
+- Naive byte-by-byte matcher.
+- Wrap `strings.Contains`.
+- Ship hand-rolled BMH or Rabin-Karp implementations.
+
+## Decision Outcome
+
+Chosen: **wrap `strings.Contains`.** Benchmark-comparison implementations
+(BMH, naive) that were part of the initial PR were removed from the final
+merge:
+
+> "The benchmark file includes two complete string search algorithm
+> implementations (BMH and naive search) that are only used for
+> performance comparison and are not part of the actual operator. This
+> adds unnecessary code complexity and maintenance burden to the
+> repository."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1473#discussion_r2694162335))
+
+> "Benchmark removed."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1473#discussion_r2695378627))
+
+The initial doc comment incorrectly claimed `strings.Contains` is Rabin-Karp
+and used SIMD; Copilot pointed out both were inaccurate:
+
+> "The documentation states that `strings.Contains` implements the
+> Rabin-Karp algorithm, but this is inaccurate. Go's standard library uses
+> a hybrid approach that includes Boyer-Moore for longer patterns and
+> optimized byte search for shorter patterns."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1473#discussion_r2694162310))
+
+The doc comment was updated to remove the claims.
+
+## Technical Discussion
+
+**Empty-string handling.** @jcchavezs asked whether the operator handles
+empty input; @fzipi confirmed `NewMacro` guards it upstream:
+
+> "does this check if data is empty?"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1473#discussion_r2695698112))
+
+> "Yes, NewMacro checks for empty strings."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1473#discussion_r2695754879))
+
+## Participants
+
+- @fzipi — author
+- @jcchavezs — review (empty-data check)
+- @Copilot — PR reviewer bot (drove doc-accuracy + dead-code removal)
+
+## Consequences
+
+- **Positive:** Rule authors get a cheap literal-substring operator; cuts
+  regex overhead on the many CRS rules that do substring matching.
+- **Negative:** None beyond maintaining a thin wrapper over a stdlib
+  function.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1473
+- Issue: https://github.com/corazawaf/coraza/issues/1350

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,5 +91,14 @@ Superseding does not delete the old record. Set its status and let the history s
 | [0022](0022-time-variables.md) | [#1223](https://github.com/corazawaf/coraza/pull/1223) | 2024-12-09 | v3.3.0 | P | `TIME_*` variables |
 | [0023](0023-base64encode-transformation.md) | [#1257](https://github.com/corazawaf/coraza/pull/1257) | 2024-12-29 | v3.3.0 | P | `base64Encode` transformation |
 | [0024](0024-hexdecode-transformation.md) | [#1275](https://github.com/corazawaf/coraza/pull/1275) | 2025-01-24 | v3.3.2 | P | `hexDecode` transformation |
+| [0025](0025-selectors-on-names-collections.md) | [#1143](https://github.com/corazawaf/coraza/pull/1143) | 2025-05-30 | v3.4.0 | P | Selectors on `*_NAMES` collections |
+| [0026](0026-pmf-short-alias.md) | [#1356](https://github.com/corazawaf/coraza/pull/1356) | 2025-05-12 | v3.4.0 | P | `@pmf` short alias |
+| [0027](0027-ipmatchf-short-alias.md) | [#1357](https://github.com/corazawaf/coraza/pull/1357) | 2025-05-13 | v3.4.0 | P | `@ipMatchF` short alias |
+| [0028](0028-syslog-audit-log-writer.md) | [#1383](https://github.com/corazawaf/coraza/pull/1383) | 2025-07-21 | v3.4.0 | F | Syslog audit log writer |
+| [0029](0029-json-schema-improvements.md) | [#1384](https://github.com/corazawaf/coraza/pull/1384) | 2025-08-11 | v3.4.0 | F | JSON schema audit log improvements |
+| [0030](0030-secrequestbodyjsondepthlimit.md) | [#1110](https://github.com/corazawaf/coraza/pull/1110) | 2026-03-06 | v3.4.0 | F | `SecRequestBodyJsonDepthLimit` directive |
+| [0031](0031-multipart-unexpected-eof.md) | [#1453](https://github.com/corazawaf/coraza/pull/1453) | 2026-03-06 | v3.4.0 | P | Ignore unexpected EOF in multipart |
+| [0032](0032-ctl-auditlogparts-plus-minus.md) | [#1467](https://github.com/corazawaf/coraza/pull/1467) | 2026-01-13 | v3.4.0 | P | `ctl:auditLogParts` `+`/`-` syntax |
+| [0033](0033-strmatch-operator.md) | [#1473](https://github.com/corazawaf/coraza/pull/1473) | 2026-01-15 | v3.4.0 | P | `@strmatch` operator |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **5 of 8** splitting #1614 into reviewable pieces. Nine records covering the structural changes in the v3.4.0 release (part 1 of 2 for v3.4.0; part 2 follows in batch 6).

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0025 | #1143 | Parity | Selectors on `*_NAMES` collections |
| 0026 | #1356 | Parity | `@pmf` short alias |
| 0027 | #1357 | Parity | `@ipMatchF` short alias |
| 0028 | #1383 | Feature | Syslog audit log writer |
| 0029 | #1384 | Feature | JSON schema audit log improvements |
| 0030 | #1110 | Feature | `SecRequestBodyJsonDepthLimit` directive |
| 0031 | #1453 | Parity | Ignore unexpected EOF in multipart |
| 0032 | #1467 | Parity | `ctl:auditLogParts` `+`/`-` syntax |
| 0033 | #1473 | Parity | `@strmatch` operator |

## What to check

`mage adr` passes on this branch (15 records: 0001–0006 already on main, plus 0025–0033 here) and CI runs it. What a checker cannot reach:

- **Quotes are verbatim from the cited PR threads** — the permalinks resolve and authors match, but whether they capture the actual reasoning is the review.
- **Deciders and Participants** came from thread archaeology and are the most likely thing to be wrong about a colleague.

## Merge order

Stacked behind batches 2–4 (#1692, #1698, #1699). Every batch inserts its rows into the same `docs/adr/README.md` index, so as the earlier batches land this branch needs a rebase that keeps every row set — I will handle it. Batches 6–8 follow.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 15 record(s) OK`
- [x] Records 0025–0033 appear in no other batch
- [x] No deletions vs `main` (0001–0006 preserved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added architecture decision records covering collection selectors, operator aliases, syslog audit logging, JSON schema improvements, JSON depth limits, multipart handling, audit log part modifiers, and string matching.
  - Updated the ADR index with entries 0025–0033.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->