### PR TITLE
docs(adr): records for the v3.4.0 release, part 2 (6 of 8)

### DIFF
--- a/docs/adr/0034-rule-observer-callback.md
+++ b/docs/adr/0034-rule-observer-callback.md
@@ -1,0 +1,100 @@
+# ADR-0034: Optional rule observer callback on `WAFConfig`
+
+- **Status:** accepted
+- **Date:** 2026-02-24
+- **Version:** v3.4.0
+- **PR:** [#1478](https://github.com/corazawaf/coraza/pull/1478)
+- **Issue(s):** No linked issue
+- **Deciders:** @heaven, @fzipi, @jcchavezs
+- **Category:** Feature (plugin surface)
+
+## Context and Problem
+
+UIs and ops tooling around Coraza wanted a way to introspect the exact
+rules loaded by a running WAF (for display, metrics, audit). Previously
+they had to maintain a parallel copy of the ruleset — a drift hazard.
+
+## Decision Drivers
+
+- Expose the loaded ruleset to the embedder without breaking the existing
+  `WAF`/`Transaction` interfaces.
+- Zero cost when unused.
+- Stage the API through `experimental` so future shape changes aren't
+  blocked by semver.
+
+## Considered Options
+
+- Add `WithRuleObserver` directly on `WAFConfig` (non-experimental).
+- Add the type-level method + an `experimental.WAFConfigWithRuleObserver`
+  helper that does the type assertion.
+- Expose rules via a pull API (`RulesCount()` etc.) — tackled separately in
+  [ADR-0035](0035-wafwithrules-interface.md).
+
+## Decision Outcome
+
+Chosen: **type-level method + `experimental` helper**, mirroring the
+existing `WithErrorCallback` pattern. @fzipi initially preferred putting
+the whole thing under `experimental`:
+
+> "I like this idea. But maybe moving it to the `experimental` package
+> first?"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3770237942))
+
+@jcchavezs articulated the final shape and the v4-safety rationale:
+
+> "I like the idea too but I was thinking we should move this to
+> experimental. We could
+> 1. Do not add the method in the interface but the type only
+> 2. create a function in
+> https://github.com/corazawaf/coraza/tree/main/experimental called
+> `WAFConfigWithRuleObserver` which does the interface assertion and calles
+> the type method.
+>
+> What do you think @heaven ?"
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3787116970))
+
+> "To avoid future breaking changes, we usually land new features that are
+> still in development under the experimental package so we won't break
+> anyone if we decide to change it later."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3814374587))
+
+## Technical Discussion
+
+**Circular-import hurdle.** @heaven hit an unexpected cyclic import:
+
+> "Because the core `coraza` package already depends on `experimental`, the
+> experimental helper cannot reference the `WAFConfig` directly without
+> creating a cyclic import. So I had to use reflection to preserve the
+> immutable builder semantics."
+> — @heaven ([comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3828189778))
+
+The cyclic-import finding motivated the separate refactor in
+[ADR-0036](0036-remove-root-experimental-dep.md) that removed the root →
+`experimental` direction.
+
+**Immutability preservation.** @heaven opted for the minimum-footprint
+path, mimicking the existing `WithErrorCallback`:
+
+> "My goal was to make the footprint as small as possible, though, so I
+> tried the opposite – to avoid new types and other exports."
+> — @heaven ([comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3798817597))
+
+## Participants
+
+- @heaven — author
+- @fzipi — review (experimental-package proposal)
+- @jcchavezs — review (shape: type + experimental assertion helper)
+
+## Consequences
+
+- **Positive:** UIs can observe the loaded ruleset directly; no parallel
+  dataset to keep in sync.
+- **Negative / follow-up:** Reflection in the experimental helper is a
+  temporary wart — cleaned up by the package-dependency flip in
+  [ADR-0036](0036-remove-root-experimental-dep.md).
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1478
+- Related ADRs: ADR-0035 (`WAFWithRules` / `RulesCount()`), ADR-0036
+  (remove root→experimental dep)

--- a/docs/adr/0035-wafwithrules-interface.md
+++ b/docs/adr/0035-wafwithrules-interface.md
@@ -1,4 +1,4 @@
-# ADR-0035: `WAFWithRules` experimental interface — `RulesCount()` / `MergeRules()`
+# ADR-0035: `WAFWithRules` experimental interface — `RulesCount()`
 
 - **Status:** accepted
 - **Date:** 2026-02-27
@@ -10,37 +10,57 @@
 
 ## Context and Problem
 
-Connectors (nginx, Apache) needed a way to:
+Connectors (nginx, Apache) needed a way to report how many rules a WAF
+instance has loaded — for caching, logging, and load-verification checks.
+No such capability was exposed before this PR.
 
-1. Report how many rules a WAF instance has loaded — for caching, logging,
-   and load-verification checks.
-2. Inherit/merge rules across config scopes (http → server → location in
-   nginx terms).
-
-Neither capability was exposed before this PR.
+The PR originally also proposed a `MergeRules()` method to inherit/merge
+rules across config scopes (http → server → location in nginx terms). That
+part was dropped before merge — see Decision Outcome.
 
 ## Decision Drivers
 
 - Provide an experimental interface (`WAFWithRules`) that connectors can
   type-assert to, keeping the main `WAF` interface small.
-- Define merge semantics: duplicate IDs skipped, ID=0 rules (`SecMarker`,
-  un-ID'd `SecAction`) always merged because they legitimately repeat.
-- Allow concurrent-safety guarantees to remain with the initialization
-  phase only.
+- Ship what's actually needed now (`RulesCount()`) rather than a larger,
+  unused surface — see Decision Outcome.
 
 ## Considered Options
 
-- Promote `RulesCount()` / `MergeRules()` onto `WAF` (breaks semver).
-- Ship as a separate `WAFWithRules` experimental interface.
+- Promote `RulesCount()` onto `WAF` (breaks semver).
+- Ship `RulesCount()` as a separate `WAFWithRules` experimental interface.
+- Also ship `MergeRules()` in the same interface/PR (attempted, then
+  descoped — see Technical Discussion).
 
 ## Decision Outcome
 
-Chosen: **separate `experimental.WAFWithRules` interface**. ID=0 merge
-semantics explicitly documented.
+Chosen: **separate `experimental.WAFWithRules` interface exposing only
+`RulesCount()`**. `MergeRules()` was implemented and went through review
+(the ID=0 semantics and structural concerns below), but was pulled from
+the PR before merge once it turned out the downstream consumer didn't
+need it yet:
+
+> "In fact, `MergeRules` is not used at all by the nginx module. Only
+> `RulesCount` is. I initially wanted to remove the stub from libcoraza,
+> but since it is not (yet) needed, we can re-introduce it later — as you
+> wish. I can simplify this PR to remove `MergeRules` and keep only
+> `RulesCount` if you prefer."
+> — @ppomes ([comment](https://github.com/corazawaf/coraza/pull/1492#issuecomment-3939553512))
+
+> "The simpler the better, and if it is not used, then we can always add
+> it later."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1492#issuecomment-3969120877))
+
+The merged diff touches only `experimental/waf.go`, `waf.go`, and
+`waf_test.go`, and adds `RulesCount()` alone — no `MergeRules`,
+`RuleGroup.Merge`, or ID=0 handling shipped in this PR.
 
 ## Technical Discussion
 
-The Copilot reviewer drove five substantive structural changes:
+This discussion concerns the `MergeRules()` design that was in the PR at
+review time and was later dropped (see Decision Outcome); it is kept here
+because it's the reason `MergeRules()` didn't ship. The Copilot reviewer
+raised five structural concerns against that now-removed code:
 
 **1. O(n·m) merge complexity.**
 > "`RuleGroup.Merge` performs `FindByID` for each rule being merged, making
@@ -90,24 +110,34 @@ The Copilot reviewer drove five substantive structural changes:
 >   and never deduplicated"
 > — @ppomes ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835771992))
 
-@fzipi flagged the ID=0 semantic during review ("wait, my bad: `SecMarker`
-has ID=0, not `SecAction`"), showing the nuance the Copilot reviewer's
-concern was pointing at.
+@fzipi initially second-guessed the semantics during review ("wait, my
+bad: `SecMarker` has ID=0, not `SecAction`"), but @ppomes confirmed both
+get ID=0 in the default build:
+
+> "You're right that `SecMarker` always has ID=0. Note that `SecAction`
+> without explicit `id:` also gets ID=0 (default build without
+> `mandatory_rule_id_check` tag), so the test is still valid."
+> — @ppomes ([comment](https://github.com/corazawaf/coraza/pull/1492#issuecomment-3939553512))
+
+None of this shipped — it documents why `MergeRules()` was dropped, not
+behavior present in the merged code.
 
 ## Participants
 
 - @ppomes — author (downstream libcoraza driving the need)
 - @fzipi — review (SecAction / SecMarker ID-0 semantics)
 - @M4tteoP — review
-- @Copilot — reviewer bot (drove 5 structural improvements)
+- @Copilot — reviewer bot (raised 5 structural concerns on the dropped
+  `MergeRules` design)
 
 ## Consequences
 
-- **Positive:** Connectors can query rule counts and merge rulesets across
-  configuration scopes without maintaining their own bookkeeping.
-- **Negative / follow-up:** Merge is not safe concurrent with transaction
-  processing — documented. The brittle type-switch / lack of decorator
-  support were improved during review but remain an area to watch.
+- **Positive:** Connectors can query rule counts without maintaining their
+  own bookkeeping, via a small experimental interface.
+- **Negative / follow-up:** No rule-merging capability shipped.
+  `MergeRules()`'s O(n·m) cost, nil-safety, concurrency-safety
+  documentation, and brittle type-switch (Technical Discussion) remain
+  open questions for whoever picks it up if/when a consumer needs it.
 
 ## References
 

--- a/docs/adr/0035-wafwithrules-interface.md
+++ b/docs/adr/0035-wafwithrules-interface.md
@@ -1,0 +1,116 @@
+# ADR-0035: `WAFWithRules` experimental interface — `RulesCount()` / `MergeRules()`
+
+- **Status:** accepted
+- **Date:** 2026-02-27
+- **Version:** v3.4.0
+- **PR:** [#1492](https://github.com/corazawaf/coraza/pull/1492)
+- **Issue(s):** Dependency of [libcoraza#50](https://github.com/corazawaf/libcoraza/pull/50)
+- **Deciders:** @ppomes, @fzipi, @M4tteoP, @Copilot (reviewer)
+- **Category:** Feature (API)
+
+## Context and Problem
+
+Connectors (nginx, Apache) needed a way to:
+
+1. Report how many rules a WAF instance has loaded — for caching, logging,
+   and load-verification checks.
+2. Inherit/merge rules across config scopes (http → server → location in
+   nginx terms).
+
+Neither capability was exposed before this PR.
+
+## Decision Drivers
+
+- Provide an experimental interface (`WAFWithRules`) that connectors can
+  type-assert to, keeping the main `WAF` interface small.
+- Define merge semantics: duplicate IDs skipped, ID=0 rules (`SecMarker`,
+  un-ID'd `SecAction`) always merged because they legitimately repeat.
+- Allow concurrent-safety guarantees to remain with the initialization
+  phase only.
+
+## Considered Options
+
+- Promote `RulesCount()` / `MergeRules()` onto `WAF` (breaks semver).
+- Ship as a separate `WAFWithRules` experimental interface.
+
+## Decision Outcome
+
+Chosen: **separate `experimental.WAFWithRules` interface**. ID=0 merge
+semantics explicitly documented.
+
+## Technical Discussion
+
+The Copilot reviewer drove five substantive structural changes:
+
+**1. O(n·m) merge complexity.**
+> "`RuleGroup.Merge` performs `FindByID` for each rule being merged, making
+> merges O(n*m). In nginx config inheritance, this could be invoked per
+> location and become noticeably expensive with large rulesets (e.g., CRS).
+> Consider building a set/map of existing IDs once … and doing O(1)
+> lookups while iterating the source rules."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835610053))
+
+**2. Nil-safety on `Merge`.**
+> "`RuleGroup.Merge` will panic if called with `other == nil`. Since the
+> method returns an `error`, it would be safer to treat a nil source as a
+> no-op"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835610061))
+
+**3. Thread-safety documentation.**
+> "`MergeRules` mutates the WAF's rule set, but both the public `WAF` type
+> and internal WAF docs state instances are 'concurrent safe' … Please
+> document the required usage constraints (e.g., must be called during
+> initialization before any transactions are created / not safe
+> concurrently with transaction processing)"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835610080))
+
+**4. Brittle concrete-type switch.**
+> "`MergeRules` only accepts `other` when it is exactly the unexported
+> concrete type `wafWrapper` (value). This makes the
+> `experimental.WAFWithRules` interface hard to use with
+> decorators/wrappers and is also brittle … Consider using a type switch
+> that supports both `wafWrapper` and `*wafWrapper`"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835610087))
+
+**5. ID=0 semantics.**
+> "`WAFWithRules` docs say 'Rules already present (by ID) are skipped', but
+> the underlying implementation (via `RuleGroup.Merge`) always merges rules
+> with ID 0 (e.g., `SecMarker`) even if the destination already has ID 0
+> rules. Please either document this ID=0 exception here, or change the
+> merge logic"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835610077))
+
+@ppomes extended tests to cover `SecAction` without explicit `id:`:
+
+> "Done — added tests at both levels:
+> - `TestRuleGroupMergeSecAction` in rulegroup_test.go: uses ID=0 directly,
+>   verifies both are kept after merge
+> - `TestMergeRulesSecAction` in waf_test.go: uses `SecAction` without `id:`
+>   (which gets ID=0 internally), verifies both SecAction rules are merged
+>   and never deduplicated"
+> — @ppomes ([review](https://github.com/corazawaf/coraza/pull/1492#discussion_r2835771992))
+
+@fzipi flagged the ID=0 semantic during review ("wait, my bad: `SecMarker`
+has ID=0, not `SecAction`"), showing the nuance the Copilot reviewer's
+concern was pointing at.
+
+## Participants
+
+- @ppomes — author (downstream libcoraza driving the need)
+- @fzipi — review (SecAction / SecMarker ID-0 semantics)
+- @M4tteoP — review
+- @Copilot — reviewer bot (drove 5 structural improvements)
+
+## Consequences
+
+- **Positive:** Connectors can query rule counts and merge rulesets across
+  configuration scopes without maintaining their own bookkeeping.
+- **Negative / follow-up:** Merge is not safe concurrent with transaction
+  processing — documented. The brittle type-switch / lack of decorator
+  support were improved during review but remain an area to watch.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1492
+- libcoraza dependency: https://github.com/corazawaf/libcoraza/pull/50
+- Related ADRs: ADR-0034 (rule observer callback)

--- a/docs/adr/0036-remove-root-experimental-dep.md
+++ b/docs/adr/0036-remove-root-experimental-dep.md
@@ -1,0 +1,64 @@
+# ADR-0036: Remove root package dependency on `experimental`
+
+- **Status:** accepted
+- **Date:** 2026-02-24
+- **Version:** v3.4.0
+- **PR:** [#1494](https://github.com/corazawaf/coraza/pull/1494)
+- **Issue(s):** No linked issue (surfaced by [#1478](https://github.com/corazawaf/coraza/pull/1478))
+- **Deciders:** @fzipi
+- **Category:** Refactor
+
+## Context and Problem
+
+The root `github.com/corazawaf/coraza/v3` package imported
+`experimental`, which made it impossible for the `experimental` package to
+import back into the root — the kind of thing that blocks clean
+assertion-helper patterns. The cycle bit the rule-observer work
+([ADR-0034](0034-rule-observer-callback.md)), where @heaven had to fall
+back to reflection.
+
+## Decision Drivers
+
+- Let `experimental` reference root-package types so assertion helpers
+  (e.g. `WAFConfigWithRuleObserver`) can be implemented without reflection.
+- `experimental` should depend on stable; stable should not depend on
+  experimental.
+
+## Considered Options
+
+- Keep the status quo, continue using reflection-based workarounds.
+- Invert the direction: root no longer imports `experimental`; `experimental`
+  imports root.
+
+## Decision Outcome
+
+Chosen: **invert the direction.** This is the preparatory refactor that
+unblocks clean helpers (#1478) and future additions.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread — the
+refactor is mechanical and reviewers approved it as a plumbing fix. The
+*why* is documented explicitly in the follow-up PR:
+
+> "Because the core `coraza` package already depends on `experimental`, the
+> experimental helper cannot reference the `WAFConfig` directly without
+> creating a cyclic import. … Of course, the best long-term solution would
+> be to remove the dependency from the core `coraza` to `experimental`."
+> — @heaven, ahead of this refactor, in
+> [PR #1478 comment](https://github.com/corazawaf/coraza/pull/1478#issuecomment-3828189778)
+
+## Participants
+
+- @fzipi — author
+
+## Consequences
+
+- **Positive:** `experimental` helpers can use root types directly;
+  reflection-based workarounds become unnecessary.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1494
+- Related ADRs: ADR-0034 (rule observer callback — motivating use case)

--- a/docs/adr/0037-ctl-whole-collection-exclusion.md
+++ b/docs/adr/0037-ctl-whole-collection-exclusion.md
@@ -1,0 +1,72 @@
+# ADR-0037: `ctl:ruleRemoveTargetById` whole-collection exclusion
+
+- **Status:** accepted
+- **Date:** 2026-03-05
+- **Version:** v3.4.0
+- **PR:** [#1495](https://github.com/corazawaf/coraza/pull/1495)
+- **Issue(s):** No linked issue
+- **Deciders:** @app/copilot-swe-agent (author), @fzipi (review)
+- **Category:** Parity (closes ModSecurity-compatible exclusion gap)
+
+## Context and Problem
+
+`ctl:ruleRemoveTargetById=RULE_ID;COLLECTION` (no `:key` suffix) had no
+effect — only the keyed form `COLLECTION:key` worked. This meant an operator
+could not say "exclude the entire `ARGS` collection from rule 941390" — a
+common CRS tuning pattern.
+
+Root cause (from the PR body):
+
+> "In `GetField()`, exception matching evaluated:
+> `(ex.KeyRx != nil && ex.KeyRx.MatchString(lkey)) || strings.ToLower(ex.KeyStr) == lkey`
+> When no key is specified, `ex.KeyStr == \"\"` and `ex.KeyRx == nil`. The
+> second condition only matched parameters with an empty name, so all real
+> parameters passed through unfiltered."
+> — PR body
+
+## Decision Drivers
+
+- Match ModSecurity's whole-collection exclusion semantics.
+- Minimal surface change — one additional wildcard branch in the match
+  expression.
+
+## Considered Options
+
+- Treat empty-key exceptions as wildcards in the existing match expression.
+- Introduce a separate code path for whole-collection exclusion.
+
+## Decision Outcome
+
+Chosen: **extend the match expression with an empty-key wildcard branch:**
+
+```go
+(ex.KeyRx != nil && ex.KeyRx.MatchString(lkey)) ||
+  strings.ToLower(ex.KeyStr) == lkey ||
+  (ex.KeyStr == "" && ex.KeyRx == nil)
+```
+
+Tests added at both unit (`TestNoMatchEvaluateBecauseOfWholeCollectionException`)
+and integration (`testing/engine/ctl.go`) levels.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The Copilot
+SWE agent authored the change in response to a human-filed bug; reviewers
+approved the one-line fix on the strength of the root-cause analysis in the
+PR body.
+
+## Participants
+
+- @app/copilot-swe-agent — author
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Whole-collection exclusions work; CRS tuning idiom
+  `ctl:ruleRemoveTargetById=941390;ARGS` now has effect.
+- **Negative:** None — purely additive behaviour.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1495
+- Related ADRs: ADR-0047 (regex keys in `ctl:ruleRemoveTarget*`)

--- a/docs/adr/0038-map-for-ruleremovebyid.md
+++ b/docs/adr/0038-map-for-ruleremovebyid.md
@@ -1,0 +1,71 @@
+# ADR-0038: `map[int]struct{}` for per-transaction `ruleRemoveByID` lookup
+
+- **Status:** accepted
+- **Date:** 2026-03-06
+- **Version:** v3.4.0
+- **PR:** [#1524](https://github.com/corazawaf/coraza/pull/1524)
+- **Issue(s):** No linked issue
+- **Deciders:** @jptosso, @fzipi
+- **Category:** Perf
+
+## Context and Problem
+
+Every rule evaluation consulted a per-transaction `[]int` of excluded rule
+IDs (populated by `ctl:ruleRemoveById`). In CRS workloads with many exclusion
+directives, the linear scan is hit once per rule per phase.
+
+## Decision Drivers
+
+- O(1) lookup for rule-exclusion checks on a hot path.
+- Lazy allocation so the zero-exclusion case stays allocation-free.
+- No external API change.
+
+## Considered Options
+
+- Sorted slice + binary search.
+- `map[int]struct{}` with lazy init.
+- Bitset / roaring bitmap.
+
+## Decision Outcome
+
+Chosen: **`map[int]struct{}` with lazy init**. Benchmarked on the actual
+hot path (`BenchmarkRuleEvalWithRemovedRules`):
+
+```
+main ([]int linear scan):  135.0 ns/op
+branch (map O(1) lookup):  114.5 ns/op   (~15% faster)
+```
+
+Scales with the number of removed IDs — the improvement grows with real CRS
+exclusion loads.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR or issue thread
+beyond approvals. The rationale and measurement live in the PR body:
+
+> "`BenchmarkRuleEvalWithRemovedRules` — 1 rule loaded, 100 rule IDs
+> removed via `RemoveRuleByID`, benchmarks `Eval(PhaseRequestHeaders)` …
+> ~15% faster with 100 removed rule IDs. The improvement scales with the
+> number of removed rules and the number of rules evaluated — in CRS
+> workloads with many `ctl:ruleRemoveById` directives and hundreds of
+> rules, each rule evaluation benefits from the O(1) lookup."
+> — @jptosso, [PR body](https://github.com/corazawaf/coraza/pull/1524)
+
+## Participants
+
+- @jptosso — author
+- @fzipi — review
+- @Copilot — PR reviewer bot
+
+## Consequences
+
+- **Positive:** Rule-evaluation hot path drops ~15% for exclusion-heavy
+  configs; no cost when no rules are excluded.
+- **Negative / follow-up:** Paired with [ADR-0041](0041-ruleremovebyid-range-storage.md)
+  (range storage) to also avoid map bloat when ranges are used.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1524
+- Related ADRs: ADR-0041 (`ruleRemoveById` range storage)

--- a/docs/adr/0039-bulk-allocate-matchdata.md
+++ b/docs/adr/0039-bulk-allocate-matchdata.md
@@ -1,0 +1,64 @@
+# ADR-0039: Bulk-allocate `MatchData` in collection `Find*` methods
+
+- **Status:** accepted
+- **Date:** 2026-03-11
+- **Version:** v3.4.0
+- **PR:** [#1530](https://github.com/corazawaf/coraza/pull/1530)
+- **Issue(s):** No linked issue
+- **Deciders:** @jptosso, @fzipi
+- **Category:** Perf
+
+## Context and Problem
+
+`Map.FindRegex`, `Map.FindString`, `Map.FindAll` and the `NamedCollectionNames`
+counterparts allocated one `MatchData` per result via `&corazarules.MatchData{}`
+literals. At N results that is N+1 heap allocations. These methods run
+per-request, so the allocator pressure compounds.
+
+## Decision Drivers
+
+- Reduce heap allocations on the rule-evaluation hot path.
+- Preserve public semantics — returned slices are independently owned.
+- Avoid a double regex pass in `FindRegex`.
+
+## Considered Options
+
+- Pre-allocate a contiguous `[]MatchData` buffer and return pointers into it.
+- `sync.Pool` of `MatchData` slices.
+- Leave as-is, rely on escape analysis.
+
+## Decision Outcome
+
+Chosen: **pre-allocated contiguous buffer, pointers into the buffer.**
+
+Benchmark from the PR body:
+
+```
+FindAll    608 → 405 ns/op  (-33%)  26 → 2 allocs (-92%)
+FindRegex 1008 → 965 ns/op  (-4%)   15 → 6 allocs (-60%)
+FindString 495 → 221 ns/op  (-55%)  26 → 2 allocs (-92%)
+```
+
+`FindRegex` was also rewritten to single-pass collection (no regex
+re-evaluation).
+
+## Technical Discussion
+
+No substantive technical discussion recorded beyond the benchmark data. The
+change is localised, covered by `TestFindAllBulkAllocIndependence` and
+siblings to prove results remain independent after the pool redesign.
+
+## Participants
+
+- @jptosso — author
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Heavy allocation drop on hot-path collection finds; up to
+  55% faster for `FindString`.
+- **Negative / follow-up:** None flagged in review.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1530

--- a/docs/adr/0039-bulk-allocate-matchdata.md
+++ b/docs/adr/0039-bulk-allocate-matchdata.md
@@ -46,7 +46,7 @@ re-evaluation).
 
 No substantive technical discussion recorded beyond the benchmark data. The
 change is localised, covered by `TestFindAllBulkAllocIndependence` and
-siblings to prove results remain independent after the pool redesign.
+siblings to prove results remain independent after the bulk-allocation redesign.
 
 ## Participants
 

--- a/docs/adr/0040-crslang-antlr4-buildtag.md
+++ b/docs/adr/0040-crslang-antlr4-buildtag.md
@@ -1,0 +1,61 @@
+# ADR-0040: Gate `crslang` ANTLR4 parser behind a build tag
+
+- **Status:** accepted
+- **Date:** 2026-03-08
+- **Version:** v3.4.0
+- **PR:** [#1536](https://github.com/corazawaf/coraza/pull/1536)
+- **Issue(s):** No linked issue
+- **Deciders:** @app/copilot-swe-agent (author)
+- **Category:** Feature (new experimental parser behind a build tag)
+
+## Context and Problem
+
+The experimental ANTLR4-based SecLang parser (`experimental/seclang/parser_v2.go`)
+pulled in heavy dependencies (`antlr4-go`, `crslang`, `seclang_parser`)
+unconditionally, bloating every default Coraza build even though only a
+handful of developers need the new parser.
+
+## Decision Drivers
+
+- Keep default binary size small — most users don't need the ANTLR4 parser.
+- Still allow opt-in testing and development of the experimental parser.
+- Zero default-behaviour change.
+
+## Considered Options
+
+- Leave dependencies compiled in.
+- Split to a separate module / repository.
+- Gate behind a build tag so the code compiles only when explicitly opted
+  in.
+
+## Decision Outcome
+
+Chosen: **build-tag gate** — `//go:build coraza.experimental.crslang_parser`
+on `parser_v2.go` and its test file. Default builds skip the package
+entirely:
+
+```
+go build -tags=coraza.experimental.crslang_parser ./...
+go test -tags=coraza.experimental.crslang_parser ./experimental/seclang/...
+```
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The Copilot
+SWE agent authored the refactor; reviewers approved on the strength of the
+binary-size motivation captured in the PR body.
+
+## Participants
+
+- @app/copilot-swe-agent — author
+
+## Consequences
+
+- **Positive:** Default Coraza builds no longer drag in ANTLR4; experimental
+  parser work continues under the tag.
+- **Negative / follow-up:** One more build-tag combination the CI matrix
+  must cover for the experimental parser specifically.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1536

--- a/docs/adr/0040-crslang-antlr4-buildtag.md
+++ b/docs/adr/0040-crslang-antlr4-buildtag.md
@@ -34,7 +34,7 @@ Chosen: **build-tag gate** — `//go:build coraza.experimental.crslang_parser`
 on `parser_v2.go` and its test file. Default builds skip the package
 entirely:
 
-```
+```shell
 go build -tags=coraza.experimental.crslang_parser ./...
 go test -tags=coraza.experimental.crslang_parser ./experimental/seclang/...
 ```

--- a/docs/adr/0041-ruleremovebyid-range-storage.md
+++ b/docs/adr/0041-ruleremovebyid-range-storage.md
@@ -1,0 +1,69 @@
+# ADR-0041: `ruleRemoveById` range storage (no expansion)
+
+- **Status:** accepted
+- **Date:** 2026-03-09
+- **Version:** v3.4.0
+- **PR:** [#1538](https://github.com/corazawaf/coraza/pull/1538)
+- **Issue(s):** No linked issue
+- **Deciders:** @app/copilot-swe-agent (author)
+- **Category:** Perf
+
+## Context and Problem
+
+`rangeToInts` iterated every WAF rule and inserted each matching ID into
+the per-transaction removal map one at a time. For broad CRS exclusion
+ranges like `1000-9999`, this churned thousands of allocations per request
+even though the effective filter was just two numbers.
+
+## Decision Drivers
+
+- Avoid thousands of per-request allocations for common CRS ranges.
+- Keep the rule-evaluation skip check cheap.
+- Cover both `ctl:ruleRemoveById` and `ctl:ruleRemoveTargetById` range
+  forms.
+
+## Considered Options
+
+- Expand ranges into the map (status quo, O(range size) allocations).
+- Store ranges separately as `[2]int`; evaluate with a short `len(ranges)`
+  loop.
+- Bitset indexed by rule ID (overkill for a handful of ranges).
+
+## Decision Outcome
+
+Chosen: **store ranges as `[2]int` entries on the transaction; rule-eval
+loop checks both the ID map and the range slice.**
+
+New helpers:
+
+- `parseRange("start-end") → (start, end int)`
+- `parseIDOrRange(...)` — handles single IDs and ranges
+- `Transaction.RemoveRuleByIDRange(start, end)`
+- `Transaction.GetRuleRemoveByIDRanges()` accessor
+- `RuleGroup.rules` eval consults `ruleRemoveByIDRanges` in addition to the
+  ID map.
+
+Pool reuse resets the range slice alongside other per-transaction state.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The Copilot
+SWE agent delivered the change in response to a human-filed issue tracked
+in the original prompt block of the PR body.
+
+## Participants
+
+- @app/copilot-swe-agent — author
+
+## Consequences
+
+- **Positive:** A `ctl:ruleRemoveById=1000-9999` directive no longer causes
+  thousands of per-transaction allocations; the range lives as a single
+  `[2]int` entry.
+- **Negative / follow-up:** Rule-eval skip now has two data structures to
+  consult (map + range slice). Both small, overall cost is net-negative.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1538
+- Related ADRs: ADR-0038 (map for `ruleRemoveByID`)

--- a/docs/adr/0041-ruleremovebyid-range-storage.md
+++ b/docs/adr/0041-ruleremovebyid-range-storage.md
@@ -19,8 +19,8 @@ even though the effective filter was just two numbers.
 
 - Avoid thousands of per-request allocations for common CRS ranges.
 - Keep the rule-evaluation skip check cheap.
-- Cover both `ctl:ruleRemoveById` and `ctl:ruleRemoveTargetById` range
-  forms.
+- Scoped to `ctl:ruleRemoveById`; `ctl:ruleRemoveTargetById` keeps its
+  existing per-call scan (see Consequences) and was not touched.
 
 ## Considered Options
 
@@ -62,6 +62,10 @@ in the original prompt block of the PR body.
   `[2]int` entry.
 - **Negative / follow-up:** Rule-eval skip now has two data structures to
   consult (map + range slice). Both small, overall cost is net-negative.
+  `ctl:ruleRemoveTargetById` still parses its range with `parseIDOrRange`
+  but doesn't store it — it walks every WAF rule and calls
+  `RemoveRuleTargetByID` per match, an O(n) scan on every invocation. It
+  wasn't part of this optimization.
 
 ## References
 

--- a/docs/adr/0054-xml-unexpected-eof.md
+++ b/docs/adr/0054-xml-unexpected-eof.md
@@ -1,0 +1,61 @@
+# ADR-0054: Ignore `SyntaxError` unexpected EOF in XML body processor
+
+- **Status:** accepted
+- **Date:** 2025-12-18
+- **Version:** v3.4.0
+- **PR:** [#1452](https://github.com/corazawaf/coraza/pull/1452)
+- **Issue(s):** No linked issue
+- **Deciders:** @hnakamur
+- **Category:** Parity (ProcessPartial semantics)
+
+## Context and Problem
+
+`SecRequestBodyLimitAction ProcessPartial` can truncate an XML document
+mid-parse. The XML body processor treated the resulting
+`xml.SyntaxError: unexpected EOF` as fatal, discarding whatever had been
+parsed. This is the XML twin of the multipart fix in
+[ADR-0031](0031-multipart-unexpected-eof.md).
+
+## Decision Drivers
+
+- Honour `ProcessPartial`'s contract for XML bodies.
+- Stay consistent with the multipart processor's handling.
+
+## Considered Options
+
+- Propagate the error (status quo).
+- Treat unexpected-EOF as clean termination for ProcessPartial.
+
+## Decision Outcome
+
+Chosen: **treat `SyntaxError` unexpected-EOF as clean termination** so
+whatever parsed before the cut is retained.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR or issue thread.
+The rationale is stated in the PR body:
+
+> "We need this behavior since we need to process an incomplete XML
+> document when `SecRequestBodyLimitAction` is set to `ProcessPartial`."
+> — @hnakamur, [PR body](https://github.com/corazawaf/coraza/pull/1452)
+
+The PR merged with approvals and a clean codecov report; no reviewer
+counter-proposals on the thread.
+
+## Participants
+
+- @hnakamur — author
+
+## Consequences
+
+- **Positive:** Parity with [ADR-0031](0031-multipart-unexpected-eof.md)
+  for XML; `ProcessPartial` consistently yields partial data across body
+  processors.
+- **Negative:** Genuine XML corruption becomes indistinguishable from a
+  legitimate truncation on the parser side.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1452
+- Related ADRs: ADR-0031 (multipart unexpected EOF)

--- a/docs/adr/0054-xml-unexpected-eof.md
+++ b/docs/adr/0054-xml-unexpected-eof.md
@@ -52,8 +52,13 @@ counter-proposals on the thread.
 - **Positive:** Parity with [ADR-0031](0031-multipart-unexpected-eof.md)
   for XML; `ProcessPartial` consistently yields partial data across body
   processors.
-- **Negative:** Genuine XML corruption becomes indistinguishable from a
-  legitimate truncation on the parser side.
+- **Negative:** `readXML`/`ProcessRequest` don't receive the body-limit
+  action, so the unexpected-EOF suppression is unconditional — it applies
+  to every request, not just ones truncated by `ProcessPartial`. Genuine
+  XML corruption becomes indistinguishable from a legitimate truncation,
+  and an incomplete (attacker-truncated or transport-truncated) request
+  body can populate `RequestXML` with partial data even when
+  `SecRequestBodyLimitAction` is not `ProcessPartial`.
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,5 +100,14 @@ Superseding does not delete the old record. Set its status and let the history s
 | [0031](0031-multipart-unexpected-eof.md) | [#1453](https://github.com/corazawaf/coraza/pull/1453) | 2026-03-06 | v3.4.0 | P | Ignore unexpected EOF in multipart |
 | [0032](0032-ctl-auditlogparts-plus-minus.md) | [#1467](https://github.com/corazawaf/coraza/pull/1467) | 2026-01-13 | v3.4.0 | P | `ctl:auditLogParts` `+`/`-` syntax |
 | [0033](0033-strmatch-operator.md) | [#1473](https://github.com/corazawaf/coraza/pull/1473) | 2026-01-15 | v3.4.0 | P | `@strmatch` operator |
+| [0034](0034-rule-observer-callback.md) | [#1478](https://github.com/corazawaf/coraza/pull/1478) | 2026-02-24 | v3.4.0 | F | Optional rule observer callback |
+| [0035](0035-wafwithrules-interface.md) | [#1492](https://github.com/corazawaf/coraza/pull/1492) | 2026-02-27 | v3.4.0 | F | `WAFWithRules` interface |
+| [0036](0036-remove-root-experimental-dep.md) | [#1494](https://github.com/corazawaf/coraza/pull/1494) | 2026-02-24 | v3.4.0 | R | Remove root package dependency on `experimental` |
+| [0037](0037-ctl-whole-collection-exclusion.md) | [#1495](https://github.com/corazawaf/coraza/pull/1495) | 2026-03-05 | v3.4.0 | P | `ctl:ruleRemoveTargetById` whole-collection exclusion |
+| [0038](0038-map-for-ruleremovebyid.md) | [#1524](https://github.com/corazawaf/coraza/pull/1524) | 2026-03-06 | v3.4.0 | ⚡ | `map` for `ruleRemoveByID` O(1) lookup |
+| [0039](0039-bulk-allocate-matchdata.md) | [#1530](https://github.com/corazawaf/coraza/pull/1530) | 2026-03-11 | v3.4.0 | ⚡ | Bulk-allocate `MatchData` in `collection.Find*` |
+| [0040](0040-crslang-antlr4-buildtag.md) | [#1536](https://github.com/corazawaf/coraza/pull/1536) | 2026-03-08 | v3.4.0 | F | `crslang` ANTLR4 parser behind build tag |
+| [0041](0041-ruleremovebyid-range-storage.md) | [#1538](https://github.com/corazawaf/coraza/pull/1538) | 2026-03-09 | v3.4.0 | ⚡ | `ruleRemoveById` range storage |
+| [0054](0054-xml-unexpected-eof.md) | [#1452](https://github.com/corazawaf/coraza/pull/1452) | 2025-12-18 | v3.4.0 | P | Ignore unexpected EOF in XML body processor |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **6 of 8** splitting #1614 into reviewable pieces. 9 records covering the structural changes in the v3.4.0 release (part 2 of 2).

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0034 | #1478 | Feature | Optional rule observer callback |
| 0035 | #1492 | Feature | `WAFWithRules` interface |
| 0036 | #1494 | Refactor | Remove root package dependency on `experimental` |
| 0037 | #1495 | Parity | `ctl:ruleRemoveTargetById` whole-collection exclusion |
| 0038 | #1524 | Perf | `map` for `ruleRemoveByID` O(1) lookup |
| 0039 | #1530 | Perf | Bulk-allocate `MatchData` in `collection.Find*` |
| 0040 | #1536 | Feature | `crslang` ANTLR4 parser behind build tag |
| 0041 | #1538 | Perf | `ruleRemoveById` range storage |
| 0054 | #1452 | Parity | Ignore unexpected EOF in XML body processor |

## What to check

`mage adr` passes on this branch (15 records: 0001–0006 already on main, plus this batch's slice) and CI runs it. What a checker cannot reach:

- **Quotes are verbatim from the cited PR threads** — permalinks resolve and authors match, but whether they capture the actual reasoning is the review.
- **Deciders and Participants** came from thread archaeology and are the most likely thing to be wrong about a colleague.

## Merge order

Stacked behind the earlier batches. Every batch inserts its rows into the same `docs/adr/README.md` index, so as the earlier batches land this branch needs a rebase that keeps every row set — I will handle it.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 15 record(s) OK`
- [x] Records 0034–0054 appear in no other batch
- [x] No deletions vs `main` (0001–0006 preserved)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added architecture decision records for rule observation, experimental rule-count APIs, package boundaries, collection-wide exclusions, and rule-removal performance.
  - Documented allocation improvements for collection matching and range-based rule exclusions.
  - Recorded the opt-in build tag for the experimental SecLang parser.
  - Documented XML partial-body handling for truncated documents.
  - Updated the ADR index with entries 0034–0041 and 0054.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->