### PR TITLE
docs(variables): correct XML SecLang example and note REQUEST_XML alias

### DIFF
--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -554,10 +554,13 @@ const (
 	// Description: Special collection used to interact with the XML parser. It must contain a
 	// valid XPath expression, which will then be evaluated against a previously parsed XML DOM
 	// tree. Requires the XML body processor to be active.
+	//
+	// `REQUEST_XML` is an alias for `XML`. Use `XML` or `REQUEST_XML` interchangeably to inspect a
+	// parsed request XML body.
 	// ---
 	// ```seclang
 	// SecRule REQUEST_HEADERS:Content-Type "^text/xml$" "phase:1,id:87,t:lowercase,nolog,pass,ctl:requestBodyProcessor=XML"
-	// SecRule XML:/employees/employee/name "Fred" "phase:2,id:88,deny,log"
+	// SecRule XML://@* "sensitive" "phase:2,id:88,deny,log"
 	// ```
 	//
 	// It would match against payload such as this one:
@@ -584,6 +587,14 @@ const (
 	//     </employee>
 	// </employees>
 	// ```
+	//
+	// {{< callout context="caution" title="Limited XPath support" >}}
+	// Coraza only supports two XPath expressions: `//@*` (all attributes) and `/*` (root element). Arbitrary XPath expressions are not supported due to the absence of libxml2.
+	// {{< /callout >}}
+	//
+	// {{< callout context="caution" title="Not supported in TinyGo / proxy-wasm" >}}
+	// XML processing is not available in the TinyGo build used for proxy-wasm deployments.
+	// {{< /callout >}}
 	XML // CanBeSelected
 	// MultipartPartHeaders contains the multipart headers
 	MultipartPartHeaders // CanBeSelected


### PR DESCRIPTION
## Summary

- Fixes the `XML` variable's SecLang example, which used an arbitrary XPath expression (`/employees/employee/name`) that Coraza does not support; replaces it with `//@*`, one of the two hardcoded XPath expressions Coraza actually supports.
- Documents that `REQUEST_XML` is an alias for `XML`.
- Adds caution notes for limited XPath support (no libxml2) and TinyGo/proxy-wasm incompatibility.

`content/en/docs/seclang/variables.md` on coraza.io is generated from these godoc comments via `tools/variablesgen`, so this keeps the source of truth in sync with corazawaf/coraza.io#388, which made the equivalent documentation fix directly in the generated file.

Refers to corazawaf/coraza.io#223.

## Test plan

- [x] `go build ./internal/variables/...`
- [x] `go vet ./internal/variables/...`
- [ ] Regenerate coraza.io docs with `tools/variablesgen` against this branch and confirm output matches corazawaf/coraza.io#388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that `REQUEST_XML` is an alias for `XML`.
  - Updated the XML example to use the supported `XML://@*` expression.
  - Documented supported XPath expressions and noted that XML processing is unavailable in TinyGo builds used for proxy-wasm deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->