### PR TITLE
chore: split modsecurity benchmark into its own module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ go 1.25.0
 // - ocsf-schema-golang
 
 require (
-	github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df
 	github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc
 	github.com/corazawaf/libinjection-go v0.3.2
 	github.com/foxcpp/go-mockdns v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df h1:YWiVl53v0R8Knj/k+4slO0SXPL67Y4dXWiOIWNzrkew=
-github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc h1:OlJhrgI3I+FLUCTI3JJW8MoqyM78WbqJjecqMnqG+wc=
 github.com/corazawaf/coraza-coreruleset v0.0.0-20240226094324-415b1017abdc/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
 github.com/corazawaf/libinjection-go v0.3.2 h1:9rrKt0lpg4WvUXt+lwS06GywfqRXXsa/7JcOw5cQLwI=

--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	.
 	./examples/http-server
 	./testing/coreruleset
+	./testing/modsecurity
 )

--- a/testing/modsecurity/go.mod
+++ b/testing/modsecurity/go.mod
@@ -1,0 +1,5 @@
+module github.com/corazawaf/coraza/v3/testing/modsecurity
+
+go 1.25.0
+
+require github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df

--- a/testing/modsecurity/go.sum
+++ b/testing/modsecurity/go.sum
@@ -1,0 +1,2 @@
+github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df h1:YWiVl53v0R8Knj/k+4slO0SXPL67Y4dXWiOIWNzrkew=
+github.com/anuraaga/go-modsecurity v0.0.0-20220824035035-b9a4099778df/go.mod h1:7jguE759ADzy2EkxGRXigiC0ER1Yq2IFk2qNtwgzc7U=

--- a/testing/modsecurity/modsecurity_test.go
+++ b/testing/modsecurity/modsecurity_test.go
@@ -13,9 +13,9 @@
 //
 // The benchmarks require a build tag and cgo flags to run.
 //
-//	CGO_CFLAGS=$(pkg-config --cflags modsecurity) CGO_LDFLAGS=$(pkg-config --libs modsecurity) go test -bench . ./testing -tags modsecurity
+//	CGO_CFLAGS=$(pkg-config --cflags modsecurity) CGO_LDFLAGS=$(pkg-config --libs modsecurity) go test -bench . ./testing/modsecurity -tags modsecurity
 
-package testing
+package modsecurity_test
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ import (
 
 func BenchmarkModSecurityCRSCompilation(b *testing.B) {
 	files := []string{
-		"../coraza.conf-recommended",
+		"../../coraza.conf-recommended",
 		filepath.Join(crspath, "crs-setup.conf.example"),
 	}
 	r, err := filepath.Glob(filepath.Join(crspath, "rules", "*.conf"))
@@ -157,7 +157,7 @@ func BenchmarkModSecurityCRSSimplePOST(b *testing.B) {
 
 func crsMS() (*modsecurity.Modsecurity, *modsecurity.RuleSet, error) {
 	files := []string{
-		"../coraza.conf-recommended",
+		"../../coraza.conf-recommended",
 		filepath.Join(crspath, "crs-setup.conf.example"),
 	}
 	r, err := filepath.Glob(filepath.Join(crspath, "rules", "*.conf"))


### PR DESCRIPTION
## Summary
- Move `testing/modsecurity_test.go` into a new `testing/modsecurity` module, following the same pattern already used by `testing/coreruleset`
- `github.com/anuraaga/go-modsecurity` is CGo bindings to `libmodsecurity`, used only by this build-tag-gated (`modsecurity`) benchmark that compares Coraza against ModSecurity; it no longer needs to appear in the library's own `go.mod`/`go.sum`
- Register the new module in `go.work`

## Note
This file references an undefined `crspath` variable and did not compile before this change either — that variable used to be set in the old `testing/coreruleset_test.go`, and was left behind when CRS testing was refactored to load rules from the `coraza-coreruleset` module's embedded FS instead of an unzipped local path. Nothing in CI builds this file (it requires `-tags modsecurity` plus a local `libmodsecurity` install), so this is unrelated pre-existing breakage, not introduced by this PR, and is not addressed here.

## Test plan
- [x] `go build ./...` (root module)
- [x] `go vet ./...` (root module)
- [x] `go build ./...` in `testing/coreruleset` and `examples/http-server` (other workspace modules)
- [x] Confirmed `go-modsecurity` no longer appears in root `go.mod`/`go.sum`
- [x] Confirmed `go vet -tags modsecurity` in the new module fails with the same pre-existing cgo error as before the move (missing local `libmodsecurity` headers), i.e. no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated the optional ModSecurity testing setup and benchmark organization.
  - Adjusted resource references so ModSecurity benchmark runs continue to locate the recommended configuration correctly.
  - Isolated the ModSecurity test dependency in a dedicated testing module, keeping it separate from the primary module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->