### PR TITLE
docs(adr): records for v3.6.0, v3.7.0 and main (8 of 8)

### DIFF
--- a/docs/adr/0049-rx-literal-prefilter.md
+++ b/docs/adr/0049-rx-literal-prefilter.md
@@ -1,0 +1,102 @@
+# ADR-0049: `@rx` operator literal pre-filter (build-tag opt-in)
+
+- **Status:** accepted
+- **Date:** 2026-03-31
+- **Version:** v3.6.0 (gated by `coraza.rule.rx_prefilter`)
+- **PR:** [#1534](https://github.com/corazawaf/coraza/pull/1534)
+- **Issue(s):** No linked issue (superseded by runtime directive — [ADR-0050](0050-secrxprefilter-directive.md))
+- **Deciders:** @jptosso, @fzipi, @M4tteoP
+- **Category:** Perf
+
+## Context and Problem
+
+`@rx` is the largest hot path in Coraza. CRS loads hundreds of `@rx` rules
+and 95%+ of evaluations return `false` for benign traffic — but the regex
+engine still runs to completion before concluding "no match". Compile-time
+analysis can cheaply short-circuit clear non-matches.
+
+## Decision Drivers
+
+- Skip the regex engine entirely when a pattern's required literals are
+  absent from the input.
+- **Safety first:** a prefilter may only say "definitely no match" or
+  "maybe match" — any uncertainty must fall through to the full regex.
+  A missed attack is worse than a missed optimisation.
+- Opt-in via a build tag so existing deployments don't change behaviour
+  silently.
+
+## Considered Options
+
+- Ship only the allocation reduction from
+  [ADR-0045](0045-findstringsubmatchindex-noalloc.md).
+- Add compile-time AST walking to extract min-length + required-literal
+  pre-checks, gated by build tag.
+
+## Decision Outcome
+
+Chosen: **build-tag-gated AST prefilter with three optimizations:**
+
+1. **Minimum match length check** — walk `regexp/syntax` AST to compute
+   minimum input bytes; skip if `len(input) < minLen`.
+2. **Required literal pre-filtering (highest impact)** — extract literals
+   that *must* appear; check with `strings.Contains` (single) or
+   Aho-Corasick (alternation), reusing the `@pm` dependency.
+3. **Allocation reduction in capturing path** — `FindStringSubmatchIndex`,
+   shipped always-on in [ADR-0045](0045-findstringsubmatchindex-noalloc.md).
+
+**Safety rule** quoted from the PR body:
+
+> "When in doubt, fall back to the regex. The prefilter is purely an
+> optimization. If there is **any** uncertainty about whether the input
+> could match — non-ASCII input with `(?i)` patterns, unknown AST nodes,
+> unparseable patterns, or any other ambiguity — we return 'maybe match'
+> and let the full regex engine make the final decision. **A missed
+> optimization is free; a missed attack is a security vulnerability.**"
+> — @jptosso, PR body
+
+**Unicode case-folding safety.** The prefilter only knows ASCII case
+folding (A-Z ↔ a-z), so `(?i)` patterns that see non-ASCII input
+conservatively return "maybe match" to avoid missing `s`↔`ſ`, `k`↔`K`
+edge cases:
+
+> "In practice, 99%+ of WAF traffic is pure ASCII, so the optimization
+> still applies for the vast majority of requests."
+> — @jptosso, PR body
+
+## Technical Discussion
+
+Runtime vs. build-time activation was the unresolved question, and it was
+split out rather than settled here:
+
+> "I would move this to be a different PR so we can skip the build flag."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1534#discussion_r2901889272))
+
+That follow-up became [ADR-0050](0050-secrxprefilter-directive.md): build-tag
+gating made testing harder for embedders wanting per-instance opt-in without a
+rebuild.
+
+The chosen literal-length threshold was also queried, without a cited source:
+
+> "I wonder about this number, do we have any reference?"
+> — @jcchavezs ([review](https://github.com/corazawaf/coraza/pull/1534#discussion_r2923591762))
+
+## Participants
+
+- @jptosso — author
+- @fzipi — review
+- @M4tteoP — review (followed up with the runtime directive)
+
+## Consequences
+
+- **Positive:** For typical traffic, most `@rx` evaluations short-circuit
+  before touching the regex engine.
+- **Negative / follow-up:** Build-tag gating requires a rebuild to toggle —
+  addressed by [ADR-0050](0050-secrxprefilter-directive.md)
+  (`SecRxPreFilter` directive) in v3.7.0.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1534
+- Related ADRs: ADR-0045 (FindStringSubmatchIndex), ADR-0050
+  (`SecRxPreFilter` directive), ADR-0052 (Aho-Corasick → bitmap matcher
+  for this prefilter)

--- a/docs/adr/0050-secrxprefilter-directive.md
+++ b/docs/adr/0050-secrxprefilter-directive.md
@@ -1,0 +1,100 @@
+# ADR-0050: `SecRxPreFilter` runtime directive for `@rx` pre-filtering
+
+- **Status:** accepted
+- **Date:** 2026-04-05
+- **Version:** v3.7.0 (directive default `Off`)
+- **PR:** [#1589](https://github.com/corazawaf/coraza/pull/1589)
+- **Issue(s):** No linked issue (supersedes build-tag gating in [ADR-0049](0049-rx-literal-prefilter.md))
+- **Deciders:** @M4tteoP, @jptosso, @fzipi, @Copilot, @coderabbitai
+- **Category:** Feature
+
+## Context and Problem
+
+The `@rx` literal pre-filter ([ADR-0049](0049-rx-literal-prefilter.md))
+was behind the `coraza.rule.rx_prefilter` build tag. Enabling it required
+a rebuild, which made per-instance rollout and A/B testing hard in
+production settings.
+
+## Decision Drivers
+
+- Let operators toggle the prefilter per WAF instance without a rebuild.
+- Preserve the build tag for Coraza's own CI (test both codepaths).
+- Keep default behaviour conservative (directive `Off`) since the
+  prefilter is marked experimental.
+
+## Considered Options
+
+- Keep build-tag only.
+- Runtime directive, `On` by default.
+- Runtime directive, `Off` by default, build tag flips the default to `On`
+  for CI/test purposes only.
+
+## Decision Outcome
+
+Chosen: **runtime directive, default `Off`, build tag remains but only
+changes the default for tests.** The directive is explicitly labelled
+`EXPERIMENTAL` in the recommended config + docs.
+
+> "I added a warning Experimental line on both the recommended and docs
+> comments, plus some rewording."
+> — @M4tteoP ([comment](https://github.com/corazawaf/coraza/pull/1589#issuecomment-4188929785))
+
+## Technical Discussion
+
+**Copilot's catches shaped the doc and tests:**
+
+Concurrency test that didn't actually exercise the prefilter:
+
+> "`TestPrefilterConcurrentSafety` is intended to validate the prefilter
+> closure/Aho-Corasick behavior under concurrency, but `newRX` is
+> constructed without `RxPreFilterEnabled: true`, so the operator will not
+> build/use the prefilter at all."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1589#discussion_r3032578657))
+
+Default vs. tag-dependent semantics:
+
+> "The directive doc comment says `Default: Off`, but `NewWAF()` sets
+> `RxPreFilterEnabled` from `defaultRxPreFilterEnabled`, which becomes
+> `true` when built with `coraza.rule.rx_prefilter`. Consider updating
+> this comment to reflect that the default can be tag-dependent (or
+> explicitly note that the build tag is test-only and changes the
+> default)."
+> — @Copilot ([review](https://github.com/corazawaf/coraza/pull/1589#discussion_r3032578690))
+
+Runtime-vs-compile-time wording in the recommended config:
+
+> "Line 13 currently describes `SecRxPreFilter` as compile-time behavior,
+> but this directive is runtime-configurable. This can confuse operators
+> reading the recommended config."
+> — @coderabbitai[bot] ([review](https://github.com/corazawaf/coraza/pull/1589#discussion_r3034771145))
+
+Both were applied.
+
+**Should a warning fire on use?** @jptosso asked; @fzipi and @M4tteoP
+opted for the `EXPERIMENTAL` comment in the recommended config instead of
+a runtime warn log:
+
+> "Should we send a warning telling the user this is an experimental
+> feature?"
+> — @jptosso ([comment](https://github.com/corazawaf/coraza/pull/1589#issuecomment-4185780082))
+
+## Participants
+
+- @M4tteoP — author
+- @jptosso — review (asked about experimental-warning)
+- @fzipi — review (approved wording approach)
+- @Copilot — reviewer bot (drove doc + test fixes)
+- @coderabbitai[bot] — reviewer (wording)
+
+## Consequences
+
+- **Positive:** Operators can enable / disable the prefilter without a
+  rebuild; Coraza's CI still exercises both codepaths by toggling the tag.
+- **Negative / follow-up:** Two sources of truth for the default
+  (directive + build tag); clearly documented as test-only.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1589
+- Related ADRs: ADR-0049 (rx literal prefilter), ADR-0052 (Aho-Corasick →
+  bitmap matcher)

--- a/docs/adr/0051-audit-log-part-j.md
+++ b/docs/adr/0051-audit-log-part-j.md
@@ -13,7 +13,7 @@
 ModSecurity v2 defines `Part J` of `SecAuditLogParts` as a list of
 uploaded-file metadata:
 
-```
+```text
 1,12345,"image.png","image/png"
 2,67890,"doc.pdf","application/pdf"
 Total,80235
@@ -94,9 +94,10 @@ Applied.
 
 ## Consequences
 
-- **Positive:** Coraza emits ModSecurity v2 Part J verbatim; SIEM
-  pipelines that parse Part J work out of the box across native, JSON, and
-  OCSF formats.
+- **Positive:** the native audit log emits a Part J block of uploaded-file
+  metadata (the part ModSecurity v2 reserved for this purpose); the JSON and
+  OCSF outputs expose the equivalent metadata through their own field
+  structures. SIEM pipelines that consume it work out of the box.
 - **Negative / follow-up:** Part I (fake urlencoded body for multipart
   requests) is still unimplemented and documented as such.
 

--- a/docs/adr/0051-audit-log-part-j.md
+++ b/docs/adr/0051-audit-log-part-j.md
@@ -1,0 +1,107 @@
+# ADR-0051: Audit log Part J (uploaded files metadata)
+
+- **Status:** accepted
+- **Date:** 2026-04-03
+- **Version:** v3.7.0
+- **PR:** [#1591](https://github.com/corazawaf/coraza/pull/1591)
+- **Issue(s):** No linked issue
+- **Deciders:** @fzipi, @M4tteoP, @coderabbitai
+- **Category:** Parity (ModSecurity v2 Part J parity)
+
+## Context and Problem
+
+ModSecurity v2 defines `Part J` of `SecAuditLogParts` as a list of
+uploaded-file metadata:
+
+```
+1,12345,"image.png","image/png"
+2,67890,"doc.pdf","application/pdf"
+Total,80235
+```
+
+Coraza documented Part J but emitted nothing; uploaded-file metadata was
+being folded into Part C in a way that wasn't spec-compliant.
+
+## Decision Drivers
+
+- ModSecurity v2 format parity for audit-log consumers that already know
+  Part J.
+- Safe escaping of filenames / MIME types (`strconv.Quote`).
+- Fallback MIME string when Content-Type missing:
+  `<Unknown Content-Type>`.
+
+## Considered Options
+
+- Leave file metadata in Part C.
+- Move metadata to Part J per spec, keep native/JSON/OCSF formats in sync.
+
+## Decision Outcome
+
+Chosen: **move to Part J, emit in ModSecurity v2 native format**, use
+`strconv.Quote` for safe escaping. JSON format inherits the data via
+struct marshalling; OCSF already read from `Request().Files()` so it gains
+the data automatically.
+
+## Technical Discussion
+
+**Implementation notes from the PR body:**
+
+> "**Native format** matches ModSecurity v2's Part J output from
+> `msc_logging.c` … **JSON format** gets file data automatically via struct
+> marshaling — no extra code needed. **OCSF format** already had file
+> observable logic in `formats_ocsf.go:110` that reads from
+> `Request().Files()`, so it works once the data is populated."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1591#issuecomment-4183561086))
+
+**TODO cleanup** @M4tteoP asked:
+
+> "Is this still a todo? Should it be revisited and just become code
+> documentation?"
+> — @M4tteoP ([review](https://github.com/corazawaf/coraza/pull/1591#discussion_r3033682654))
+
+> "Converted to a concise documentation note — no longer a TODO, just
+> describes what Part I would do (still not implemented)."
+> — @fzipi ([review](https://github.com/corazawaf/coraza/pull/1591#discussion_r3034070981))
+
+**Version tag on docs:**
+
+> "Also internal/seclang/directives.go directiveSecAuditLogParts
+> documentation should be updated:
+>
+> ```
+> // - J: This part contains information about the files uploaded using `multipart/form-data` encoding; not implemented yet.
+> ```
+>
+> might make sense to specify the Coraza version from when this is
+> avaiable. `not implemented yet.` -> `Available from Coraza v3.7.0` or
+> similar"
+> — @M4tteoP ([review](https://github.com/corazawaf/coraza/pull/1591#discussion_r3033700886))
+
+Applied.
+
+**Error-handling discipline on size parsing:**
+
+> "`strconv.ParseInt` for file sizes now checks the error and logs a debug
+> message with the file name, raw value, and parse error via
+> `tx.DebugLogger()`. Size defaults to 0 on failure."
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1591#issuecomment-4183650976))
+
+## Participants
+
+- @fzipi — author
+- @M4tteoP — review (TODO cleanup, version-tag in docs)
+- @coderabbitai[bot] — reviewer (MIME assertion in tests)
+
+## Consequences
+
+- **Positive:** Coraza emits ModSecurity v2 Part J verbatim; SIEM
+  pipelines that parse Part J work out of the box across native, JSON, and
+  OCSF formats.
+- **Negative / follow-up:** Part I (fake urlencoded body for multipart
+  requests) is still unimplemented and documented as such.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1591
+- ModSecurity reference: Part J in `msc_logging.c`
+- Related ADRs: ADR-0005 (formatter interface), ADR-0018 (OCSF)

--- a/docs/adr/0051-audit-log-part-j.md
+++ b/docs/adr/0051-audit-log-part-j.md
@@ -10,8 +10,11 @@
 
 ## Context and Problem
 
-ModSecurity v2 defines `Part J` of `SecAuditLogParts` as a list of
-uploaded-file metadata:
+ModSecurity v2's docs describe `Part J` of `SecAuditLogParts` as a list of
+uploaded-file metadata, but ModSecurity v2 itself never implemented it —
+`msc_logging.c` has no Part J output or escaping logic to match. The
+format below is Coraza's own, built from the documented field list, not a
+byte-for-byte match to a real ModSecurity output:
 
 ```text
 1,12345,"image.png","image/png"
@@ -37,10 +40,12 @@ being folded into Part C in a way that wasn't spec-compliant.
 
 ## Decision Outcome
 
-Chosen: **move to Part J, emit in ModSecurity v2 native format**, use
-`strconv.Quote` for safe escaping. JSON format inherits the data via
-struct marshalling; OCSF already read from `Request().Files()` so it gains
-the data automatically.
+Chosen: **move to Part J, emit Coraza's own CSV-like format based on
+ModSecurity v2's documented field list** (index, size, filename,
+content-type), using `strconv.Quote` for escaping — there's no shipped
+ModSecurity v2 output to be byte-compatible with. JSON format inherits
+the data via struct marshalling; OCSF already read from
+`Request().Files()` so it gains the data automatically.
 
 ## Technical Discussion
 
@@ -52,6 +57,11 @@ the data automatically.
 > observable logic in `formats_ocsf.go:110` that reads from
 > `Request().Files()`, so it works once the data is populated."
 > — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1591#issuecomment-4183561086))
+
+`msc_logging.c` doesn't actually contain a Part J implementation to match —
+ModSecurity v2 documented the part but never shipped it. "Matches" here
+means the field list (index, size, filename, content-type), not verified
+wire-compatible output.
 
 **TODO cleanup** @M4tteoP asked:
 
@@ -104,5 +114,6 @@ Applied.
 ## References
 
 - PR: https://github.com/corazawaf/coraza/pull/1591
-- ModSecurity reference: Part J in `msc_logging.c`
+- ModSecurity reference: Part J documented (but unimplemented) in
+  `msc_logging.c`
 - Related ADRs: ADR-0005 (formatter interface), ADR-0018 (OCSF)

--- a/docs/adr/0052-ahocorasick-to-bitmap.md
+++ b/docs/adr/0052-ahocorasick-to-bitmap.md
@@ -1,0 +1,96 @@
+# ADR-0052: Replace Aho-Corasick with indexed-bitmap matcher for `@rx` `anyRequired` prefilter
+
+- **Status:** accepted
+- **Date:** 2026-04-09
+- **Version:** unreleased (post-v3.7.0)
+- **PR:** [#1597](https://github.com/corazawaf/coraza/pull/1597)
+- **Issue(s):** No linked issue
+- **Deciders:** @soujanyanmbri, @fzipi, @coderabbitai
+- **Category:** Perf
+
+## Context and Problem
+
+The `@rx` prefilter ([ADR-0049](0049-rx-literal-prefilter.md)) used
+Aho-Corasick for `anyRequired` alternations. Aho-Corasick scans at O(H)
+with non-trivial allocation. A Wu-Manber-style indexed-bitmap matcher can
+do sub-linear scans with zero match-time allocations.
+
+Two additional structural issues were found:
+
+1. Go's `regexp/syntax.Simplify()` rewrites `(select|sleep|substr)` into
+   a trie with a 1-byte shared prefix. The old extractor saw the short
+   prefix, returned `nil`, and built no prefilter at all.
+2. `anyRequired` sets nested inside `OpConcat` nodes (e.g.
+   `(?:^|["':;=])\s*(?:select|union|drop)`) were discarded.
+
+## Decision Drivers
+
+- Faster `anyRequired` scanning; zero-alloc match path.
+- Recover literals from simplified tries so large SQL keyword sets
+  actually benefit from the prefilter.
+- Propagate `anyRequired` through `OpConcat` children.
+- Cheap length-only prefilter for patterns with no extractable literals.
+
+## Considered Options
+
+- Keep Aho-Corasick, accept the allocations.
+- Replace with Wu-Manber indexed-bitmap matcher + trie reconstruction + 
+  propagation + min-length fallback.
+
+## Decision Outcome
+
+Chosen: **Wu-Manber indexed-bitmap matcher + three structural fixes.**
+
+- `indexedMatcher` scanner with a 2-byte bigram shift table; sub-linear
+  average step (`minNeedleLen/2`), zero heap allocation at match time,
+  up to 256 needles before falling back.
+- `trieReconstruct`: detects `OpConcat(OpLiteral, OpAlternate)` and
+  prepends the shared prefix to each suffix branch, recovering the full
+  keyword set for the scanner.
+- `extractLiterals` walks `OpConcat` children and surfaces the most
+  restrictive `anyRequired`.
+- If no literals can be extracted and `minMatchLength >= 4`, a
+  length-only prefilter `len(s) >= mml` is returned — free O(1) guard.
+
+## Technical Discussion
+
+**Safety claim from the PR body:**
+
+> "The prefilter is **safe by construction**: it can only say 'definitely
+> no match' (skip regex) or 'maybe match' (run regex). A bug in literal
+> extraction degrades performance; it cannot produce a false negative.
+> When in doubt (non-ASCII CI input, unknown AST nodes, unparseable
+> patterns), we fall through to the regex."
+> — @soujanyanmbri, PR body
+
+**Coverage was a merge gate:**
+
+> "Looks amazing @soujanyanmbri Can you add more coverage?"
+> — @fzipi ([comment](https://github.com/corazawaf/coraza/pull/1597#issuecomment-4189353503))
+
+> "Thank you! Done, added more coverage. Please check :)"
+> — @soujanyanmbri ([comment](https://github.com/corazawaf/coraza/pull/1597#issuecomment-4189392213))
+
+No architectural debate — the three structural fixes plus the matcher
+swap were approved on the evidence of CRS-scale benchmarks in the PR body.
+
+## Participants
+
+- @soujanyanmbri — author
+- @fzipi — review (coverage driver)
+- @coderabbitai[bot] — reviewer
+
+## Consequences
+
+- **Positive:** Large SQL-keyword alternations (previously un-prefiltered
+  because of the trie-simplification issue) now short-circuit; zero-alloc
+  hot path for `anyRequired` scanning.
+- **Negative / follow-up:** `indexedMatcher` is a second literal-matching
+  primitive alongside the `@pm` Aho-Corasick path — operator of the two
+  codepaths must be aware of the distinct responsibilities.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1597
+- Related ADRs: ADR-0049 (rx literal prefilter), ADR-0053 (`@pm` minLen
+  prefilter)

--- a/docs/adr/0052-ahocorasick-to-bitmap.md
+++ b/docs/adr/0052-ahocorasick-to-bitmap.md
@@ -41,9 +41,9 @@ Two additional structural issues were found:
 
 Chosen: **Wu-Manber indexed-bitmap matcher + three structural fixes.**
 
-- `indexedMatcher` scanner with a 2-byte bigram shift table; sub-linear
-  average step (`minNeedleLen/2`), zero heap allocation at match time,
-  up to 256 needles before falling back.
+- `indexedMatcher` scanner with a 256-entry single-byte shift table plus
+  per-byte `endBuckets`; sub-linear average scanning (~`O(H/minLen)`), zero
+  heap allocation at match time, up to 256 needles before falling back.
 - `trieReconstruct`: detects `OpConcat(OpLiteral, OpAlternate)` and
   prepends the shared prefix to each suffix branch, recovering the full
   keyword set for the scanner.

--- a/docs/adr/0053-pm-minlen-prefilter.md
+++ b/docs/adr/0053-pm-minlen-prefilter.md
@@ -1,0 +1,82 @@
+# ADR-0053: `@pm` operator `minLen` prefilter
+
+- **Status:** accepted
+- **Date:** 2026-04-13
+- **Version:** unreleased (post-v3.7.0)
+- **PR:** [#1601](https://github.com/corazawaf/coraza/pull/1601)
+- **Issue(s):** No linked issue
+- **Deciders:** @fzipi
+- **Category:** Perf
+
+## Context and Problem
+
+`@pm` (and `@pmFromFile`, `@pmFromDataset`) dispatches into the upstream
+`aho-corasick` library even for inputs shorter than the shortest pattern.
+That library has its own prefilter (rare-byte scanning) but no
+minimum-length early exit — so calling `matcher.Iter("ab")` with a set
+whose shortest pattern is 4 chars still copies the string, allocates a
+`*prefilterState`, allocates a `*findIter`, and walks some automaton
+states before concluding "no match".
+
+## Decision Drivers
+
+- Cut the cost of short-input `@pm` evaluations — common on headers,
+  cookies, single-token query params.
+- Zero-alloc on the early-exit path.
+
+## Considered Options
+
+- Push the fix upstream into `aho-corasick`.
+- Compute the shortest-pattern length at init, add a trivial `len(value)
+  < minLen` gate inside the `@pm` operator.
+
+## Decision Outcome
+
+Chosen: **`minLen` field on the `pm` struct, checked before the upstream
+matcher.** Applies uniformly to `pm`, `pmFromFile`, `pmFromDataset`.
+
+**Why not upstream:**
+
+> "The aho-corasick library has its own prefilter (`startBytes`/`rareBytes`
+> — scanning for rare start bytes to skip automaton states), but it does
+> **not** have a minimum-length early exit. Calling `matcher.Iter(value)`
+> always: 1. Copies the string to `[]byte` (allocation) 2. Creates a
+> `*prefilterState` (heap allocation) 3. Creates a `*findIter` (heap
+> allocation via interface) 4. Walks the automaton on `Next()` before
+> concluding 'no match'."
+> — @fzipi, PR body
+
+## Technical Discussion
+
+No substantive technical discussion recorded on the PR thread. The
+benchmarks, CRS-workload numbers, and allocation analysis are all in the
+PR body. Reviewers approved on that basis.
+
+Micro-benchmark from the PR body:
+
+| Input | ns/op | allocs |
+|---|---:|---:|
+| below minLen (3 chars) | **2** | 0 |
+| at minLen, no match (4 chars) | 98 | 4 |
+| longer, no match (62 chars) | 317 | 4 |
+
+CRS benchmark: −3% memory / −3% wall-time on simple GET/POST.
+
+## Participants
+
+- @fzipi — author
+
+## Consequences
+
+- **Positive:** Short inputs (shorter than any `@pm` pattern) skip the
+  upstream matcher entirely — roughly 50× faster on the pure skip path;
+  CRS wall-time drops several percent end-to-end.
+- **Negative:** `minLen` adds state on the `pm` struct; unchanged if
+  the pattern list is dynamic.
+
+## References
+
+- PR: https://github.com/corazawaf/coraza/pull/1601
+- Upstream library: https://github.com/petar-dambovaliev/aho-corasick
+- Related ADRs: ADR-0049 (rx literal prefilter — analogous `minMatchLength`
+  for `@rx`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -116,5 +116,10 @@ Superseding does not delete the old record. Set its status and let the history s
 | [0046](0046-secuploadkeepfiles-directive.md) | [#1557](https://github.com/corazawaf/coraza/pull/1557) | 2026-03-19 | v3.5.0 | P | `SecUploadKeepFiles` directive |
 | [0047](0047-regex-in-ctl-ruleremovetarget.md) | [#1561](https://github.com/corazawaf/coraza/pull/1561) | 2026-03-21 | v3.5.0 | F | Regex in `ctl:ruleRemoveTarget*` |
 | [0048](0048-ndjson-body-processor.md) | [#1563](https://github.com/corazawaf/coraza/pull/1563) | 2026-03-21 | v3.5.0 | F | NDJSON (JSON Stream) body processor |
+| [0049](0049-rx-literal-prefilter.md) | [#1534](https://github.com/corazawaf/coraza/pull/1534) | 2026-03-31 | v3.6.0 | ⚡ | `@rx` literal pre-filter |
+| [0050](0050-secrxprefilter-directive.md) | [#1589](https://github.com/corazawaf/coraza/pull/1589) | 2026-04-05 | v3.7.0 | F | `SecRxPreFilter` directive |
+| [0051](0051-audit-log-part-j.md) | [#1591](https://github.com/corazawaf/coraza/pull/1591) | 2026-04-03 | v3.7.0 | P | Audit log Part J (uploaded files) |
+| [0052](0052-ahocorasick-to-bitmap.md) | [#1597](https://github.com/corazawaf/coraza/pull/1597) | 2026-04-09 | unreleased | ⚡ | Aho-Corasick → indexed-bitmap matcher |
+| [0053](0053-pm-minlen-prefilter.md) | [#1601](https://github.com/corazawaf/coraza/pull/1601) | 2026-04-13 | unreleased | ⚡ | `@pm` `minLen` prefilter |
 
 Categories: **F**eature · **P**arity · **⚡** Perf · **R**efactor


### PR DESCRIPTION
## Summary

Batch **8 of 8** splitting #1614 into reviewable pieces. 5 records covering the structural changes in v3.6.0, v3.7.0 and unreleased main.

#1614 stays open as the tracking PR for the whole set; it is not merged.

| ADR | PR | Category | Title |
|---|---|---|---|
| 0049 | #1534 | Perf | `@rx` literal pre-filter |
| 0050 | #1589 | Feature | `SecRxPreFilter` directive |
| 0051 | #1591 | Parity | Audit log Part J (uploaded files) |
| 0052 | #1597 | Perf | Aho-Corasick → indexed-bitmap matcher |
| 0053 | #1601 | Perf | `@pm` `minLen` prefilter |

## What to check

`mage adr` passes on this branch (11 records: 0001–0006 already on main, plus this batch's slice) and CI runs it. What a checker cannot reach:

- **Quotes are verbatim from the cited PR threads** — permalinks resolve and authors match, but whether they capture the actual reasoning is the review.
- **Deciders and Participants** came from thread archaeology and are the most likely thing to be wrong about a colleague.

## Merge order

Stacked behind the earlier batches. Every batch inserts its rows into the same `docs/adr/README.md` index, so as the earlier batches land this branch needs a rebase that keeps every row set — I will handle it.

## Test plan

- [x] `go run mage.go adr` → `docs/adr: 11 record(s) OK`
- [x] Records 0049–0053 appear in no other batch
- [x] No deletions vs `main` (0001–0006 preserved)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision records covering regex and phrase-matching performance optimizations, including literal pre-filtering, minimum-length checks, and indexed matching.
  * Documented the experimental `SecRxPreFilter` runtime directive, including its default behavior and safety fallback.
  * Documented native ModSecurity v2 audit-log Part J support for uploaded-file metadata.
  * Updated indexed matching documentation to reflect the current shift-table and bucket-based scanning approach.
  * Updated the ADR index with records covering these decisions and implementation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->