### PR TITLE
docs(adr): records for the v3.5.0 release (7 of 8)

### DIFF
--- a/docs/adr/0042-regex-memoize-default-on.md
+++ b/docs/adr/0042-regex-memoize-default-on.md
@@ -35,7 +35,10 @@ default-on.
 Chosen: **default-on with `coraza.no_memoize` opt-out.**
 
 The build tag `memoize_builders` no longer exists. `OperatorOptions` grows a
-`Memoizer` field (zero value = no memoization, backwards compatible).
+`Memoizer` field (zero value = no memoization). This is backwards compatible
+for callers using keyed struct literals or field access; external code that
+builds `OperatorOptions{...}` with unkeyed positional literals breaks, since
+the struct now has one more field.
 
 ## Technical Discussion
 
@@ -83,7 +86,8 @@ The tests were reshaped to fit TinyGo timing before the PR merged.
 - **Negative / follow-up:** TinyGo scale benchmarks were reshaped because
   the slower regex engine can't run them in CI time. Backwards-compat for
   out-of-tree operator plugins is maintained via the zero-value-Memoizer
-  behaviour.
+  behaviour for keyed literals and field access only; plugins that build
+  `OperatorOptions` with unkeyed positional literals need updating.
 
 ## References
 

--- a/docs/adr/0042-regex-memoize-default-on.md
+++ b/docs/adr/0042-regex-memoize-default-on.md
@@ -1,0 +1,93 @@
+# ADR-0042: Regex memoize enabled by default
+
+- **Status:** accepted
+- **Date:** 2026-03-18
+- **Version:** v3.5.0
+- **PR:** [#1540](https://github.com/corazawaf/coraza/pull/1540)
+- **Issue(s):** No linked issue (follows [ADR-0006](0006-regex-ahocorasick-memoize.md), [ADR-0043](0043-waf-close-per-owner-memoize.md))
+- **Deciders:** @jptosso, @jcchavezs, @fzipi, @app/copilot-swe-agent
+- **Category:** Perf (default-policy shift)
+
+## Context and Problem
+
+The regex + Aho-Corasick memoize cache shipped in v3.0.3 behind the
+`memoize_builders` build tag ([ADR-0006](0006-regex-ahocorasick-memoize.md)).
+Most embedders never knew to set the tag and therefore paid the full
+compile cost per WAF. Now that per-owner tracking and `WAF.Close()` landed
+([ADR-0043](0043-waf-close-per-owner-memoize.md)), the cache can be safely
+default-on.
+
+## Decision Drivers
+
+- Make the default-path fast; don't require a flag to get the obvious win.
+- Refactor the memoize package to pass a `Memoizer` explicitly through
+  `OperatorOptions` so it is testable and injectable.
+- Offer `coraza.no_memoize` as an explicit opt-out.
+
+## Considered Options
+
+- Leave opt-in.
+- Flip the tag to opt-out (`coraza.no_memoize`).
+- Default-on, no opt-out.
+
+## Decision Outcome
+
+Chosen: **default-on with `coraza.no_memoize` opt-out.**
+
+The build tag `memoize_builders` no longer exists. `OperatorOptions` grows a
+`Memoizer` field (zero value = no memoization, backwards compatible).
+
+## Technical Discussion
+
+**Caddy validation was a merge gate.** @jcchavezs asked for end-to-end
+validation with the Caddy integration:
+
+> "We need to extensively test this with Caddy before merging."
+> — @jcchavezs ([comment](https://github.com/corazawaf/coraza/pull/1540#issuecomment-4047246804))
+
+@fzipi confirmed the companion Caddy PR:
+
+> "@jcchavezs Added https://github.com/corazawaf/coraza-caddy/pull/275. Can
+> you take a look?"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1540#issuecomment-4063209206))
+
+**TinyGo CI stalled** because the scale benchmarks that now ran on default
+builds are extremely slow on TinyGo's regex engine. @fzipi captured the
+exact arithmetic:
+
+> "- **`TestCacheBoundedWithClose`** — 100 cycles × 300 patterns =
+>   **30,000 `regexp.Compile` calls** under TinyGo (each `Release` clears
+>   the cache, so every cycle recompiles all 300 patterns).
+> […]
+>
+> TinyGo's regex engine is dramatically slower than Go's, so these scale
+> tests are taking hours instead of seconds. The `-short` flag is passed in
+> CI but these tests don't check `testing.Short()`."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1540#issuecomment-4064049379))
+
+The tests were reshaped to fit TinyGo timing before the PR merged.
+
+**Coverage and lint** drove two follow-up Copilot PRs (#1555, #1556).
+
+## Participants
+
+- @jptosso — author
+- @jcchavezs — review (Caddy integration gate)
+- @fzipi — review (TinyGo CI triage, coverage driver)
+- @app/copilot-swe-agent — orchestrated coverage + lint follow-ups
+
+## Consequences
+
+- **Positive:** All embedders get the memoize speedup by default; operator
+  plugins receive a `Memoizer` explicitly and are easier to test.
+- **Negative / follow-up:** TinyGo scale benchmarks were reshaped because
+  the slower regex engine can't run them in CI time. Backwards-compat for
+  out-of-tree operator plugins is maintained via the zero-value-Memoizer
+  behaviour.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1540
+- Caddy validation: https://github.com/corazawaf/coraza-caddy/pull/275
+- Related ADRs: ADR-0006 (initial memoize), ADR-0043 (`WAF.Close()` +
+  per-owner tracking)

--- a/docs/adr/0043-waf-close-per-owner-memoize.md
+++ b/docs/adr/0043-waf-close-per-owner-memoize.md
@@ -1,0 +1,85 @@
+# ADR-0043: `WAF.Close()` + per-owner memoize cache tracking
+
+- **Status:** accepted
+- **Date:** 2026-03-11
+- **Version:** v3.5.0
+- **PR:** [#1541](https://github.com/corazawaf/coraza/pull/1541)
+- **Issue(s):** No linked issue (follows [ADR-0006](0006-regex-ahocorasick-memoize.md))
+- **Deciders:** @jptosso
+- **Category:** Feature (new lifecycle API)
+
+## Context and Problem
+
+The memoize cache ([ADR-0006](0006-regex-ahocorasick-memoize.md)) was
+process-global with no way to release entries when a specific WAF instance
+was destroyed. In long-running processes that construct and discard many
+WAFs (reload-heavy embedders, multi-tenant hosts), this was a slow leak.
+ADR-0006 had noted the absence of `WAF.Close()` as the reason for the
+global-plus-experimental-reset shape; this PR fixes the root cause.
+
+## Decision Drivers
+
+- Release compiled regex/Aho-Corasick memory when a WAF goes away.
+- Preserve the speed benefit of the shared cache across live WAFs.
+- Safe concurrent access during Close (tombstone-based cleanup).
+- Minimal API break — expose via `experimental.WAFCloser` so stable
+  consumers are unaffected.
+
+## Considered Options
+
+- Simple refcount per entry.
+- Per-owner (per-WAF) `uint64` IDs tracked against cache entries;
+  `Release(owner)` clears the owner's refs with tombstones.
+- Full WAF-scoped cache (no sharing across WAFs — kills the benefit).
+
+## Decision Outcome
+
+Chosen: **per-owner ID tracking + tombstone-based `Release`**, exposed via
+`experimental.WAFCloser.Close()`. Two helpers: `memoize.Release(ownerID)`
+and `memoize.Reset()`.
+
+Benchmark evidence from the PR body:
+
+```
+BenchmarkCompileWithoutMemoize/WAFs=100  54,030,097 ns/op
+BenchmarkCompileWithMemoize/WAFs=100      2,227,625 ns/op   24× speedup
+
+CRS cold→warm WAF: 58ms → 9ms  (6.3× speedup)
+Close() memory release: 28MiB peak → 1MiB after Close()
+```
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR or issue thread
+beyond reviewer approvals. The PR body is the design document:
+
+> "Add per-owner tracking to the memoize cache using `uint64` owner IDs
+> for efficient WAF lifecycle management. Implement `WAF.Close()` (via
+> `experimental.WAFCloser`) to release cached regex/aho-corasick entries
+> when a WAF instance is destroyed. Add `Release()` and `Reset()`
+> functions with tombstone-based cleanup to safely handle concurrent
+> access."
+> — @jptosso, [PR body](https://github.com/corazawaf/coraza/pull/1541)
+
+> "At 100 WAFs: **24× speedup** (54ms → 2.2ms). CRS integration: Cold vs
+> warm WAF compilation: 58ms vs 9ms (**6.3× speedup**). Close() memory
+> release: 28MiB peak → 1MiB after Close() (**27MiB released**)."
+> — @jptosso, [PR body](https://github.com/corazawaf/coraza/pull/1541)
+
+## Participants
+
+- @jptosso — author
+
+## Consequences
+
+- **Positive:** Reload-heavy or multi-tenant embedders can free ~27MiB per
+  WAF after `Close()`; first-WAF compile cost is still paid once, shared
+  across all subsequent WAFs.
+- **Negative / follow-up:** Release is O(entries × owners-to-clean) at
+  tombstone-scan time — benchmarked at ~900μs for 300 entries × 100 owners,
+  acceptable for a rare-event path.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1541
+- Related ADRs: ADR-0006 (memoize initial), ADR-0042 (default-on)

--- a/docs/adr/0044-prefix-transformation-cache.md
+++ b/docs/adr/0044-prefix-transformation-cache.md
@@ -1,0 +1,64 @@
+# ADR-0044: Prefix-based transformation cache with inline values
+
+- **Status:** accepted
+- **Date:** 2026-03-11
+- **Version:** v3.5.0
+- **PR:** [#1544](https://github.com/corazawaf/coraza/pull/1544)
+- **Issue(s):** No linked issue
+- **Deciders:** @fzipi, @jptosso
+- **Category:** Perf
+
+## Context and Problem
+
+Two rules that share a common transformation prefix
+(e.g. `t:lowercase,t:urlDecodeUni` and `t:lowercase`) redundantly recomputed
+the prefix. The existing cache stored only the final result, not the
+intermediate steps, and used pointer values (extra heap allocs).
+
+## Decision Drivers
+
+- Reuse intermediate transformation results across rules.
+- Fix `ClearTransformations` (t:none) so it resets the cached ID.
+- Cut heap allocations on the request hot path.
+
+## Considered Options
+
+- Cache only the final result per rule (status quo).
+- Cache every intermediate step, keyed by the transformation chain prefix,
+  with inline values.
+
+## Decision Outcome
+
+Chosen: **cache every intermediate step with inline values**, adding a
+`transformationPrefixIDs` field to `Rule` for backward prefix search. The
+key insight: transformations are deterministic, so two rules sharing the
+first K transformations can share the cached result after step K.
+
+PR-body benchmark against full CRS v4 (8 runs, benchstat):
+
+- Allocations: −2% (small payloads) to −19% (30 args)
+- Memory: −2% to −12%
+- Timing: −5% small/large, neutral mid-range
+
+No regressions on any metric.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The design
+and the benchmark results are in the PR body; reviewers approved on that
+basis.
+
+## Participants
+
+- @fzipi — author
+- @jptosso — review
+
+## Consequences
+
+- **Positive:** Fewer redundant transformation runs across CRS; inline
+  values avoid heap allocation; `t:none` semantics corrected.
+- **Negative / follow-up:** None noted.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1544

--- a/docs/adr/0045-findstringsubmatchindex-noalloc.md
+++ b/docs/adr/0045-findstringsubmatchindex-noalloc.md
@@ -1,0 +1,65 @@
+# ADR-0045: `FindStringSubmatchIndex` replaces `FindStringSubmatch` on capture path
+
+- **Status:** accepted
+- **Date:** 2026-03-11
+- **Version:** v3.5.0
+- **PR:** [#1547](https://github.com/corazawaf/coraza/pull/1547)
+- **Issue(s):** Extracted from [#1534](https://github.com/corazawaf/coraza/pull/1534)
+- **Deciders:** @jptosso, @fzipi
+- **Category:** Perf
+
+## Context and Problem
+
+`@rx` captures used `FindStringSubmatch`, which allocates a `[]string` per
+match. With CRS loading hundreds of `@rx` rules, this allocation compounds
+across every capturing evaluation on every request.
+
+## Decision Drivers
+
+- Eliminate the per-match `[]string` allocation.
+- Keep behaviour identical for all capture cases, including
+  non-participating optional groups.
+- Ship independently of the build-tagged prefilter work in
+  [ADR-0049](0049-rx-literal-prefilter.md).
+
+## Considered Options
+
+- Keep `FindStringSubmatch` and tolerate the allocs.
+- Switch to `FindStringSubmatchIndex`, materialise substrings as slices of
+  the original input (zero-alloc).
+
+## Decision Outcome
+
+Chosen: **`FindStringSubmatchIndex` + slice-into-input substrings**,
+passing `""` for non-participating optional groups (negative index).
+
+PR-body benchmark:
+
+```
+FindStringSubmatch       355.9 ns/op  128 B/op  2 allocs
+FindStringSubmatchIndex  316.0 ns/op   64 B/op  1 alloc     (~11% faster)
+```
+
+Allocations halved; memory halved.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The code
+change is small and self-contained; reviewers approved on the benchmark
+evidence.
+
+## Participants
+
+- @jptosso — author
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Always-on perf win on the rule-evaluation capture path;
+  this shipped outside any build tag because it is semantically identical.
+- **Negative:** None.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1547
+- Extracted from: https://github.com/corazawaf/coraza/pull/1534

--- a/docs/adr/0045-findstringsubmatchindex-noalloc.md
+++ b/docs/adr/0045-findstringsubmatchindex-noalloc.md
@@ -26,7 +26,8 @@ across every capturing evaluation on every request.
 
 - Keep `FindStringSubmatch` and tolerate the allocs.
 - Switch to `FindStringSubmatchIndex`, materialise substrings as slices of
-  the original input (zero-alloc).
+  the original input (removes the per-match `[]string` allocation; the
+  returned slice still allocates once).
 
 ## Decision Outcome
 

--- a/docs/adr/0046-secuploadkeepfiles-directive.md
+++ b/docs/adr/0046-secuploadkeepfiles-directive.md
@@ -79,8 +79,9 @@ Follow-up landed as PR #1560.
 - **Positive:** ModSecurity parity; operators get `RelevantOnly` to keep
   only suspicious uploads for post-hoc forensics.
 - **Negative / follow-up:** Full ModSecurity spec requires pairing with
-  `SecUploadDir`; check was added. Wasm builds silently ignore the
-  directive (no FS access).
+  `SecUploadDir`; check was added. On Wasm builds (no FS access) enabling
+  the directive (`On`/`RelevantOnly`) returns an error; `Off` is the no-op
+  default.
 
 ## References
 

--- a/docs/adr/0046-secuploadkeepfiles-directive.md
+++ b/docs/adr/0046-secuploadkeepfiles-directive.md
@@ -1,0 +1,89 @@
+# ADR-0046: `SecUploadKeepFiles` directive
+
+- **Status:** accepted
+- **Date:** 2026-03-19
+- **Version:** v3.5.0
+- **PR:** [#1557](https://github.com/corazawaf/coraza/pull/1557)
+- **Issue(s):** [#1550](https://github.com/corazawaf/coraza/issues/1550)
+- **Deciders:** @fzipi, @M4tteoP, @Copilot
+- **Category:** Parity (ModSecurity parity)
+
+## Context and Problem
+
+ModSecurity exposes `SecUploadKeepFiles On|Off|RelevantOnly` to control
+whether uploaded multipart files are retained or deleted after processing.
+Coraza had a parser entry for the directive but the `RelevantOnly` branch
+and the lifecycle plumbing were missing; deletion was unconditional.
+
+## Decision Drivers
+
+- ModSecurity parity.
+- Respect the `RelevantOnly` semantics: keep files only when rules matched.
+- TinyGo / Wasm builds have no filesystem access — gate cleanly under the
+  existing `environment.HasAccessToFS` check.
+
+## Considered Options
+
+- Implement `On`/`Off` only.
+- Implement all three states, mirroring ModSecurity semantics.
+
+## Decision Outcome
+
+Chosen: **implement all three states** — `On`, `Off` (default),
+`RelevantOnly`. File operations are already guarded by
+`environment.HasAccessToFS`, so the directive is safe on Wasm builds.
+
+> "Also, ModSec [requires](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secuploadkeepfiles)
+> `SecUploadKeepFiles` directive to work with `SecUploadDir`:
+>
+> > This directive requires the storage directory to be defined (using
+> > `SecUploadDir`).
+>
+> Should we distinguish the dir where we save persisted files from the tmp
+> dir where we save the tmp ones? If so, we should take care of
+> `SecUploadDir` and enforce the same requirement of ModSec"
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1557#issuecomment-4067770063))
+
+> "Makes sense. Added in 25b636d0"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1557#issuecomment-4071743033))
+
+## Technical Discussion
+
+**Copilot flagged a consistency gap** on directive error handling:
+
+> "`directiveSecUploadKeepFiles` is the only nearby directive that doesn't
+> check for empty `options.Opts` and return `errEmptyOptions`. With the
+> current code, an empty value yields an 'invalid upload keep files status'
+> error instead of the consistent 'expected options' error used by most
+> directives in this file."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1557#discussion_r2939770730))
+
+The author applied the guard.
+
+**A lint break from a Copilot suggestion** caused a chained follow-up:
+
+> "@copilot Fix the lint pipeline, as your latest suggestions broke it."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1557#issuecomment-4076746486))
+
+Follow-up landed as PR #1560.
+
+## Participants
+
+- @fzipi — author
+- @M4tteoP — review (drove `SecUploadDir` alignment)
+- @Copilot — reviewer bot (directive error-handling consistency)
+- @app/copilot-swe-agent — follow-up lint fix (#1560)
+
+## Consequences
+
+- **Positive:** ModSecurity parity; operators get `RelevantOnly` to keep
+  only suspicious uploads for post-hoc forensics.
+- **Negative / follow-up:** Full ModSecurity spec requires pairing with
+  `SecUploadDir`; check was added. Wasm builds silently ignore the
+  directive (no FS access).
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1557
+- Issue: https://github.com/corazawaf/coraza/issues/1550
+- Follow-up lint fix: https://github.com/corazawaf/coraza/pull/1560

--- a/docs/adr/0047-regex-in-ctl-ruleremovetarget.md
+++ b/docs/adr/0047-regex-in-ctl-ruleremovetarget.md
@@ -30,7 +30,7 @@ entirely or exclude the whole collection. Regex-delimited keys
 - Extract `HasRegex` into `internal/strings` and reuse in `rule.go` +
   `ctl.go`.
 - Pass the memoizer through `OperatorOptions` to dedupe
-  `regexp.MustCompile` calls.
+  `regexp.Compile` calls.
 
 ## Decision Outcome
 

--- a/docs/adr/0047-regex-in-ctl-ruleremovetarget.md
+++ b/docs/adr/0047-regex-in-ctl-ruleremovetarget.md
@@ -1,0 +1,109 @@
+# ADR-0047: Regex keys in `ctl:ruleRemoveTarget{ById,ByTag,ByMsg}`
+
+- **Status:** accepted
+- **Date:** 2026-03-21
+- **Version:** v3.5.0
+- **PR:** [#1561](https://github.com/corazawaf/coraza/pull/1561)
+- **Issue(s):** No linked issue (parallels earlier attempt [#1207](https://github.com/corazawaf/coraza/pull/1207))
+- **Deciders:** @fzipi, @M4tteoP, @app/copilot-swe-agent
+- **Category:** Feature
+
+## Context and Problem
+
+`ctl:ruleRemoveTargetById` and siblings accepted only exact string keys.
+For dynamically indexed JSON args (`ARGS:json.0.field`,
+`ARGS:json.1.field`, …), this forced operators to either disable the rule
+entirely or exclude the whole collection. Regex-delimited keys
+(`ARGS:/^json\.\d+\.field$/`) close this gap.
+
+## Decision Drivers
+
+- Per-URI exclusions for dynamically-indexed variables.
+- Reuse logic from an earlier attempt (#1207) — notably its `HasRegex`
+  helper and escape-slash handling.
+- Dedupe compiled regexes across rules that share the same pattern
+  (memoize).
+
+## Considered Options
+
+- Implement only in `ctl.go` with ad-hoc regex detection.
+- Extract `HasRegex` into `internal/strings` and reuse in `rule.go` +
+  `ctl.go`.
+- Pass the memoizer through `OperatorOptions` to dedupe
+  `regexp.MustCompile` calls.
+
+## Decision Outcome
+
+Chosen: **extracted `HasRegex` + memoizer-based regex dedup**.
+
+- `internal/strings/strings.go` — new `HasRegex(s string) (bool, string)`
+  handling `/user\/` (literal) vs `/user\\/` (regex) correctly.
+- `ctlFn.Init` type-asserts `plugintypes.RuleMetadata` to `*corazawaf.Rule`
+  to extract its memoizer and pass it into `parseCtl`.
+- `RemoveRuleTargetByID` grows a `keyRx *regexp.Regexp` parameter stored
+  directly in `ruleVariableParams`.
+
+Example from the PR:
+
+```apache
+SecRule REQUEST_URI "@beginsWith /api/jobs" \
+  "id:100100,phase:1,pass,nolog,\
+   ctl:ruleRemoveTargetById=932125;ARGS:/^json\.\d+\.jobdescription$/"
+```
+
+## Technical Discussion
+
+**Reuse earlier work.** @fzipi steered the Copilot agent toward #1207's
+`HasRegex`:
+
+> "@copilot+claude-sonnet-4.6 Read https://github.com/corazawaf/coraza/pull/1207
+> as it is another implementation of the same feature. In particular, you
+> could take from there the `HasRegex` func (and tests) that will make the
+> code more easy to read."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1561#issuecomment-4089545322))
+
+**Memoize the compiled regex.**
+
+> "@copilot Wouldn't this benefit from memoization?"
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1561#discussion_r2957185229))
+
+> "Yes, great suggestion. In commit `16d2cdd`:
+>
+> - Added a public `Memoizer()` getter on `*Rule`
+> - Updated `parseCtl` to accept a `plugintypes.Memoizer` parameter; when
+>   non-nil, it calls `memoizer.Do(rxPattern, ...)` so identical patterns
+>   across rules share a single compiled `*regexp.Regexp`
+> […]"
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1561#discussion_r2957227192))
+
+**POST JSON body test coverage.** @fzipi asked for a test that exercises
+the JSON-body-processor path, where `json.0.desc` → `json.1.desc` etc.:
+
+> "@copilot+claude-sonnet-4.6 While the test 'ruleRemoveTargetById regex
+> key' targets GET arguments, a test that does POST using json formatted
+> input would also be good to have."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1561#issuecomment-4089655772))
+
+Four integration test stages cover all three `ctl` variants plus the
+POST JSON body path.
+
+## Participants
+
+- @app/copilot-swe-agent — author
+- @fzipi — review (drove reuse, memoize, POST test coverage, docs)
+- @M4tteoP — review
+
+## Consequences
+
+- **Positive:** Operators can exclude dynamically-indexed variables
+  precisely without nuking the rule or collection; compiled regex is
+  memoized once per unique pattern across rules.
+- **Negative / follow-up:** Regex exception matching carries a per-call
+  cost (benchmarked); acceptable relative to the alternative of disabling
+  rules wholesale.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1561
+- Earlier attempt: https://github.com/corazawaf/coraza/pull/1207
+- Related ADRs: ADR-0037 (whole-collection exclusion)

--- a/docs/adr/0048-ndjson-body-processor.md
+++ b/docs/adr/0048-ndjson-body-processor.md
@@ -1,0 +1,81 @@
+# ADR-0048: NDJSON (JSON Stream) body processor
+
+- **Status:** accepted
+- **Date:** 2026-03-21
+- **Version:** v3.5.0
+- **PR:** [#1563](https://github.com/corazawaf/coraza/pull/1563)
+- **Issue(s):** No linked issue
+- **Deciders:** @app/copilot-swe-agent (author), @fzipi
+- **Category:** Feature
+
+## Context and Problem
+
+NDJSON / JSON Lines / RFC 7464 (JSON Sequence) streams carry one JSON
+record per line. Applied to WAF processing, each record should be
+evaluated independently — otherwise a malicious record hiding mid-stream
+requires buffering the whole body just to catch it.
+
+## Decision Drivers
+
+- Stream-native inspection: evaluate rules per record, don't buffer.
+- Preserve cross-record state (TX variables, anomaly scores) across
+  evaluations.
+- Autodetect RFC 7464 by peeking for RS (`0x1E`) byte.
+- Enforce the same JSON depth limit as the regular JSON processor
+  ([ADR-0030](0030-secrequestbodyjsondepthlimit.md)).
+
+## Considered Options
+
+- Buffer the whole stream, then run rules once.
+- Line-by-line processing, evaluate per record, clear and repopulate
+  `ARGS_POST` between records.
+
+## Decision Outcome
+
+Chosen: **line-by-line processing with per-record rule evaluation.**
+
+- `bufio.Scanner` with configurable max token size.
+- `json.<N>.<field>` indexing pattern (same conventions as the JSON body
+  processor).
+- Registered under aliases `JSONSTREAM`, `NDJSON`, `JSONLINES`.
+- `processRequestBodyStreaming` / `processResponseBodyStreaming` on
+  `Transaction` make `Eval(Phase2)` safe to call multiple times:
+  `AllowTypePhase`, `Skip`, and transformation cache all reset between
+  calls.
+- `experimental.StreamingTransaction` exposes
+  `ProcessRequestBodyFromStream(input, output)` /
+  `ProcessResponseBodyFromStream(input, output)` for integrators building
+  streaming middleware.
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The Copilot
+SWE agent delivered the change end-to-end; the design and e2e tests are
+captured in the PR body. Reviewers approved on the strength of the
+streaming-relay API design and per-record test coverage:
+
+- clean stream → 200
+- stream with malicious record → 403
+- `application/jsonlines` content type
+- SQLi inside a record field → 403
+- blank lines ignored
+- non-NDJSON content type unaffected
+
+## Participants
+
+- @app/copilot-swe-agent — author
+- @fzipi — review
+
+## Consequences
+
+- **Positive:** Streaming APIs emitting NDJSON can be protected without
+  per-connection buffering; cross-record anomaly-score accumulation works.
+- **Negative / follow-up:** `processRequestBodyStreaming` mutates
+  `ARGS_POST` between records — embedders relying on post-phase argument
+  state will see only the last record's values.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1563
+- Related ADRs: ADR-0010 (raw body processor), ADR-0030
+  (`SecRequestBodyJsonDepthLimit`)

--- a/docs/adr/0048-ndjson-body-processor.md
+++ b/docs/adr/0048-ndjson-body-processor.md
@@ -10,8 +10,9 @@
 
 ## Context and Problem
 
-NDJSON / JSON Lines / RFC 7464 (JSON Sequence) streams carry one JSON
-record per line. Applied to WAF processing, each record should be
+NDJSON / JSON Lines streams carry one JSON record per line. (RFC 7464
+JSON Text Sequences use `0x1E` record separators rather than line framing
+and are out of scope for this line-delimited processor.) Applied to WAF processing, each record should be
 evaluated independently — otherwise a malicious record hiding mid-stream
 requires buffering the whole body just to catch it.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -109,5 +109,12 @@ Superseding does not delete the old record. Set its status and let the history s
 | [0040](0040-crslang-antlr4-buildtag.md) | [#1536](https://github.com/corazawaf/coraza/pull/1536) | 2026-03-08 | v3.4.0 | F | `crslang` ANTLR4 parser behind build tag |
 | [0041](0041-ruleremovebyid-range-storage.md) | [#1538](https://github.com/corazawaf/coraza/pull/1538) | 2026-03-09 | v3.4.0 | ⚡ | `ruleRemoveById` range storage |
 | [0054](0054-xml-unexpected-eof.md) | [#1452](https://github.com/corazawaf/coraza/pull/1452) | 2025-12-18 | v3.4.0 | P | Ignore unexpected EOF in XML body processor |
+| [0042](0042-regex-memoize-default-on.md) | [#1540](https://github.com/corazawaf/coraza/pull/1540) | 2026-03-18 | v3.5.0 | ⚡ | Regex memoize enabled by default |
+| [0043](0043-waf-close-per-owner-memoize.md) | [#1541](https://github.com/corazawaf/coraza/pull/1541) | 2026-03-11 | v3.5.0 | F | `WAF.Close()` + per-owner memoize tracking |
+| [0044](0044-prefix-transformation-cache.md) | [#1544](https://github.com/corazawaf/coraza/pull/1544) | 2026-03-11 | v3.5.0 | ⚡ | Prefix-based transformation cache |
+| [0045](0045-findstringsubmatchindex-noalloc.md) | [#1547](https://github.com/corazawaf/coraza/pull/1547) | 2026-03-11 | v3.5.0 | ⚡ | `FindStringSubmatchIndex` no-alloc path |
+| [0046](0046-secuploadkeepfiles-directive.md) | [#1557](https://github.com/corazawaf/coraza/pull/1557) | 2026-03-19 | v3.5.0 | P | `SecUploadKeepFiles` directive |
+| [0047](0047-regex-in-ctl-ruleremovetarget.md) | [#1561](https://github.com/corazawaf/coraza/pull/1561) | 2026-03-21 | v3.5.0 | F | Regex in `ctl:ruleRemoveTarget*` |
+| [0048](0048-ndjson-body-processor.md) | [#1563](https://github.com/corazawaf/coraza/pull/1563) | 2026-03-21 | v3.5.0 | F | NDJSON (JSON Stream) body processor |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **7 of 8** splitting #1614 into reviewable pieces. 7 records covering the structural changes in the v3.5.0 release.

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0042 | #1540 | Perf | Regex memoize enabled by default |
| 0043 | #1541 | Feature | `WAF.Close()` + per-owner memoize tracking |
| 0044 | #1544 | Perf | Prefix-based transformation cache |
| 0045 | #1547 | Perf | `FindStringSubmatchIndex` no-alloc path |
| 0046 | #1557 | Parity | `SecUploadKeepFiles` directive |
| 0047 | #1561 | Feature | Regex in `ctl:ruleRemoveTarget*` |
| 0048 | #1563 | Feature | NDJSON (JSON Stream) body processor |

## What to check

`mage adr` passes on this branch (13 records: 0001–0006 already on main, plus this batch's slice) and CI runs it. What a checker cannot reach:

- **Quotes are verbatim from the cited PR threads** — permalinks resolve and authors match, but whether they capture the actual reasoning is the review.
- **Deciders and Participants** came from thread archaeology and are the most likely thing to be wrong about a colleague.

## Merge order

Stacked behind the earlier batches. Every batch inserts its rows into the same `docs/adr/README.md` index, so as the earlier batches land this branch needs a rebase that keeps every row set — I will handle it.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 13 record(s) OK`
- [x] Records 0042–0048 appear in no other batch
- [x] No deletions vs `main` (0001–0006 preserved)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added seven architecture decision records covering memoization, cache management, WAF cleanup, upload-file retention, regex-based rule-target removal, efficient regex capture handling, and NDJSON body processing.
  * Documented configurable upload-file retention modes, streaming JSON/NDJSON evaluation, and performance improvements for transformations and regex matching.
  * Updated the ADR index with decisions 0042–0048, including rationale, trade-offs, compatibility considerations, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->